### PR TITLE
Add documentation for arbiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Below is a list of components either already or planning to be implemented.
   - Gray to Binary
   - Binary to Gray
   - Priority
-- Arbiters
-  - Priority
+- [Arbiters](./doc/arbiter.md)
+  - [Priority](./doc/arbiter.md#priority-arbiter)
   - Round-robin
 - [FIFO](./doc/fifo.md)
   - Synchronous

--- a/doc/arbiter.md
+++ b/doc/arbiter.md
@@ -1,0 +1,7 @@
+# Arbiters
+
+ROHD HCL implements a generic `abstract` [`Arbiter`](https://intel.github.io/rohd-hcl/rohd_hcl/Arbiter-class.html) class that other arbiters can extend.  It accepts a `List` of `requests`, where each request is a `1-bit` signal indicating that there is a request for a resource.  The output `grants` is a `List` where each element corresponds to the request with the same index.  The arbiter implementation decides how to select which request receives a grant.
+
+## Priority Arbiter
+
+The [`PriorityArbiter`](https://intel.github.io/rohd-hcl/rohd_hcl/PriorityArbiter-class.html) is a combinational (stateless) arbiter that always grants to the lowest-indexed request.


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Adding documentation for `Arbiter` and `PriorityArbiter`, plus link from README.

## Related Issue(s)

N/A

## Testing

N/A

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

That's all it is
