### PR TITLE
Schematic Generation

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -73,8 +73,8 @@ jobs:
       - name: Install project dependencies
         run: tool/gh_actions/install_dependencies.sh
 
-      - name: Install synthesis
-        run: tool/gh_actions/install_synthesis.sh
+      - name: Install Schematic support (includes yosys)
+        run: tool/gh_actions/install_schematic.sh
 
       - name: Generate HTML for examples
         run: tool/gh_actions/create_htmls.sh

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -81,5 +81,5 @@ jobs:
       - name: Deploy generated documentation
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          folder: doc/home/
+          folder: doc/api
           branch: docs

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -72,11 +72,11 @@ jobs:
       - name: Install Schematic support (includes yosys)
         run: tool/gh_actions/install_schematic.sh
 
-      - name: Generate HTML for examples
-        run: tool/gh_actions/create_htmls.sh
-
       - name: Generate project documentation
         run: tool/gh_actions/generate_documentation.sh
+
+      - name: Generate HTML for examples
+        run: tool/gh_actions/create_htmls.sh
 
       - name: Deploy generated documentation
         uses: JamesIves/github-pages-deploy-action@v4

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Install Schematic support (includes yosys)
         run: tool/gh_actions/install_schematic.sh
 
+      - name: Install D3 Schematic viewer
+        run: tool/gh_actions/install_d3_schematic.sh
+
       - name: Generate project documentation
         run: tool/gh_actions/generate_documentation.sh
 

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
       - name: Lint Markdown files
         uses: DavidAnson/markdownlint-cli2-action@v9
@@ -37,17 +39,21 @@ jobs:
       - name: Install project dependencies
         run: tool/gh_actions/install_dependencies.sh
 
+      - name: Install Schematic support (includes yosys)
+        run: tool/gh_actions/install_schematic.sh
+
       - name: Verify project formatting
         run: tool/gh_actions/verify_formatting.sh
 
       - name: Analyze project source
         run: tool/gh_actions/analyze_source.sh
 
+      - name: Trial generate HTML for examples # Here for testing only
+        run: tool/gh_actions/create_htmls.sh
+
       - name: Check project documentation
         run: tool/gh_actions/check_documentation.sh
 
-      - name: Run project tests
-        run: tool/gh_actions/run_tests.sh
 
   deploy-documentation:
     name: Deploy Documentation
@@ -66,6 +72,12 @@ jobs:
 
       - name: Install project dependencies
         run: tool/gh_actions/install_dependencies.sh
+
+      - name: Install synthesis
+        run: tool/gh_actions/install_synthesis.sh
+
+      - name: Generate HTML for examples
+        run: tool/gh_actions/create_htmls.sh
 
       - name: Generate project documentation
         run: tool/gh_actions/generate_documentation.sh

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -81,5 +81,5 @@ jobs:
       - name: Deploy generated documentation
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          folder: doc/api
+          folder: doc/home/
           branch: docs

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -39,17 +39,11 @@ jobs:
       - name: Install project dependencies
         run: tool/gh_actions/install_dependencies.sh
 
-      - name: Install Schematic support (includes yosys)
-        run: tool/gh_actions/install_schematic.sh
-
       - name: Verify project formatting
         run: tool/gh_actions/verify_formatting.sh
 
       - name: Analyze project source
         run: tool/gh_actions/analyze_source.sh
-
-      - name: Trial generate HTML for examples # Here for testing only
-        run: tool/gh_actions/create_htmls.sh
 
       - name: Check project documentation
         run: tool/gh_actions/check_documentation.sh
@@ -66,6 +60,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -73,7 +73,7 @@ jobs:
         run: tool/gh_actions/install_schematic.sh
 
       - name: Install D3 Schematic viewer
-        run: tool/gh_actions/install_d3_schematic.sh
+        run: tool/gh_actions/install_d3_hwschematic.sh
 
       - name: Generate project documentation
         run: tool/gh_actions/generate_documentation.sh

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -48,6 +48,8 @@ jobs:
       - name: Check project documentation
         run: tool/gh_actions/check_documentation.sh
 
+      - name: Run project tests
+        run: tool/gh_actions/run_tests.sh
 
   deploy-documentation:
     name: Deploy Documentation
@@ -69,8 +71,8 @@ jobs:
       - name: Install project dependencies
         run: tool/gh_actions/install_dependencies.sh
 
-      - name: Install Schematic support (includes yosys)
-        run: tool/gh_actions/install_schematic.sh
+      - name: Install CAD Suite (includes yosys)
+        run: tool/gh_actions/install_opencadsuite.sh
 
       - name: Install D3 Schematic viewer
         run: tool/gh_actions/install_d3_hwschematic.sh

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "doc/d3-hwschematic"]
+	path = doc/d3-hwschematic
+	url = https://github.com/Nic30/d3-hwschematic.git

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -6,6 +6,11 @@
   },
 
   "ignores": [
-    "doc/api/"
-  ]
+    "doc/api/",
+    "doc/d3-hwschematic-assets/",
+    "doc/d3-hwschematic-assets/elkjs",
+    "doc/api/d3-hwschematic-assets/",
+    "doc/api/d3-hwschematic-assets/elkjs",
+    "doc/d3-hwschematic/"
+    ]
 }

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,1 @@
+This directory is for Verilog output and HTML conversion of components.

--- a/doc/arbiter.md
+++ b/doc/arbiter.md
@@ -6,4 +6,4 @@ ROHD HCL implements a generic `abstract` [`Arbiter`](https://intel.github.io/roh
 
 The [`PriorityArbiter`](https://intel.github.io/rohd-hcl/rohd_hcl/PriorityArbiter-class.html) is a combinational (stateless) arbiter that always grants to the lowest-indexed request.
 
-[PriorityArbiter Schematic](https://desmonddak.github.io/rohd-hcl/PriorityArbiter.html)
+[PriorityArbiter Schematic](https://intel.github.io/rohd-hcl/PriorityArbiter.html)

--- a/doc/arbiter.md
+++ b/doc/arbiter.md
@@ -6,4 +6,4 @@ ROHD HCL implements a generic `abstract` [`Arbiter`](https://intel.github.io/roh
 
 The [`PriorityArbiter`](https://intel.github.io/rohd-hcl/rohd_hcl/PriorityArbiter-class.html) is a combinational (stateless) arbiter that always grants to the lowest-indexed request.
 
-['Schematic'](https://desmonddak.github.io/rohd-hcl/rohd_hcl/PriorityArbiter.html)
+['Schematic'](https://desmonddak.github.io/rohd-hcl/PriorityArbiter.html)

--- a/doc/arbiter.md
+++ b/doc/arbiter.md
@@ -6,4 +6,4 @@ ROHD HCL implements a generic `abstract` [`Arbiter`](https://intel.github.io/roh
 
 The [`PriorityArbiter`](https://intel.github.io/rohd-hcl/rohd_hcl/PriorityArbiter-class.html) is a combinational (stateless) arbiter that always grants to the lowest-indexed request.
 
-[Schematic](https://desmonddak.github.io/rohd-hcl/PriorityArbiter.html)
+[PriorityArbiter Schematic](https://desmonddak.github.io/rohd-hcl/PriorityArbiter.html)

--- a/doc/arbiter.md
+++ b/doc/arbiter.md
@@ -6,4 +6,4 @@ ROHD HCL implements a generic `abstract` [`Arbiter`](https://intel.github.io/roh
 
 The [`PriorityArbiter`](https://intel.github.io/rohd-hcl/rohd_hcl/PriorityArbiter-class.html) is a combinational (stateless) arbiter that always grants to the lowest-indexed request.
 
-['Schematic'](https://desmonddak.github.io/rohd-hcl/PriorityArbiter.html)
+[Schematic](https://desmonddak.github.io/rohd-hcl/PriorityArbiter.html)

--- a/doc/arbiter.md
+++ b/doc/arbiter.md
@@ -5,3 +5,5 @@ ROHD HCL implements a generic `abstract` [`Arbiter`](https://intel.github.io/roh
 ## Priority Arbiter
 
 The [`PriorityArbiter`](https://intel.github.io/rohd-hcl/rohd_hcl/PriorityArbiter-class.html) is a combinational (stateless) arbiter that always grants to the lowest-indexed request.
+
+['Schematic'](https://desmonddak.github.io/rohd-hcl/rohd_hcl/PriorityArbiter.html)

--- a/doc/fifo.md
+++ b/doc/fifo.md
@@ -29,3 +29,5 @@ There is no guarantee that the `error` signal will hold high once asserted once.
 ## Occupancy
 
 Occupancy information can optionally be generated and provided if `generateOccupancy` is set.  The `occupancy` signal will indicate the number of items currently stored in the FIFO.
+
+[FIFO Schematic](https://desmonddak.github.io/rohd-hcl/Fifo.html)

--- a/doc/memory.md
+++ b/doc/memory.md
@@ -16,4 +16,4 @@ Currently, `RegisterFile` only generates flop-based memory (no latches).
 
 The read path is combinational, so data is provided immediately according to the control signals.
 
-[RegisterFile Schematic](https://desmonddak.github.io/rohd-hcl/RegisterFile.html)
+[RegisterFile Schematic](https://intel.github.io/rohd-hcl/RegisterFile.html)

--- a/doc/memory.md
+++ b/doc/memory.md
@@ -15,3 +15,5 @@ The `RegisterFile` accepts masks on writes, but not on reads.
 Currently, `RegisterFile` only generates flop-based memory (no latches).
 
 The read path is combinational, so data is provided immediately according to the control signals.
+
+[RegisterFile Schematic](https://desmonddak.github.io/rohd-hcl/RegisterFile.html)

--- a/doc/onehot.md
+++ b/doc/onehot.md
@@ -10,4 +10,4 @@ The decoders take a Logic input representing the bit position to be set to '1', 
 
 [OneHotToBinary Schematic](https://desmonddak.github.io/rohd-hcl/OneHotToBinary.html)
 
-[TreeOneHotToBinary Schematic](https://desmonddak.github.io/rohd-hcl/OneHotToBinary.html)
+[TreeOneHotToBinary Schematic](https://desmonddak.github.io/rohd-hcl/TreeOneHotToBinary.html)

--- a/doc/onehot.md
+++ b/doc/onehot.md
@@ -2,14 +2,14 @@
 
 ROHD HCL implements a set of one hot encoder and decoders.
 
-For example, we have an encoder [`BinaryToOneHot`](https://desmonddak.github.io/rohd-hcl/rohd_hcl/BinaryToOneHot-class.html) class, and a couple of implementations of decoder classes like [`OneHotToBinary`](https://desmonddak.github.io/rohd-hcl/rohd_hcl/OneHotToBinary-class.html) and a more performant [`BinaryToOneHot`](https://desmonddak.github.io/rohd-hcl/rohd_hcl/TreeOneHotToBinary-class.html).
+For example, we have an encoder [`BinaryToOneHot`](https://intel.github.io/rohd-hcl/rohd_hcl/BinaryToOneHot-class.html) class, and a couple of implementations of decoder classes like [`OneHotToBinary`](https://intel.github.io/rohd-hcl/rohd_hcl/OneHotToBinary-class.html) and a more performant [`TreeBinaryToOneHot`](https://intel.github.io/rohd-hcl/rohd_hcl/TreeOneHotToBinary-class.html).
 
 The encoders take a Logic bitvector, with the constraint that only a single bit is set to '1' and outputs the bit position in binary.
 
 The decoders take a Logic input representing the bit position to be set to '1', and returns a Logic bitvector with that bit position set to '1', and all others set to '0'
 
-[BinaryToOneHot Schematic](https://desmonddak.github.io/rohd-hcl/BinaryToOneHot.html)
+[BinaryToOneHot Schematic](https://intel.github.io/rohd-hcl/BinaryToOneHot.html)
 
-[OneHotToBinary Schematic](https://desmonddak.github.io/rohd-hcl/OneHotToBinary.html)
+[OneHotToBinary Schematic](https://intel.github.io/rohd-hcl/OneHotToBinary.html)
 
-[TreeOneHotToBinary Schematic](https://desmonddak.github.io/rohd-hcl/TreeOneHotToBinary.html)
+[TreeOneHotToBinary Schematic](https://intel.github.io/rohd-hcl/TreeOneHotToBinary.html)

--- a/doc/onehot.md
+++ b/doc/onehot.md
@@ -1,0 +1,13 @@
+# One Hot Codecs
+
+ROHD HCL implements a set of one hot encoder and decoders.
+
+The encoders take a Logic bitvector, with the constraint that only a single bit is set to '1' and outputs the bit position in binary.
+
+The decoders take a Logic input representing the bit position to be set to '1', and returns a Logic bitvector with that bit position set to '1', and all others set to '0'
+
+[BinaryToOneHot Schematic](https://desmonddak.github.io/rohd-hcl/BinaryToOneHot.html)
+
+[OneHotToBinary Schematic](https://desmonddak.github.io/rohd-hcl/OneHotToBinary.html)
+
+[TreeOneHotToBinary Schematic](https://desmonddak.github.io/rohd-hcl/OneHotToBinary.html)

--- a/doc/onehot.md
+++ b/doc/onehot.md
@@ -2,6 +2,8 @@
 
 ROHD HCL implements a set of one hot encoder and decoders.
 
+For example, we have an encoder [`BinaryToOneHot`](https://desmonddak.github.io/rohd-hcl/rohd_hcl/BinaryToOneHot-class.html) class, and a couple of implementations of decoder classes like [`OneHotToBinary`](https://desmonddak.github.io/rohd-hcl/rohd_hcl/OneHotToBinary-class.html) and a more performant [`BinaryToOneHot`](https://desmonddak.github.io/rohd-hcl/rohd_hcl/TreeOneHotToBinary-class.html).
+
 The encoders take a Logic bitvector, with the constraint that only a single bit is set to '1' and outputs the bit position in binary.
 
 The decoders take a Logic input representing the bit position to be set to '1', and returns a Logic bitvector with that bit position set to '1', and all others set to '0'

--- a/doc/rotate.md
+++ b/doc/rotate.md
@@ -60,3 +60,4 @@ Also included are `extension`s for `LogicValue` with a similar rotation API for 
 ```dart
 LogicValue.ofInt(0xf000, 16).rotateLeft(8); // results in 0x00f0
 ```
+[Rotateleft Schematic](https://desmonddak.github.io/rohd-hcl/RotateLeft.html)

--- a/doc/rotate.md
+++ b/doc/rotate.md
@@ -61,4 +61,4 @@ Also included are `extension`s for `LogicValue` with a similar rotation API for 
 LogicValue.ofInt(0xf000, 16).rotateLeft(8); // results in 0x00f0
 ```
 
-[Rotateleft Schematic](https://desmonddak.github.io/rohd-hcl/RotateLeft.html)
+[Rotateleft Schematic](https://intel.github.io/rohd-hcl/RotateLeft.html)

--- a/doc/rotate.md
+++ b/doc/rotate.md
@@ -60,4 +60,5 @@ Also included are `extension`s for `LogicValue` with a similar rotation API for 
 ```dart
 LogicValue.ofInt(0xf000, 16).rotateLeft(8); // results in 0x00f0
 ```
+
 [Rotateleft Schematic](https://desmonddak.github.io/rohd-hcl/RotateLeft.html)

--- a/gen/arbiter_gen.dart
+++ b/gen/arbiter_gen.dart
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// arbiter_gen.dart
+// Generate an example arbiter
+//
+// 2023 May 09
+// Author: Desmond Kirkpatrick <desmond.a.kirkpatrick@intel.com>
+//
+
+// ignore_for_file: unused_element
+
+import 'dart:async';
+import 'dart:io';
+import 'package:rohd/rohd.dart';
+import 'package:rohd_hcl/src/arbiter.dart';
+
+Future<void> arbiterGen() async {
+  const width = 8;
+
+  final vector = Logic(width: width);
+  final reqs = List.generate(width, (i) => vector[i]);
+
+  final arb = PriorityArbiter(reqs);
+
+  await arb.build();
+  final res = arb.generateSynth();
+  File('build/${arb.definitionName}.v').openWrite().write(res);
+}

--- a/gen/arbiter_gen.dart
+++ b/gen/arbiter_gen.dart
@@ -25,5 +25,5 @@ Future<void> arbiterGen() async {
 
   await arb.build();
   final res = arb.generateSynth();
-  File('build/${arb.definitionName}.v').openWrite().write(res);
+  File('build/${arb.definitionName}.v').writeAsStringSync(res);
 }

--- a/gen/fifo_gen.dart
+++ b/gen/fifo_gen.dart
@@ -14,10 +14,10 @@ import 'package:rohd_hcl/src/fifo.dart';
 
 Future<void> fifoGen() async {
   final clk = SimpleClockGenerator(10).clk;
-  final reset = Logic()..put(0);
+  final reset = Logic();
 
-  final wrEn = Logic()..put(0);
-  final rdEn = Logic()..put(0);
+  final wrEn = Logic();
+  final rdEn = Logic();
   final wrData = Logic(width: 32);
 
   final fifo = Fifo(

--- a/gen/fifo_gen.dart
+++ b/gen/fifo_gen.dart
@@ -1,0 +1,36 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// one_hot_test.dart
+// Test of one_hot codec.
+//
+// 2023 May 09
+// Author: Desmond Kirkpatrick <desmond.a.kirkpatrick@intel.com>
+//
+
+import 'dart:io';
+import 'package:rohd/rohd.dart';
+import 'package:rohd_hcl/src/fifo.dart';
+
+Future<void> fifoGen() async {
+  final clk = SimpleClockGenerator(10).clk;
+  final reset = Logic()..put(0);
+
+  final wrEn = Logic()..put(0);
+  final rdEn = Logic()..put(0);
+  final wrData = Logic(width: 32);
+
+  final fifo = Fifo(
+    clk,
+    reset,
+    writeEnable: wrEn,
+    readEnable: rdEn,
+    writeData: wrData,
+    generateError: true,
+    generateOccupancy: true,
+    depth: 3,
+  );
+  await fifo.build();
+  final res = fifo.generateSynth();
+  File('build/${fifo.definitionName}.v').openWrite().write(res);
+}

--- a/gen/fifo_gen.dart
+++ b/gen/fifo_gen.dart
@@ -1,8 +1,8 @@
 // Copyright (C) 2023 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
-// one_hot_test.dart
-// Test of one_hot codec.
+// fifo_gen.dart
+// Genarate a FIFO.
 //
 // 2023 May 09
 // Author: Desmond Kirkpatrick <desmond.a.kirkpatrick@intel.com>

--- a/gen/fifo_gen.dart
+++ b/gen/fifo_gen.dart
@@ -32,5 +32,5 @@ Future<void> fifoGen() async {
   );
   await fifo.build();
   final res = fifo.generateSynth();
-  File('build/${fifo.definitionName}.v').openWrite().write(res);
+  File('build/${fifo.definitionName}.v').writeAsStringSync(res);
 }

--- a/gen/generate.dart
+++ b/gen/generate.dart
@@ -1,0 +1,23 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// rotate_gen.dart
+// Generate an example rotator
+//
+// 2023 May 09
+// Author: Desmond Kirkpatrick <desmond.a.kirkpatrick@intel.com>
+//
+
+import 'arbiter_gen.dart';
+import 'fifo_gen.dart';
+import 'one_hot_gen.dart';
+import 'rf_gen.dart';
+import 'rotate_gen.dart';
+
+void main() async {
+  await arbiterGen();
+  await fifoGen();
+  await oneHotGen();
+  await rfGen();
+  await rotateGen();
+}

--- a/gen/generate.dart
+++ b/gen/generate.dart
@@ -1,8 +1,9 @@
 // Copyright (C) 2023 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
-// rotate_gen.dart
-// Generate an example rotator
+// generate.dart
+// Generate a series of examples for documentation
+// Call a generator to create an instance of your component for schematic viewing.
 //
 // 2023 May 09
 // Author: Desmond Kirkpatrick <desmond.a.kirkpatrick@intel.com>

--- a/gen/generate.dart
+++ b/gen/generate.dart
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // generate.dart
-// Generate a series of examples for documentation
-// Call a generator to create an instance of your component for schematic viewing.
+// Generate a series of examples for documentation.
+//
+// Call a generator to create an instance of your component for
+// schematic viewing.
 //
 // 2023 May 09
 // Author: Desmond Kirkpatrick <desmond.a.kirkpatrick@intel.com>

--- a/gen/one_hot_gen.dart
+++ b/gen/one_hot_gen.dart
@@ -24,5 +24,5 @@ Future<void> oneHotGen() async {
   final mod2 = OneHotToBinary(Const(val, width: pos + 1));
   await mod2.build();
   final res2 = mod2.generateSynth();
-  File('build/${mod2.definitionName}.v').openWrite().write(res2);
+  File('build/${mod2.definitionName}.v').writeAsStringSync(res);
 }

--- a/gen/one_hot_gen.dart
+++ b/gen/one_hot_gen.dart
@@ -20,9 +20,16 @@ Future<void> oneHotGen() async {
   await mod.build();
   final res = mod.generateSynth();
   File('build/${mod.definitionName}.v').openWrite().write(res);
-  final val = BigInt.from(2).pow(pos);
-  final mod2 = OneHotToBinary(Const(val, width: pos + 1));
+
+  final val2 = BigInt.from(2).pow(pos);
+  final mod2 = OneHotToBinary(Const(val2, width: pos + 1));
   await mod2.build();
   final res2 = mod2.generateSynth();
-  File('build/${mod2.definitionName}.v').writeAsStringSync(res);
+  File('build/${mod2.definitionName}.v').writeAsStringSync(res2);
+
+  final val3 = BigInt.from(2).pow(pos);
+  final mod3 = TreeOneHotToBinary(Const(val3, width: pos + 1));
+  await mod3.build();
+  final res3 = mod3.generateSynth();
+  File('build/${mod3.definitionName}.v').writeAsStringSync(res3);
 }

--- a/gen/one_hot_gen.dart
+++ b/gen/one_hot_gen.dart
@@ -15,21 +15,17 @@ import 'package:rohd_hcl/src/utils.dart';
 
 Future<void> oneHotGen() async {
   const pos = 8;
-  final w = log2Ceil(pos + 1);
-  final mod = BinaryToOneHot(Const(pos, width: w));
-  await mod.build();
-  final res = mod.generateSynth();
-  File('build/${mod.definitionName}.v').openWrite().write(res);
+  final binaryInput = Logic(width: log2Ceil(pos + 1));
+  final m1 = BinaryToOneHot(binaryInput);
+  await m1.build();
+  File('build/${m1.definitionName}.v').writeAsStringSync(m1.generateSynth());
 
-  final val2 = BigInt.from(2).pow(pos);
-  final mod2 = OneHotToBinary(Const(val2, width: pos + 1));
-  await mod2.build();
-  final res2 = mod2.generateSynth();
-  File('build/${mod2.definitionName}.v').writeAsStringSync(res2);
+  final onehotInput = Logic(width: pos + 1);
+  final m2 = OneHotToBinary(onehotInput);
+  await m2.build();
+  File('build/${m2.definitionName}.v').writeAsStringSync(m2.generateSynth());
 
-  final val3 = BigInt.from(2).pow(pos);
-  final mod3 = TreeOneHotToBinary(Const(val3, width: pos + 1));
-  await mod3.build();
-  final res3 = mod3.generateSynth();
-  File('build/${mod3.definitionName}.v').writeAsStringSync(res3);
+  final m3 = TreeOneHotToBinary(onehotInput);
+  await m3.build();
+  File('build/${m3.definitionName}.v').writeAsStringSync(m3.generateSynth());
 }

--- a/gen/one_hot_gen.dart
+++ b/gen/one_hot_gen.dart
@@ -1,0 +1,28 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// one_hot_gen.dart
+// Generate one_hot codecs.
+//
+// 2023 May 09
+// Author: Desmond Kirkpatrick <desmond.a.kirkpatrick@intel.com>
+//
+
+import 'dart:io';
+import 'package:rohd/rohd.dart';
+import 'package:rohd_hcl/src/one_hot.dart';
+import 'package:rohd_hcl/src/utils.dart';
+
+Future<void> oneHotGen() async {
+  const pos = 8;
+  final w = log2Ceil(pos + 1);
+  final mod = BinaryToOneHot(Const(pos, width: w));
+  await mod.build();
+  final res = mod.generateSynth();
+  File('build/${mod.definitionName}.v').openWrite().write(res);
+  final val = BigInt.from(2).pow(pos);
+  final mod2 = OneHotToBinary(Const(val, width: pos + 1));
+  await mod2.build();
+  final res2 = mod2.generateSynth();
+  File('build/${mod2.definitionName}.v').openWrite().write(res2);
+}

--- a/gen/rf_gen.dart
+++ b/gen/rf_gen.dart
@@ -24,11 +24,11 @@ Future<void> rfGen() async {
 
   final wrPorts = [
     for (var i = 0; i < numWr; i++)
-      DataPortInterface(dataWidth, addrWidth)..en.put(0)
+      DataPortInterface(dataWidth, addrWidth)
   ];
   final rdPorts = [
     for (var i = 0; i < numRd; i++)
-      DataPortInterface(dataWidth, addrWidth)..en.put(0)
+      DataPortInterface(dataWidth, addrWidth)
   ];
 
   final rf = RegisterFile(clk, reset, wrPorts, rdPorts, numEntries: 20);

--- a/gen/rf_gen.dart
+++ b/gen/rf_gen.dart
@@ -23,12 +23,10 @@ Future<void> rfGen() async {
   final reset = Logic();
 
   final wrPorts = [
-    for (var i = 0; i < numWr; i++)
-      DataPortInterface(dataWidth, addrWidth)
+    for (var i = 0; i < numWr; i++) DataPortInterface(dataWidth, addrWidth)
   ];
   final rdPorts = [
-    for (var i = 0; i < numRd; i++)
-      DataPortInterface(dataWidth, addrWidth)
+    for (var i = 0; i < numRd; i++) DataPortInterface(dataWidth, addrWidth)
   ];
 
   final rf = RegisterFile(clk, reset, wrPorts, rdPorts, numEntries: 20);

--- a/gen/rf_gen.dart
+++ b/gen/rf_gen.dart
@@ -36,5 +36,5 @@ Future<void> rfGen() async {
   await rf.build();
 
   final res = rf.generateSynth();
-  File('build/${rf.definitionName}.v').openWrite().write(res);
+  File('build/${rf.definitionName}.v').writeAsStringSync(res);
 }

--- a/gen/rf_gen.dart
+++ b/gen/rf_gen.dart
@@ -1,0 +1,40 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// rf_gen.dart
+// Generate an example register file
+//
+// 2023 May 09
+// Author: Desmond Kirkpatrick <desmond.a.kirkpatrick@intel.com>
+//
+
+import 'dart:io';
+import 'package:rohd/rohd.dart';
+import 'package:rohd_hcl/rohd_hcl.dart';
+
+Future<void> rfGen() async {
+  const dataWidth = 16;
+  const addrWidth = 4;
+
+  const numWr = 2;
+  const numRd = 2;
+
+  final clk = SimpleClockGenerator(10).clk;
+  final reset = Logic();
+
+  final wrPorts = [
+    for (var i = 0; i < numWr; i++)
+      DataPortInterface(dataWidth, addrWidth)..en.put(0)
+  ];
+  final rdPorts = [
+    for (var i = 0; i < numRd; i++)
+      DataPortInterface(dataWidth, addrWidth)..en.put(0)
+  ];
+
+  final rf = RegisterFile(clk, reset, wrPorts, rdPorts, numEntries: 20);
+
+  await rf.build();
+
+  final res = rf.generateSynth();
+  File('build/${rf.definitionName}.v').openWrite().write(res);
+}

--- a/gen/rotate_gen.dart
+++ b/gen/rotate_gen.dart
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// rotate_gen.dart
+// Generate an example rotator
+//
+// 2023 May 09
+// Author: Desmond Kirkpatrick <desmond.a.kirkpatrick@intel.com>
+//
+
+import 'dart:io';
+import 'package:rohd/rohd.dart';
+import 'package:rohd_hcl/src/rotate.dart';
+
+Future<void> rotateGen() async {
+  final rot = RotateLeft(
+    Const(0xf000, width: 16),
+    Const(4, width: 8),
+    maxAmount: 4,
+  );
+  await rot.build();
+  final res = rot.generateSynth();
+  File('build/${rot.definitionName}.v').openWrite().write(res);
+}

--- a/gen/rotate_gen.dart
+++ b/gen/rotate_gen.dart
@@ -20,5 +20,5 @@ Future<void> rotateGen() async {
   );
   await rot.build();
   final res = rot.generateSynth();
-  File('build/${rot.definitionName}.v').openWrite().write(res);
+  File('build/${rot.definitionName}.v').writeAsStringSync(res);
 }

--- a/test/one_hot_test.dart
+++ b/test/one_hot_test.dart
@@ -8,7 +8,6 @@
 // Author: Desmond Kirkpatrick
 //
 
-import 'dart:io';
 import 'dart:math';
 
 import 'package:rohd/rohd.dart';
@@ -36,12 +35,6 @@ void main() {
       final expected = LogicValue.ofInt(pos, computed.width);
       expect(computed.value, equals(expected));
     }
-    const pos = 32;
-    final val = BigInt.from(2).pow(pos);
-    final mod = OneHotToBinary(Const(val, width: pos + 1));
-    await mod.build();
-    final res = mod.generateSynth();
-    File('${mod.definitionName}.v').openWrite().write(res);
   });
   test('tree_decode', () {
     // Compute the binary value (or bit position) of a one-hot encoded value

--- a/test/one_hot_test.dart
+++ b/test/one_hot_test.dart
@@ -8,7 +8,9 @@
 // Author: Desmond Kirkpatrick
 //
 
+import 'dart:io';
 import 'dart:math';
+
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/src/one_hot.dart';
 import 'package:rohd_hcl/src/utils.dart';
@@ -25,7 +27,7 @@ void main() {
           equals(LogicValue.ofBigInt(val, pow(2, w).toInt())));
     }
   });
-  test('simple_decode', () {
+  test('simple_decode', () async {
     // Compute the first 1 in a binary value
     // Limited to 64 by the Case matching inside
     for (var pos = 0; pos < 1000; pos++) {
@@ -34,6 +36,12 @@ void main() {
       final expected = LogicValue.ofInt(pos, computed.width);
       expect(computed.value, equals(expected));
     }
+    const pos = 32;
+    final val = BigInt.from(2).pow(pos);
+    final mod = OneHotToBinary(Const(val, width: pos + 1));
+    await mod.build();
+    final res = mod.generateSynth();
+    File('${mod.definitionName}.v').openWrite().write(res);
   });
   test('tree_decode', () {
     // Compute the binary value (or bit position) of a one-hot encoded value

--- a/tool/converters/json_html.sh
+++ b/tool/converters/json_html.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# jsonToHtml.sh
+# Splice a json file into an HTML form for D3 schematic display
+#
+# 2023 May 09
+# Author: Desmond Kirkpatrick <desmond.a.kirkpatrick@intel.com>
+#
+#
+# This script inserts a JSON file in the middle of an HTML file that drives
+# a D3 schematic viewer.
+
+if !(test 1 -eq $#); then
+    echo One argument required: JSON file
+    exit 1
+fi;
+
+json=`cat $1 | sed -e 's/\\\\/_/g'`
+pre='<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>d3-hwschematic</title>
+</head>
+<body>
+  </script>
+  <script type="text/javascript" src="d3-hwschematic-assets/d3/dist/d3.js"></script>
+  <!-- <script type="text/javascript" src="d3-hwschematic-assets/d3/dist/d3.min.js"></script>  -->
+  <script type="text/javascript" src="d3-hwschematic-assets/elkjs/lib/elk.bundled.js"></script>
+  <script type="text/javascript" src="d3-hwschematic-assets/d3-hwschematic.js"></script>
+  <link href="d3-hwschematic-assets/d3-hwschematic.css" rel="stylesheet">
+  <style>
+  	body {
+	   margin: 0;
+    }
+  </style>
+</head>
+<body>
+    <svg id="scheme-placeholder"></svg>
+    <script>
+        // schematic rendering script
+        function viewport() {
+          var e = window,
+            a = '\'inner\'';
+          if (!(''innerWidth'' in window)) {
+            a = '\'client\'';
+            e = document.documentElement || document.body;
+          }
+          return {
+            width: e[a + '\'Width\''],
+            height: e[a + '\'Height\'']
+          }
+        }
+      var exmpl = `'
+
+post='`;
+        var width = viewport().width,
+            height = viewport().height;
+
+        var svg = d3.select("#scheme-placeholder")
+            .attr("width", width)
+            .attr("height", height);
+
+        var orig = document.body.onresize;
+        document.body.onresize = function(ev) {
+            if (orig)
+        	    orig(ev);
+
+            var w = viewport();
+            svg.attr("width", w.width);
+			svg.attr("height", w.height);
+        }
+
+        var hwSchematic = new d3.HwSchematic(svg);
+        var zoom = d3.zoom();
+        zoom.on("zoom", function applyTransform(ev) {
+        	hwSchematic.root.attr("transform", ev.transform)
+        });
+
+        // disable zoom on doubleclick
+        // because it interferes with component expanding/collapsing
+        svg.call(zoom)
+           .on("dblclick.zoom", null)
+
+      graph = JSON.parse(exmpl);
+      if ("creator" in graph) {
+	  graph = d3.HwSchematic.fromYosys(graph);
+      }
+      if (graph.hwMeta && graph.hwMeta.name) {
+          document.title = graph.hwMeta.name;
+	  hwSchematic.bindData(graph);
+      }
+    </script>
+</body>
+</html>
+'
+echo "${pre}${json}${post}"

--- a/tool/converters/verilog_html.sh
+++ b/tool/converters/verilog_html.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# verilogToJSON.sh
+# Run yosys to convert Verilog to JSON
+#
+# 2023 May 09
+# Author: Desmond Kirkpatrick <desmond.a.kirkpatrick@intel.com>
+#
+
+# Executes synthesis given a module name
+# Assumes .v extension
+# Outputs <module>.json
+
+if !(test 1 -eq $#); then
+    echo One argument required: module
+    exit 1
+fi;
+
+cd build/
+module=`basename $1 .v`
+../tool/converters/verilog_json.sh $1
+../tool/converters/json_html.sh ${module}.json > ${module}.html

--- a/tool/converters/verilog_json.sh
+++ b/tool/converters/verilog_json.sh
@@ -21,7 +21,7 @@ fi;
 
 yosys_bin=/oss-cad-suite/bin/yosys
 module=`basename $1 .v`
-$yosys_bin <<EOF
+$yosys_bin -Q -T -q <<EOF
 read_verilog -sv $module.v
 hierarchy -top $module
 proc; opt

--- a/tool/converters/verilog_json.sh
+++ b/tool/converters/verilog_json.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# verilogToJSON.sh
+# Run yosys to convert Verilog to JSON
+#
+# 2023 May 09
+# Author: Desmond Kirkpatrick <desmond.a.kirkpatrick@intel.com>
+#
+
+# Executes synthesis given a module name
+# Assumes .v extension
+# Outputs <module>.json
+
+if !(test 1 -eq $#); then
+    echo One argument required: module
+    exit 1
+fi;
+
+yosys_bin=/oss-cad-suite/bin/yosys
+module=`basename $1 .v`
+$yosys_bin <<EOF
+read_verilog -sv $module.v
+hierarchy -top $module
+proc; opt
+write_json -compat-int $module.json
+EOF

--- a/tool/gh_actions/create_htmls.sh
+++ b/tool/gh_actions/create_htmls.sh
@@ -7,6 +7,8 @@
 
 dart gen/generate.dart
 
+mkdir -p doc/home
+
 # Convert Verilog into an HTML-based schematic for each
 for i in build/*.v
 do

--- a/tool/gh_actions/create_htmls.sh
+++ b/tool/gh_actions/create_htmls.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Scavenged from Nic30:d3-hwschematic
+#cp -r doc/d3-hwschematic-assets doc/api/
+
+# Generate components and produce Verilog
+
+dart gen/generate.dart
+
+# Convert Verilog into an HTML-based schematic for each
+for i in build/*.v
+do
+    example=`basename $i .v`
+    ./tool/converters/verilog_html.sh $example
+    cp build/$example.html doc/api/$example.html
+done

--- a/tool/gh_actions/create_htmls.sh
+++ b/tool/gh_actions/create_htmls.sh
@@ -12,5 +12,5 @@ for i in build/*.v
 do
     example=`basename $i .v`
     ./tool/converters/verilog_html.sh $example
-    cp build/$example.html doc/api/$example.html
+    cp build/$example.html doc/home/$example.html
 done

--- a/tool/gh_actions/create_htmls.sh
+++ b/tool/gh_actions/create_htmls.sh
@@ -7,12 +7,10 @@
 
 dart gen/generate.dart
 
-mkdir -p doc/home
-
 # Convert Verilog into an HTML-based schematic for each
 for i in build/*.v
 do
     example=`basename $i .v`
     ./tool/converters/verilog_html.sh $example
-    cp build/$example.html doc/home/$example.html
+    cp build/$example.html doc/api/$example.html
 done

--- a/tool/gh_actions/generate_documentation.sh
+++ b/tool/gh_actions/generate_documentation.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 # output=$(dart doc --validate-links 2>&1 | tee)
 
 # We want relative link paths to be OK in the README
-output=$(dart doc -o home/api 2>&1 | tee)
+output=$(dart doc 2>&1 | tee)
 
 echo "${output}"
 

--- a/tool/gh_actions/generate_documentation.sh
+++ b/tool/gh_actions/generate_documentation.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 # output=$(dart doc --validate-links 2>&1 | tee)
 
 # We want relative link paths to be OK in the README
-output=$(dart doc 2>&1 | tee)
+output=$(dart doc -o home/api 2>&1 | tee)
 
 echo "${output}"
 

--- a/tool/gh_actions/install_d3_hwschematic.sh
+++ b/tool/gh_actions/install_d3_hwschematic.sh
@@ -12,14 +12,14 @@
 
 set -euo pipefail
 
-apt-get update
-apt-get install -y \
-	git \
-	npm \
-	python3-pip
-
 cd doc/d3-hwschematic
 npm install
 npm install --only=dev
 nom run build
+
+cd ../..
+mkdir -p doc/api/d3-hwschematic-assets
+cp -r doc/d3-hwschematic/node_modules/d3 doc/api/d3-hwschematic-assets
+cp -r doc/d3-hwschematic/node_modules/elkjs doc/api/d3-hwschematic-assets
+cp doc/d3-hwschematic/dist/d3-hwschematic.{css,js} doc/api/d3-hwschematic-assets
 

--- a/tool/gh_actions/install_d3_hwschematic.sh
+++ b/tool/gh_actions/install_d3_hwschematic.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# install_synthesis.sh
+# GitHub Actions step: Install project dependencies.
+#
+# 2023 May 09
+# Author: Desmond Kirkpatrick <desmond.a.kirkpatrick@intel.com>
+#
+
+set -euo pipefail
+
+apt-get update
+apt-get install -y \
+	git \
+	npm \
+	python3-pip
+
+git clone https://github.com/Nic30/d3-hwschematic.git
+cd d3-hwschematic
+npm install
+npm install --only=dev
+nom run build
+

--- a/tool/gh_actions/install_d3_hwschematic.sh
+++ b/tool/gh_actions/install_d3_hwschematic.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 cd doc/d3-hwschematic
 npm install
 npm install --only=dev
-nom run build
+npm run build
 
 cd ../..
 mkdir -p doc/api/d3-hwschematic-assets

--- a/tool/gh_actions/install_d3_hwschematic.sh
+++ b/tool/gh_actions/install_d3_hwschematic.sh
@@ -18,8 +18,7 @@ apt-get install -y \
 	npm \
 	python3-pip
 
-git clone https://github.com/Nic30/d3-hwschematic.git
-cd d3-hwschematic
+cd doc/d3-hwschematic
 npm install
 npm install --only=dev
 nom run build

--- a/tool/gh_actions/install_d3_hwschematic.sh
+++ b/tool/gh_actions/install_d3_hwschematic.sh
@@ -3,7 +3,7 @@
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
-# install_synthesis.sh
+# install_d3_hwschematic.sh
 # GitHub Actions step: Install project dependencies.
 #
 # 2023 May 09

--- a/tool/gh_actions/install_opencadsuite.sh
+++ b/tool/gh_actions/install_opencadsuite.sh
@@ -3,7 +3,7 @@
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
-# install_synthesis.sh
+# install_opencadsuite.sh
 # GitHub Actions step: Install project dependencies.
 #
 # 2023 May 09

--- a/tool/gh_actions/install_schematic.sh
+++ b/tool/gh_actions/install_schematic.sh
@@ -12,16 +12,11 @@
 
 set -euo pipefail
 
-cd doc/d3-hwschematic
-npm install
-npm install --only=dev
-npm run build
-
-cd ../..
-mkdir -p doc/api/d3-hwschematic-assets
-cp -r doc/d3-hwschematic/node_modules/d3 doc/api/d3-hwschematic-assets
-cp -r doc/d3-hwschematic/node_modules/elkjs doc/api/d3-hwschematic-assets
-cp doc/d3-hwschematic/dist/d3-hwschematic.{css,js} doc/api/d3-hwschematic-assets
+apt-get update
+apt-get install -y \
+	git \
+	npm \
+	python3-pip
 
 cd /
 sudo  wget -O oss-cad-suite-build.tgz https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2023-05-12/oss-cad-suite-linux-x64-20230512.tgz

--- a/tool/gh_actions/install_schematic.sh
+++ b/tool/gh_actions/install_schematic.sh
@@ -12,8 +12,8 @@
 
 set -euo pipefail
 
-apt-get update
-apt-get install -y \
+sudo apt-get update
+sudo apt-get install -y \
 	git \
 	npm \
 	python3-pip

--- a/tool/gh_actions/install_schematic.sh
+++ b/tool/gh_actions/install_schematic.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# install_synthesis.sh
+# GitHub Actions step: Install project dependencies.
+#
+# 2023 May 09
+# Author: Desmond Kirkpatrick <desmond.a.kirkpatrick@intel.com>
+#
+
+set -euo pipefail
+
+cd doc/d3-hwschematic
+npm install
+npm install --only=dev
+npm run build
+
+cd ../..
+mkdir -p doc/api/d3-hwschematic-assets
+cp -r doc/d3-hwschematic/node_modules/d3 doc/api/d3-hwschematic-assets
+cp -r doc/d3-hwschematic/node_modules/elkjs doc/api/d3-hwschematic-assets
+cp doc/d3-hwschematic/dist/d3-hwschematic.{css,js} doc/api/d3-hwschematic-assets
+
+cd /
+sudo  wget -O oss-cad-suite-build.tgz https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2023-05-12/oss-cad-suite-linux-x64-20230512.tgz
+
+sudo tar -xvzf oss-cad-suite-build.tgz
+
+# Trim if needed

--- a/tool/gh_codespaces/run_setup.sh
+++ b/tool/gh_codespaces/run_setup.sh
@@ -17,3 +17,6 @@ tool/gh_codespaces/install_dart.sh
 
 # Install Pub dependencies.
 tool/gh_actions/install_dependencies.sh
+
+# Install Synthesis tool (yosys).
+tool/gh_actions/install_synthesis.sh

--- a/tool/synthesize.sh
+++ b/tool/synthesize.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# synthesize.sh
+# Run synthesis outputing synthesized Verilog
+#
+# 2023 May 09
+# Author: Desmond Kirkpatrick <desmond.a.kirkpatrick@intel.com>
+#
+
+# Executes synthesis given a module name
+# Assumes .v extension
+# Outputs < module>_synth.v
+
+if !(test 1 -eq $#); then
+    echo One argument required: module
+    exit 1
+fi;
+
+yosys_area=/yosys
+lib=$yosys_area/tests/liberty/normal.lib
+module=$1
+yosys <<EOF
+read_verilog -sv $module.v
+hierarchy -top $module
+proc
+dfflibmap -liberty $lib
+abc -liberty $lib
+proc; opt
+techmap
+write_verilog ${module}_synth.v
+EOF


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

This code generates interactive HTML schematics for components.  The current documentation points to the generated HTML.  
All known issues from the previous pull request were fixed (sync writes, separate generation, binary for yosys, submodule for d3-hwschematic).

<!-- Description of changes, and motivation for adding them. -->

This code uses the d3-hwschematic code to generate HTML for viewing schematics. A custom script injects JSON for the circuit into a single HTML file per schematic to avoid file loading.  The JSON is produced from Yosys.

Resolves issue #23 

## Testing

By testing in a fork, I have verified that documentation linkage will work.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

We will need to reset links in the documentation to point to the production deployment area.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

<!-- Answer here. -->
