### PR TITLE
Fix bug where FIFO depth 1 generated 0-width address

### DIFF
--- a/lib/src/fifo.dart
+++ b/lib/src/fifo.dart
@@ -7,6 +7,8 @@
 // 2023 March 13
 // Author: Max Korbel <max.korbel@intel.com>
 
+import 'dart:math';
+
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
 import 'package:rohd_vf/rohd_vf.dart';
@@ -84,8 +86,11 @@ class Fifo extends Module {
       this.generateBypass = false,
       super.name = 'fifo'})
       : dataWidth = writeData.width,
-        _addrWidth = log2Ceil(depth),
+        _addrWidth = max(1, log2Ceil(depth)),
         assert(depth > 0, 'Depth must be at least 1.') {
+    assert(_addrWidth > 0,
+        'Assumptions that address is non-zero in implementation');
+
     addInput('clk', clk);
     addInput('reset', reset);
 

--- a/lib/src/fifo.dart
+++ b/lib/src/fifo.dart
@@ -89,7 +89,7 @@ class Fifo extends Module {
         _addrWidth = max(1, log2Ceil(depth)),
         assert(depth > 0, 'Depth must be at least 1.') {
     assert(_addrWidth > 0,
-        'Assumptions that address is non-zero in implementation');
+        'Assumption that address width is non-zero in implementation');
 
     addInput('clk', clk);
     addInput('reset', reset);

--- a/lib/src/fifo.dart
+++ b/lib/src/fifo.dart
@@ -42,6 +42,8 @@ class Fifo extends Module {
   Logic? get occupancy => generateOccupancy ? output('occupancy') : null;
 
   /// The depth of this FIFO.
+  ///
+  /// Must be greater than 0.
   final int depth;
 
   /// If `true`, then the [occupancy] output will be generated.
@@ -86,8 +88,11 @@ class Fifo extends Module {
       this.generateBypass = false,
       super.name = 'fifo'})
       : dataWidth = writeData.width,
-        _addrWidth = max(1, log2Ceil(depth)),
-        assert(depth > 0, 'Depth must be at least 1.') {
+        _addrWidth = max(1, log2Ceil(depth)) {
+    if (depth <= 0) {
+      throw RohdHclException('Depth must be at least 1.');
+    }
+
     assert(_addrWidth > 0,
         'Assumption that address width is non-zero in implementation');
 

--- a/test/fifo_test.dart
+++ b/test/fifo_test.dart
@@ -127,6 +127,62 @@ void main() {
     await Simulator.simulationEnded;
   });
 
+  test('fifo with depth 1', () async {
+    final clk = SimpleClockGenerator(10).clk;
+    final reset = Logic()..put(0);
+
+    final wrEn = Logic()..put(0);
+    final rdEn = Logic()..put(0);
+    final wrData = Logic(width: 32);
+
+    final fifo = Fifo(
+      clk,
+      reset,
+      writeEnable: wrEn,
+      readEnable: rdEn,
+      writeData: wrData,
+      generateError: true,
+      depth: 1,
+    );
+
+    await fifo.build();
+
+    unawaited(Simulator.run());
+
+    // a little reset flow
+    await clk.nextNegedge;
+    reset.put(1);
+    await clk.nextNegedge;
+    await clk.nextNegedge;
+    reset.put(0);
+    await clk.nextNegedge;
+    await clk.nextNegedge;
+
+    wrEn.put(1);
+    wrData.put(0xdeadbeef);
+
+    await clk.nextNegedge;
+
+    wrEn.put(0);
+    wrData.put(0);
+    expect(fifo.full.value.toBool(), true);
+    expect(fifo.error!.value.toBool(), false);
+
+    await clk.nextNegedge;
+
+    rdEn.put(1);
+    expect(fifo.readData.value.toInt(), 0xdeadbeef);
+
+    await clk.nextNegedge;
+    rdEn.put(0);
+
+    expect(fifo.empty.value.toBool(), true);
+    expect(fifo.error!.value.toBool(), false);
+
+    Simulator.endSimulation();
+    await Simulator.simulationEnded;
+  });
+
   test('fifo underflow error without bypass', () async {
     final clk = SimpleClockGenerator(10).clk;
     final reset = Logic()..put(0);


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

When the FIFO was configured to depth=1, the computed address width was 0, which violated some assumptions in the design.  In the future, there may be room for optimization to account for when the address is unnecessary, but those changes are not included in this PR.

## Related Issue(s)

N/A

## Testing

Added a new test and an assertion.  New version of ROHD will hit errors.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
