### PR TITLE
Add the APB standard interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ Below is a list of components either already or planning to be implemented.
     - Latch-based
   - Replacement Policies
     - LRU
-- Standard interfaces
+- [Standard interfaces](./doc/standard_interfaces.md)
   - AXI
-  - APB
+  - [APB](./doc/standard_interfaces.md#apb)
   - AHB
   - SFI
   - PCIe

--- a/doc/standard_interfaces.md
+++ b/doc/standard_interfaces.md
@@ -1,0 +1,7 @@
+# Standard Interfaces
+
+ROHD HCL provides a set of standard interfaces using ROHD `Interface`s.  This makes it easy to instantiate and connect common interfaces in a configurable way.
+
+## APB
+
+The [ABP Interface](https://developer.arm.com/documentation/ihi0024/latest/) is a standard AMBA interface.  ROHD HCL has a configurable version of the APB interface called [`ABP`](https://intel.github.io/rohd-hcl/rohd_hcl/Apb-class.html).

--- a/lib/rohd_hcl.dart
+++ b/lib/rohd_hcl.dart
@@ -4,6 +4,7 @@
 export 'src/arbiter.dart';
 export 'src/exceptions.dart';
 export 'src/fifo.dart';
+export 'src/interfaces/interfaces.dart';
 export 'src/memory.dart';
 export 'src/one_hot.dart';
 export 'src/rotate.dart';

--- a/lib/src/interfaces/apb.dart
+++ b/lib/src/interfaces/apb.dart
@@ -1,0 +1,254 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// apb.dart
+// Definitions for the APB interface.
+//
+// 2023 May 19
+// Author: Max Korbel <max.korbel@intel.com>
+
+import 'package:rohd/rohd.dart';
+import 'package:rohd_hcl/src/exceptions.dart';
+
+/// A grouping of signals on the [Apb] interface based on direction.
+enum ApbDirection {
+  /// Miscellaneous system-level signals, common inputs to both sides.
+  misc,
+
+  /// Signals driven by the requester.
+  fromRequester,
+
+  /// Signals driven by the completer.
+  fromCompleter
+}
+
+/// A standard APB interface.
+class Apb extends Interface<ApbDirection> {
+  /// The width of address port [addr].
+  ///
+  /// Equvalent to the `ADDR_WIDTH` parameter in the APB specification.
+  ///
+  /// Must be less than or equal to 32 bits.
+  final int addrWidth;
+
+  /// The width of data ports [wData] and [rData];
+  ///
+  /// Equvalent to the `DATA_WIDTH` parameter in the APB specification.
+  ///
+  /// Can be 8 bits, 16 bits, or 32 bits wide.
+  final int dataWidth;
+
+  /// The width of user request port [aUser].
+  ///
+  /// Equvalent to the `USER_REQ_WIDTH` parameter in the APB specification.
+  ///
+  /// Recommended to have a maximum width of 128 bits. If set to 0, then ports
+  /// which use this width will not be created. Recommended to set to 0.
+  final int userReqWidth;
+
+  /// The width of user-defined data ports [wUser] and [rUser].
+  ///
+  /// Equvalent to the `USER_DATA_WIDTH` parameter in the APB specification.
+  ///
+  /// Recommended to have a maximum width of [dataWidth]/2. If set to 0, then
+  /// ports which use this width will not be created. Recommended to set to 0.
+  final int userDataWidth;
+
+  /// The width of user response port [bUser].
+  ///
+  /// Equvalent to the `USER_RESP_WIDTH` parameter in the APB specification.
+  ///
+  /// Recommended to have a maximum width of 16. If set to 0, then ports which
+  /// use this width will not be created. Recommended to set to 0.
+  final int userRespWidth;
+
+  /// If `true`, generates the [slvErr] port.
+  final bool includeSlvErr;
+
+  /// Clock for the interface.
+  ///
+  /// All APB signals are timed against the rising edge.
+  Logic get clk => port('PCLK');
+
+  /// Reset signal (active LOW).
+  ///
+  /// Normally connected directly to the system bus reset signal.
+  Logic get resetN => port('PRESETn');
+
+  /// Address bus.
+  ///
+  /// Width is equal to [addrWidth].
+  Logic get addr => port('PADDR');
+
+  /// Protection type.
+  ///
+  /// Indicates the normal, privileged, or secure protection level of the
+  /// transaction and whether the transaction is a data access or an instruction
+  /// access.
+  Logic get prot => port('PPROT');
+
+  /// Extension to protection type.
+  Logic get nse => port('PNSE');
+
+  /// Select.
+  ///
+  /// The Requester generates a select signal for each Completer. Select
+  /// indicates that the Completer is selected and that a data transfer is
+  /// required.
+  Logic get selX => port('PSELx');
+
+  /// Enable.
+  ///
+  /// Indicates the second and subsequent cycles of an APB transfer.
+  Logic get enable => port('PENABLE');
+
+  /// Direction.
+  ///
+  /// Indicates an APB write access when HIGH and an APB read access when LOW.
+  Logic get write => port('PWRITE');
+
+  /// Write data.
+  ///
+  /// The write data bus is driven by the APB bridge Requester during
+  /// write cycles when [write] is HIGH.
+  ///
+  /// Width is equal to [dataWidth].
+  Logic get wData => port('PWDATA');
+
+  /// Write strobe.
+  ///
+  /// Indicates which byte lanes to update during a write transfer. There is one
+  /// write strobe for each 8 bits of the write data bus. Width is equal to
+  /// [dataWidth] divided by 8.
+  ///
+  /// The `n`th bit of [strb] corresponds to range `[(8n + 7):(8n)]` of [wData].
+  ///
+  /// Must not be active during a read transfer.
+  Logic get strb => port('PSTRB');
+
+  /// Ready.
+  ///
+  /// Used to extend an APB transfer by the Completer.
+  Logic get ready => port('PREADY');
+
+  /// Read data.
+  ///
+  /// Driven by the selected Completer during read cycles when [write] is LOW.
+  ///
+  /// Width is equal to [dataWidth].
+  Logic get rData => port('PRDATA');
+
+  /// Transfer error.
+  ///
+  /// An optional signal that can be asserted HIGH by the Completer to indicate
+  /// an error condition on an APB transfer.
+  ///
+  /// Only generated if [includeSlvErr] is `true`.
+  Logic? get slvErr => includeSlvErr ? port('PSLVERR') : null;
+
+  /// Wake-up.
+  ///
+  /// Indicates any activity associated with an APB interface.
+  Logic get wakeup => port('PWAKEUP');
+
+  /// User request attribute.
+  ///
+  /// Width equal to [userReqWidth].  Only exists if [userReqWidth] > 0.
+  Logic? get aUser => userReqWidth != 0 ? port('PAUSER') : null;
+
+  /// User write data attribute.
+  ///
+  /// Width equal to [userDataWidth].  Only exists if [userDataWidth] > 0.
+  Logic? get wUser => userDataWidth != 0 ? port('PWUSER') : null;
+
+  /// User read data attribute.
+  ///
+  /// Width equal to [userDataWidth].  Only exists if [userDataWidth] > 0.
+  Logic? get rUser => userDataWidth != 0 ? port('PRUSER') : null;
+
+  /// User response attribute.
+  ///
+  /// Width equal to [userRespWidth].  Only exists if [userRespWidth] > 0.
+  Logic? get bUser => userRespWidth != 0 ? port('PBUSER') : null;
+
+  /// Construct a new instance of an APB interface.
+  Apb({
+    this.addrWidth = 32,
+    this.dataWidth = 32,
+    this.userReqWidth = 0,
+    this.userDataWidth = 0,
+    this.userRespWidth = 0,
+    this.includeSlvErr = false,
+  }) {
+    _validateParameters();
+
+    setPorts([
+      Port('PCLK'),
+      Port('PRESETn'),
+    ], [
+      ApbDirection.misc
+    ]);
+
+    setPorts([
+      Port('PADDR', addrWidth),
+      Port('PPROT', 3),
+      Port('PNSE'),
+      Port('PSELx'),
+      Port('PENABLE'),
+      Port('PWRITE'),
+      Port('PWDATA', dataWidth),
+      Port('PSTRB', dataWidth ~/ 8),
+      if (userReqWidth != 0) Port('PAUSER', userReqWidth),
+      if (userDataWidth != 0) Port('PWUSER', userDataWidth),
+    ], [
+      ApbDirection.fromRequester
+    ]);
+
+    setPorts([
+      Port('PREADY'),
+      Port('PRDATA', dataWidth),
+      Port('PSLVERR'),
+      Port('PWAKEUP'),
+      if (userDataWidth != 0) Port('PRUSER', userDataWidth),
+      if (userRespWidth != 0) Port('PBUSER', userRespWidth),
+    ], [
+      ApbDirection.fromCompleter
+    ]);
+  }
+
+  /// Constructs a new [Apb] with identical parameters to [other].
+  Apb.clone(Apb other)
+      : this(
+          addrWidth: other.addrWidth,
+          dataWidth: other.dataWidth,
+          userReqWidth: other.userReqWidth,
+          userRespWidth: other.userRespWidth,
+          includeSlvErr: other.includeSlvErr,
+        );
+
+  /// Checks that the values set for parameters follow the specification's
+  /// restrictions.
+  void _validateParameters() {
+    if (addrWidth > 32 || addrWidth < 0) {
+      throw RohdHclException(
+          'addrWidth must be a positive number no greater than 32.');
+    }
+
+    const legalDataWidths = [8, 16, 32];
+    if (!legalDataWidths.contains(dataWidth)) {
+      throw RohdHclException('dataWidth must be one of $legalDataWidths');
+    }
+
+    if (userReqWidth < 0) {
+      throw RohdHclException('userReqWidth must >= 0');
+    }
+
+    if (userDataWidth < 0) {
+      throw RohdHclException('userDataWidth must >= 0');
+    }
+
+    if (userRespWidth < 0) {
+      throw RohdHclException('userRespWidth must >= 0');
+    }
+  }
+}

--- a/lib/src/interfaces/interfaces.dart
+++ b/lib/src/interfaces/interfaces.dart
@@ -1,0 +1,4 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+
+export 'apb.dart';

--- a/test/apb_test.dart
+++ b/test/apb_test.dart
@@ -1,0 +1,65 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// apb_test.dart
+// Tests for the APB interface.
+//
+// 2023 May 19
+// Author: Max Korbel <max.korbel@intel.com>
+
+import 'package:rohd/rohd.dart';
+import 'package:rohd_hcl/rohd_hcl.dart';
+import 'package:test/test.dart';
+
+class ApbController extends Module {
+  ApbController(Apb intf) {
+    intf = Apb.clone(intf)
+      ..connectIO(this, intf,
+          inputTags: {ApbDirection.misc, ApbDirection.fromRequester},
+          outputTags: {ApbDirection.fromCompleter});
+  }
+}
+
+class ApbRequester extends Module {
+  ApbRequester(Apb intf) {
+    intf = Apb.clone(intf)
+      ..connectIO(this, intf,
+          inputTags: {ApbDirection.misc, ApbDirection.fromCompleter},
+          outputTags: {ApbDirection.fromRequester});
+  }
+}
+
+class ApbPair extends Module {
+  ApbPair(Logic clk, Logic reset) {
+    clk = addInput('clk', clk);
+    reset = addInput('reset', reset);
+
+    final apb = Apb(
+      includeSlvErr: true,
+      userDataWidth: 10,
+      userReqWidth: 11,
+      userRespWidth: 12,
+    );
+    apb.clk <= clk;
+    apb.resetN <= ~reset;
+
+    ApbController(apb);
+    ApbRequester(apb);
+  }
+}
+
+void main() {
+  test('connect apb modules', () async {
+    final abpPair = ApbPair(Logic(), Logic());
+    await abpPair.build();
+  });
+
+  test('abp optional ports null', () async {
+    final apb = Apb();
+    expect(apb.aUser, isNull);
+    expect(apb.bUser, isNull);
+    expect(apb.rUser, isNull);
+    expect(apb.wUser, isNull);
+    expect(apb.slvErr, isNull);
+  });
+}


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Add a configurable implementation of the APB interface to ROHD-HCL using ROHD `Interface`s, including docs.

## Related Issue(s)

N/A

## Testing

Added some tests that it can be instantiated, used, and optional ports can be null.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Yes, new doc and updated README
