### PR TITLE
use built-in or-reduction

### DIFF
--- a/lib/src/one_hot.dart
+++ b/lib/src/one_hot.dart
@@ -26,25 +26,6 @@ class BinaryToOneHot extends Module {
   }
 }
 
-/// Computes an Or-reduction of an input
-class OrReduction extends Module {
-  /// The [orvalue] decoded result.
-  Logic get orvalue => output('orvalue');
-
-  /// Constructs a [Module] which computes an Or-reduction on [in]
-  /// Really poor implementation to just have basic functionality
-  OrReduction(Logic input) {
-    addOutput('orvalue');
-    Combinational([
-      IfBlock([
-        // Do we have a != comparator?
-        Iff(input.eq(0), [orvalue < Const(0, width: 1)]),
-        Else([orvalue < Const(1, width: 1)]),
-      ])
-    ]);
-  }
-}
-
 /// Decodes a one-hot number into binary using a for-loop
 class OneHotToBinary extends Module {
   /// The [binary] decoded result.
@@ -96,7 +77,7 @@ class _NodeOneHotToBinary extends Module {
       final lo = onehot.getRange(0, mid).zeroExtend(mid);
       final recurse = lo | hi;
       final response = _NodeOneHotToBinary(recurse).binary;
-      binary <= [OrReduction(hi).orvalue, response].swizzle();
+      binary <= [hi.or(), response].swizzle();
     }
   }
 }

--- a/test/one_hot_test.dart
+++ b/test/one_hot_test.dart
@@ -35,18 +35,9 @@ void main() {
       expect(computed.value, equals(expected));
     }
   });
-  test('or_reduction', () {
-    // Compute the or-reduction of a binary value
-    expect(OrReduction(Const(0, width: 8)).orvalue.value,
-        equals(LogicValue.ofInt(0, 1)));
-    expect(OrReduction(Const(1, width: 8)).orvalue.value,
-        equals(LogicValue.ofInt(1, 1)));
-    expect(OrReduction(Const(2, width: 4)).orvalue.value,
-        equals(LogicValue.ofInt(1, 1)));
-  });
   test('tree_decode', () {
     // Compute the binary value (or bit position) of a one-hot encoded value
-    for (var pos = 0; pos < 64; pos++) {
+    for (var pos = 0; pos < 5120; pos++) {
       final val = BigInt.from(2).pow(pos);
       final computed = TreeOneHotToBinary(Const(val, width: pos + 1)).binary;
       final expected = LogicValue.ofInt(pos, computed.width);


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Cleanup implementation and test of one-hot codec

## Related Issue(s)

Resolves issue #3

## Testing

Removed OrReduction class and tests.  Replaced with .or() bitlevel function.

## Backwards-compatibility

Nothing should be using the OrReduction class.

<!-- Answer here. -->

## Documentation

No update
<!-- Answer here. -->
