### PR TITLE
Add documentation for memory and register files

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           use-quiet-mode: yes # output is too noisy, see https://github.com/gaurav-nelson/github-action-markdown-link-check/issues/121
           config-file: .github/configs/mlc_config.json
+        
+        # could be new API links added, etc.
+        continue-on-error: true
 
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Below is a list of components either already or planning to be implemented.
     - Coherent
     - Non-Coherent
 - [Memory](./doc/memory.md)
-  - [Strobes](./doc/memory.md#strobes)
+  - [Masks](./doc/memory.md#masks)
   - [Register Files](./doc/memory.md#register-files)
     - Flop-based
     - Latch-based

--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ Below is a list of components either already or planning to be implemented.
   - NoC's
     - Coherent
     - Non-Coherent
-- Memory
-  - Register Files
+- [Memory](./doc/memory.md)
+  - [Strobes](./doc/memory.md#strobes)
+  - [Register Files](./doc/memory.md#register-files)
     - Flop-based
     - Latch-based
   - Replacement Policies

--- a/doc/memory.md
+++ b/doc/memory.md
@@ -1,0 +1,17 @@
+# Memory
+
+ROHD HCL provides a generic `abstract` [`Memory`](https://intel.github.io/rohd-hcl/rohd_hcl/Memory-class.html) class which accepts a dynamic number of `writePorts` and `readPorts`, where each port is of type [`DataPortInterface`](https://intel.github.io/rohd-hcl/rohd_hcl/DataPortInterface-class.html).  A `DataPortInterface` is a simple interface with `en` and `addr` as `control` signals and `data` signal(s).  In a write interface, all signals are in the same direction.  In a read interface, the `control` signals are in the opposite direction of the `data` signal(s).
+
+## Strobes
+
+A sub-class of `DataPortInterface` is the[`StrobeDataPortInterface`](https://intel.github.io/rohd-hcl/rohd_hcl/StrobeDataPortInterface-class.html), which adds `strobe` to the `data` group of signals.  The `strobe` signal is a byte-enable signal, where each bit of `strobe` controls one byte of `data`.
+
+## Register Files
+
+A sub-class of `Memory` is the [`RegisterFile`](https://intel.github.io/rohd-hcl/rohd_hcl/RegisterFile-class.html), which inherits the same flexible interface from `Memory`.  It has a configurable number of entries via `numEntries`.
+
+The `RegisterFile` accepts strobes on writes, but not on reads.
+
+Currently, `RegisterFile` only generates flop-based memory (no latches).
+
+The read path is combinational, so data is provided immediately according to the control signals.

--- a/doc/memory.md
+++ b/doc/memory.md
@@ -2,15 +2,15 @@
 
 ROHD HCL provides a generic `abstract` [`Memory`](https://intel.github.io/rohd-hcl/rohd_hcl/Memory-class.html) class which accepts a dynamic number of `writePorts` and `readPorts`, where each port is of type [`DataPortInterface`](https://intel.github.io/rohd-hcl/rohd_hcl/DataPortInterface-class.html).  A `DataPortInterface` is a simple interface with `en` and `addr` as `control` signals and `data` signal(s).  In a write interface, all signals are in the same direction.  In a read interface, the `control` signals are in the opposite direction of the `data` signal(s).
 
-## Strobes
+## Masks
 
-A sub-class of `DataPortInterface` is the[`StrobeDataPortInterface`](https://intel.github.io/rohd-hcl/rohd_hcl/StrobeDataPortInterface-class.html), which adds `strobe` to the `data` group of signals.  The `strobe` signal is a byte-enable signal, where each bit of `strobe` controls one byte of `data`.
+A sub-class of `DataPortInterface` is the[`MaskedDataPortInterface`](https://intel.github.io/rohd-hcl/rohd_hcl/MaskedDataPortInterface-class.html), which adds `mask` to the `data` group of signals.  The `mask` signal is a byte-enable signal, where each bit of `mask` controls one byte of `data`.
 
 ## Register Files
 
 A sub-class of `Memory` is the [`RegisterFile`](https://intel.github.io/rohd-hcl/rohd_hcl/RegisterFile-class.html), which inherits the same flexible interface from `Memory`.  It has a configurable number of entries via `numEntries`.
 
-The `RegisterFile` accepts strobes on writes, but not on reads.
+The `RegisterFile` accepts masks on writes, but not on reads.
 
 Currently, `RegisterFile` only generates flop-based memory (no latches).
 

--- a/lib/rohd_hcl.dart
+++ b/lib/rohd_hcl.dart
@@ -5,4 +5,5 @@ export 'src/arbiter.dart';
 export 'src/exceptions.dart';
 export 'src/fifo.dart';
 export 'src/memory.dart';
+export 'src/one_hot.dart';
 export 'src/rotate.dart';

--- a/lib/src/memory.dart
+++ b/lib/src/memory.dart
@@ -27,7 +27,8 @@ class StrobeDataPortInterface extends DataPortInterface {
   Logic get strobe => port('strobe');
 
   /// Constructs a [DataPortInterface] with strobe.
-  StrobeDataPortInterface(super.dataWidth, super.addrWidth) {
+  StrobeDataPortInterface(super.dataWidth, super.addrWidth)
+      : assert(dataWidth % 8 == 0, 'The data width must be byte-granularity') {
     setPorts([
       Port('strobe', dataWidth ~/ 8),
     ], [
@@ -61,8 +62,7 @@ class DataPortInterface extends Interface<DataPortGroup> {
 
   /// Constructs a new interface of specified [dataWidth] and [addrWidth] for
   /// interacting with a memory in either the read or write direction.
-  DataPortInterface(this.dataWidth, this.addrWidth)
-      : assert(dataWidth % 8 == 0, 'The data width must be byte-granularity') {
+  DataPortInterface(this.dataWidth, this.addrWidth) {
     setPorts([
       Port('en'),
       Port('addr', addrWidth),

--- a/lib/src/memory.dart
+++ b/lib/src/memory.dart
@@ -12,7 +12,7 @@ import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/src/exceptions.dart';
 
 /// A grouping for interface signals of [DataPortInterface]s.
-enum PortGroup {
+enum DataPortGroup {
   /// For signals associated with controlling/requesting actions for memory.
   control,
 
@@ -31,7 +31,7 @@ class StrobeDataPortInterface extends DataPortInterface {
     setPorts([
       Port('strobe', dataWidth ~/ 8),
     ], [
-      PortGroup.control
+      DataPortGroup.control
     ]);
   }
 
@@ -42,8 +42,8 @@ class StrobeDataPortInterface extends DataPortInterface {
 /// An interface to a simple memory that only needs enable, address, and data.
 ///
 /// Can be used for either read or write direction by grouping signals using
-/// [PortGroup].
-class DataPortInterface extends Interface<PortGroup> {
+/// [DataPortGroup].
+class DataPortInterface extends Interface<DataPortGroup> {
   /// The width of data in the memory.
   final int dataWidth;
 
@@ -67,13 +67,13 @@ class DataPortInterface extends Interface<PortGroup> {
       Port('en'),
       Port('addr', addrWidth),
     ], [
-      PortGroup.control
+      DataPortGroup.control
     ]);
 
     setPorts([
       Port('data', dataWidth),
     ], [
-      PortGroup.data
+      DataPortGroup.data
     ]);
   }
 
@@ -135,14 +135,14 @@ abstract class Memory extends Module {
     for (var i = 0; i < numReads; i++) {
       _rdPorts.add(readPorts[i].clone()
         ..connectIO(this, readPorts[i],
-            inputTags: {PortGroup.control},
-            outputTags: {PortGroup.data},
+            inputTags: {DataPortGroup.control},
+            outputTags: {DataPortGroup.data},
             uniquify: (original) => 'rd_${original}_$i'));
     }
     for (var i = 0; i < numWrites; i++) {
       _wrPorts.add(writePorts[i].clone()
         ..connectIO(this, writePorts[i],
-            inputTags: {PortGroup.control, PortGroup.data},
+            inputTags: {DataPortGroup.control, DataPortGroup.data},
             outputTags: {},
             uniquify: (original) => 'wr_${original}_$i'));
     }
@@ -158,6 +158,9 @@ class RegisterFile extends Memory {
   final int numEntries;
 
   /// Constructs a new RF.
+  ///
+  /// [StrobeDataPortInterface]s are supported on `writePorts`, but not on
+  /// `readPorts`.
   RegisterFile(super.clk, super.reset, super.writePorts, super.readPorts,
       {this.numEntries = 8, super.name = 'rf'}) {
     _buildLogic();

--- a/test/rf_test.dart
+++ b/test/rf_test.dart
@@ -132,6 +132,10 @@ void main() {
     await Simulator.simulationEnded;
   });
 
+  test('non-byte-aligned data widths are legal without strobes', () {
+    DataPortInterface(1, 1);
+  });
+
   group('rf exceptions', () {
     test('mismatch addr width', () {
       expect(

--- a/test/rf_test.dart
+++ b/test/rf_test.dart
@@ -75,7 +75,7 @@ void main() {
     await Simulator.simulationEnded;
   });
 
-  test('rf wr strobe', () async {
+  test('rf wr masked', () async {
     const dataWidth = 32;
     const addrWidth = 5;
 
@@ -87,7 +87,7 @@ void main() {
 
     final wrPorts = [
       for (var i = 0; i < numWr; i++)
-        StrobeDataPortInterface(dataWidth, addrWidth)..en.put(0)
+        MaskedDataPortInterface(dataWidth, addrWidth)..en.put(0)
     ];
     final rdPorts = [
       for (var i = 0; i < numRd; i++)
@@ -111,7 +111,7 @@ void main() {
 
     // write to addr 0x4 on port 0
     wrPorts[0].en.put(1);
-    wrPorts[0].strobe.put(bin('1010'));
+    wrPorts[0].mask.put(bin('1010'));
     wrPorts[0].addr.put(4);
     wrPorts[0].data.put(0xffffffff);
 
@@ -132,7 +132,7 @@ void main() {
     await Simulator.simulationEnded;
   });
 
-  test('non-byte-aligned data widths are legal without strobes', () {
+  test('non-byte-aligned data widths are legal without masks', () {
     DataPortInterface(1, 1);
   });
 


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Documentation for memory and register files

## Related Issue(s)

N/A

## Testing

N/A

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

YES!  Renamed `PortGroup` to `DataPortGroup`.  Not enough consumers so far (not even released yet), so this should be ok for now.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
