### PR TITLE
Fix generation of website with confapp

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -70,7 +70,7 @@ jobs:
     name: Run Flutter Checks
     permissions: {}
     timeout-minutes: 30
-    runs-on: ubuntu-22.04
+    runs-on: intel-ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -91,36 +91,6 @@ jobs:
       
       - name: Build static site
         run: tool/gh_actions/hcl_site_generation_build.sh
-
-  deploy-site:
-    name: Deploy ROHD-HCL Generator site
-    needs: [run-checks, run-flutter-checks]
-    if: github.event_name == 'push'
-    permissions:
-      contents: write # required for "JamesIves/github-pages-deploy-action"
-    timeout-minutes: 30
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-
-      - name: Setup Flutter SDK
-        uses: flutter-actions/setup-flutter@v2
-        with:
-          channel: stable
-          version: 3.10.6
-      
-      - name: Build static site
-        run: tool/gh_actions/hcl_site_generation_build.sh
-
-      - name: Deploy the generated site to website branch
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: confapp/build/web
-          target-folder: confapp
-          branch: website
 
   deploy-documentation:
     name: Deploy Documentation
@@ -160,4 +130,33 @@ jobs:
           folder: doc/api
           branch: website
 
+  deploy-site:
+    name: Deploy ROHD-HCL Generator site
+    needs: [run-checks, run-flutter-checks, deploy-documentation]
+    if: github.event_name == 'push'
+    permissions:
+      contents: write # required for "JamesIves/github-pages-deploy-action"
+    timeout-minutes: 30
+    runs-on: intel-ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Setup Flutter SDK
+        uses: flutter-actions/setup-flutter@v2
+        with:
+          channel: stable
+          version: 3.10.6
       
+      - name: Build static site
+        run: tool/gh_actions/hcl_site_generation_build.sh
+
+      - name: Deploy the generated site to website branch
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: confapp/build/web
+          target-folder: confapp
+          branch: website
+          clean: false  # goes in after the documentation, which does a clean


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Both of the pages deployments had `clean: true` (implicitly), which meant whichever ran second would delete whichever ran first.  This PR orders them, and prevents the second from doing a "clean".

## Related Issue(s)

N/A

## Testing

This is it!

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
