### PR TITLE
Checking and tracking for `Fifo`

### DIFF
--- a/doc/fifo.md
+++ b/doc/fifo.md
@@ -30,4 +30,37 @@ There is no guarantee that the `error` signal will hold high once asserted once.
 
 Occupancy information can optionally be generated and provided if `generateOccupancy` is set.  The `occupancy` signal will indicate the number of items currently stored in the FIFO.
 
-[FIFO Schematic](https://intel.github.io/rohd-hcl/Fifo.html)
+## Example Schematic
+
+An example schematic for one configuration is viewable here: [FIFO Schematic](https://intel.github.io/rohd-hcl/Fifo.html)
+
+## Testbench Utilities
+
+The FIFO comes with both a checker and a tracker that you can leverage in your testbench.
+
+### Checker
+
+The `FifoChecker` is a ROHD-VF component which will watch for proper usge of a FIFO in your simulation. It is intended to check usage, not  the internal workings of the FIFO, which are already pre-validated in the unit tests.  This means it covers things like underflow, overflow, and that the FIFO is empty at the end of the test.
+
+### Tracker
+
+The `FifoTracker` will generate log files using the `Tracker` from ROHD-VF in either table or JSON format.  It tracks reads and writes per timestamp, including data pushed/popped and the current occupancy.  An example table is shown below (from one of the unit tests):
+
+```text
+----------------------------------------
+ | T        | C  | D              | O | 
+ | I        | O  | A              | C | 
+ | M        | M  | T              | C | 
+ | E        | M  | A              | U | 
+ |          | A  |                | P | 
+ |          | N  |                | A | 
+ |          | D  |                | N | 
+ |          |    |                | C | 
+ |          |    |                | Y | 
+----------------------------------------
+ |       55 | WR |        32'h111 | 1 | {Time: 55, Command: WR, Data: 32'h111, Occupancy: 1}
+ |       75 | WR |        32'h222 | 2 | {Time: 75, Command: WR, Data: 32'h222, Occupancy: 2}
+ |       75 | RD |        32'h111 | 1 | {Time: 75, Command: RD, Data: 32'h111, Occupancy: 1}
+ |       85 | RD |        32'h222 | 0 | {Time: 85, Command: RD, Data: 32'h222, Occupancy: 0}
+
+```

--- a/lib/src/fifo.dart
+++ b/lib/src/fifo.dart
@@ -13,8 +13,6 @@ import 'package:rohd_hcl/rohd_hcl.dart';
 import 'package:rohd_hcl/src/utils.dart';
 import 'package:rohd_vf/rohd_vf.dart';
 
-//TODO: an auto-attach verification component, check empty at end of test, error situation, etc.
-
 /// A simple FIFO (First In, First Out).
 ///
 /// Supports a bypass if the FIFO is empty and written & read at the same time.
@@ -56,14 +54,25 @@ class Fifo extends Module {
   /// and reading at the same time while [empty].
   final bool generateBypass;
 
-  //TODO: doc comment these
+  /// Push signal.
   Logic get _writeEnable => input('writeEnable');
+
+  /// Pop signal.
   Logic get _readEnable => input('readEnable');
+
+  /// Clock.
   Logic get _clk => input('clk');
+
+  /// Reset.
   Logic get _reset => input('reset');
+
+  /// Write data.
   Logic get _writeData => input('writeData');
 
+  /// The width of the data transmitted through this FIFO.
   final int dataWidth;
+
+  /// The address width for elements in the storage of this FIFO.
   final int _addrWidth;
 
   /// Constructs a FIFO with RF-based storage.

--- a/lib/src/fifo.dart
+++ b/lib/src/fifo.dart
@@ -297,7 +297,7 @@ class FifoTracker extends Tracker {
               columnWidth: fifo.dataWidth ~/ 4 + log2Ceil(fifo.dataWidth) + 1),
           TrackerField('Occupancy', columnWidth: fifo.depth ~/ 10 + 1),
         ]) {
-    var prevReadValue = LogicValue.x;
+    LogicValue? prevReadValue;
     Simulator.preTick.listen((event) {
       prevReadValue = fifo.readData.value;
     });
@@ -314,7 +314,7 @@ class FifoTracker extends Tracker {
       if (fifo._readEnable.value.toBool()) {
         record(_FifoEvent(
           _FifoCmd.rd,
-          prevReadValue,
+          prevReadValue!,
           --_occupancy,
         ));
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,9 @@ environment:
   sdk: '>=2.18.0 <3.0.0'
 
 dependencies:
+  meta: ^1.9.1
   rohd: ^0.4.2
+  rohd_vf: ^0.4.1
 
 dev_dependencies:
   test: ^1.21.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,5 +15,6 @@ dependencies:
   rohd_vf: ^0.4.1
 
 dev_dependencies:
-  test: ^1.21.0
   logging: ^1.0.1
+  test: ^1.21.0
+  

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,3 +16,4 @@ dependencies:
 
 dev_dependencies:
   test: ^1.21.0
+  logging: ^1.0.1


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Adds a ROHD-VF `FifoChecker` and `FifoTracker` that can be used to validate proper usage of the `Fifo` in designs.

Also, refactored `Fifo` a little and removed a few unnecessary gates depending on configuration.

## Related Issue(s)

N/A

## Testing

Added new tests

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Yes, updated docs
