### PR TITLE
Make FIFO bypass generation optional

### DIFF
--- a/doc/fifo.md
+++ b/doc/fifo.md
@@ -18,7 +18,7 @@ The `empty` signal indicates when nothing is in the FIFO.  The `full` signal ind
 
 ## Bypass
 
-If the FIFO is empty and both `readEnable` and `writeEnable` are high at the same time, then the FIFO will do a bypass of the internal storage, allowing for a combinational path straight through.
+THe FIFO optionally supports a bypass if `generateBypass` is set.  When generated, if the FIFO is empty and both `readEnable` and `writeEnable` are high at the same time, then the FIFO will do a bypass of the internal storage, allowing for a combinational passthrough.
 
 ## Errors
 


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Sometimes the bypass in the FIFO is not needed, and so some logic can be removed.

Additionally, it appears that yosys formal tools may have some bugs in combinational loop detection which an unused bypass can potentially expose.

This PR adds `generateBypass` as an argument for the `Fifo`, with a default of `false`.

## Related Issue(s)

N/A

## Testing

Added tests for peeking with and without bypass, and updated bypass test to enable bypass generation.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

Yes!  Bypass is now _not_ generated by default.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Updated the FIFO docs
