### PR TITLE
Remove extra bypass logic when bypass is not generated in FIFO

### DIFF
--- a/lib/src/fifo.dart
+++ b/lib/src/fifo.dart
@@ -127,10 +127,14 @@ class Fifo extends Module {
     }
 
     // bypass means don't write to the FIFO, feed straight through
-    final bypass = Logic(name: 'bypass')
-      ..gets(empty & readEnable & writeEnable);
+    final bypass = Logic(name: 'bypass');
+    if (generateBypass) {
+      bypass <= empty & readEnable & writeEnable;
+      wrPort.en <= writeEnable & ~bypass;
+    } else {
+      wrPort.en <= writeEnable;
+    }
 
-    wrPort.en <= writeEnable & ~bypass;
     wrPort.addr <= wrPointer;
     wrPort.data <= writeData;
 


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

There was some extra logic getting generated when bypass generation was disabled in the FIFO.  This fixes that.

## Related Issue(s)

N/A

## Testing

Existing tests cover it

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
