### PR TITLE
Round robin arbiters updates

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -13,7 +13,7 @@ jobs:
     name: Run Checks
     permissions: {}
     timeout-minutes: 30
-    runs-on: intel-ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'intel' && 'intel-ubuntu-latest' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -70,7 +70,7 @@ jobs:
     name: Run Flutter Checks
     permissions: {}
     timeout-minutes: 30
-    runs-on: intel-ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'intel' && 'intel-ubuntu-latest' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -99,7 +99,7 @@ jobs:
     permissions:
       contents: write # required for "JamesIves/github-pages-deploy-action"
     timeout-minutes: 30
-    runs-on: intel-ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'intel' && 'intel-ubuntu-latest' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -137,7 +137,7 @@ jobs:
     permissions:
       contents: write # required for "JamesIves/github-pages-deploy-action"
     timeout-minutes: 30
-    runs-on: intel-ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'intel' && 'intel-ubuntu-latest' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.pubignore
+++ b/.pubignore
@@ -1,0 +1,1 @@
+confapp

--- a/doc/components/arbiter.md
+++ b/doc/components/arbiter.md
@@ -2,6 +2,10 @@
 
 ROHD HCL implements a generic `abstract` [`Arbiter`](https://intel.github.io/rohd-hcl/rohd_hcl/Arbiter-class.html) class that other arbiters can extend.  It accepts a `List` of `requests`, where each request is a `1-bit` signal indicating that there is a request for a resource.  The output `grants` is a `List` where each element corresponds to the request with the same index.  The arbiter implementation decides how to select which request receives a grant.
 
+## Stateful Arbiter
+
+A `StatefulArbiter` is an `Arbiter` which can hold state, and thus requires a `clk` and `reset`.
+
 ## Priority Arbiter
 
 The [`PriorityArbiter`](https://intel.github.io/rohd-hcl/rohd_hcl/PriorityArbiter-class.html) is a combinational (stateless) arbiter that always grants to the lowest-indexed request.
@@ -10,4 +14,7 @@ The [`PriorityArbiter`](https://intel.github.io/rohd-hcl/rohd_hcl/PriorityArbite
 
 ## Round Robin Arbiter
 
-The Round Robin Arbiter is a sequential (stateful) arbiter which grants requests same ways as Priority Arbiter, but keeps track of last request granted allowing each requestor to be granted "fairly".
+The `RoundRobinArbiter` is a `StatefulArbiter` which grants requests in a "fair" way so that all requestors get equal access to grants.  There are two implementations available for `RoundRobinArbiter`:
+
+- `MaskRoundRobinArbiter` is the default implementation if you create a `RoundRobinArbiter`.  It uses internal request and grant masks to store state for fair arbitration.
+- `RotateRoundRobinArbiter` is an alternative implementation which uses a `PriorityArbiter` and two rotators controlled by a last-granted state.

--- a/lib/rohd_hcl.dart
+++ b/lib/rohd_hcl.dart
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 export 'src/adder.dart';
-export 'src/arbiter.dart';
+export 'src/arbiters/arbiters.dart';
 export 'src/carry_save_mutiplier.dart';
 export 'src/component_config/component_config.dart';
 export 'src/count.dart';

--- a/lib/src/arbiters/arbiter.dart
+++ b/lib/src/arbiters/arbiter.dart
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // arbiter.dart
-// Implementation of arbiters.
+// Definition for an interface for a generic arbiter.
 //
 // 2023 March 13
 // Author: Max Korbel <max.korbel@intel.com>

--- a/lib/src/arbiters/arbiter.dart
+++ b/lib/src/arbiters/arbiter.dart
@@ -1,0 +1,46 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// arbiter.dart
+// Implementation of arbiters.
+//
+// 2023 March 13
+// Author: Max Korbel <max.korbel@intel.com>
+
+import 'dart:collection';
+import 'package:meta/meta.dart';
+import 'package:rohd/rohd.dart';
+import 'package:rohd_hcl/src/exceptions.dart';
+
+/// An abstract description of an arbiter module.
+abstract class Arbiter extends Module {
+  /// Each element corresponds to an arbitration grant of the correspondingly
+  /// indexed request passed at construction time.
+  late final List<Logic> grants = UnmodifiableListView(_grants);
+  final List<Logic> _grants = [];
+
+  /// Each element is the [input] pin for the correspondingly indexed request.
+  ///
+  /// To be used internally to the arbiter only, since this contains the
+  /// [inputs] of the [Module].
+  @protected
+  late final List<Logic> requests = UnmodifiableListView(_requests);
+  final List<Logic> _requests = [];
+
+  /// The total number of requests and grants for this [Arbiter].
+  late final int count = _requests.length;
+
+  /// Constructs an arbiter where each element in [requests] is a one-bit signal
+  /// requesting a corresponding bit from [grants].
+  Arbiter(List<Logic> requests, {super.name = 'arbiter'}) {
+    for (var i = 0; i < requests.length; i++) {
+      if (requests[i].width != 1) {
+        throw RohdHclException('Each request must be 1 bit,'
+            ' but found ${requests[i]} at index $i.');
+      }
+
+      _requests.add(addInput('request_$i', requests[i]));
+      _grants.add(addOutput('grant_$i'));
+    }
+  }
+}

--- a/lib/src/arbiters/arbiters.dart
+++ b/lib/src/arbiters/arbiters.dart
@@ -1,0 +1,6 @@
+export 'arbiter.dart';
+export 'mask_round_robin_arbiter.dart';
+export 'priority_arbiter.dart';
+export 'rotate_round_robin_arbiter.dart';
+export 'round_robin_arbiter.dart';
+export 'stateful_arbiter.dart';

--- a/lib/src/arbiters/arbiters.dart
+++ b/lib/src/arbiters/arbiters.dart
@@ -1,3 +1,6 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+
 export 'arbiter.dart';
 export 'mask_round_robin_arbiter.dart';
 export 'priority_arbiter.dart';

--- a/lib/src/arbiters/mask_round_robin_arbiter.dart
+++ b/lib/src/arbiters/mask_round_robin_arbiter.dart
@@ -1,72 +1,14 @@
-// Copyright (C) 2023 Intel Corporation
-// SPDX-License-Identifier: BSD-3-Clause
-//
-// arbiter.dart
-// Implementation of arbiters.
-//
-// 2023 March 13
-// Author: Max Korbel <max.korbel@intel.com>
-
-import 'dart:collection';
 import 'package:rohd/rohd.dart';
-import 'package:rohd_hcl/src/exceptions.dart';
-
-/// An abstract description of an arbiter module.
-abstract class Arbiter extends Module {
-  /// Each element corresponds to an arbitration grant of the correspondingly
-  /// indexed request passed at construction time.
-  List<Logic> get grants => UnmodifiableListView(_grants);
-
-  final List<Logic> _grants = [];
-
-  final List<Logic> _requests = [];
-
-  /// The total number of requests and grants for this [Arbiter].
-  int get count => _requests.length;
-
-  /// Constructs an arbiter where each element in [requests] is a one-bit signal
-  /// requesting a corresponding bit from [grants].
-  Arbiter(List<Logic> requests, {super.name = 'arbiter'}) {
-    for (var i = 0; i < requests.length; i++) {
-      if (requests[i].width != 1) {
-        throw RohdHclException('Each request must be 1 bit,'
-            ' but found ${requests[i]} at index $i.');
-      }
-
-      _requests.add(addInput('request_$i', requests[i]));
-      _grants.add(addOutput('grant_$i'));
-    }
-  }
-}
-
-/// An [Arbiter] which always picks the lowest-indexed request.
-class PriorityArbiter extends Arbiter {
-  /// Constructs an arbiter where the grant is given to the lowest-indexed
-  /// request.
-  PriorityArbiter(super.requests, {super.name = 'priority_arbiter'}) {
-    Combinational([
-      CaseZ(_requests.rswizzle(), conditionalType: ConditionalType.priority, [
-        for (var i = 0; i < count; i++)
-          CaseItem(
-            Const(
-              LogicValue.filled(count, LogicValue.z).withSet(i, LogicValue.one),
-            ),
-            [for (var g = 0; g < count; g++) _grants[g] < (i == g ? 1 : 0)],
-          )
-      ], defaultItem: [
-        for (var g = 0; g < count; g++) _grants[g] < 0
-      ]),
-    ]);
-  }
-}
+import 'package:rohd_hcl/rohd_hcl.dart';
 
 /// Round Robin Arbiter.
-class RoundRobinArbiter extends Arbiter {
+class MaskRoundRobinArbiter extends StatefulArbiter
+    implements RoundRobinArbiter {
   /// Mask to define pending requests to be attended
   /// the main idea is to mask the requests as they are granted to ensure all
   /// requests are granted once before resetting the mask
   /// example:
-  /// [clk] [_requests] [_requestMask]   [_grantMask]   [_grants]
+  /// [clk] [_requests] [_requestMask]   [_grantMask]   [grants]
   ///  0    00100010   &  11111111      =   00100010  ->  00000010
   ///  1    00100010   &  11111100      =   00100000  ->  00100000
   ///  2    10000001   &  11000000      =   10000000  ->  10000000
@@ -76,17 +18,15 @@ class RoundRobinArbiter extends Arbiter {
   /// handle the missing requests before resetting
   List<Logic> _requestMask = [];
 
-  /// Result of masking [_requests] with [_requestMask]
-  /// Contains bits of [_requests] but as bits are granted, will turn off
+  /// Result of masking [requests] with [_requestMask]
+  /// Contains bits of [requests] but as bits are granted, will turn off
   List<Logic> _grantMask = [];
 
   /// Round Robin arbiter handles requests by granting each requestor
   /// and keeping record of requests already granted, in order to mask it until
   /// granting the turn of each request to start again
-  RoundRobinArbiter(super.requests,
-      {required Logic clk, required Logic reset}) {
-    clk = addInput('clk', clk);
-    reset = addInput('reset', reset);
+  MaskRoundRobinArbiter(super.requests,
+      {required super.clk, required super.reset}) {
     _requestMask = List.generate(count, (i) => Logic(name: 'requestMask$i'));
     _grantMask = List.generate(count, (i) => Logic(name: 'grantMask$i'));
     Sequential(clk, [
@@ -99,7 +39,7 @@ class RoundRobinArbiter extends Arbiter {
         // Example:
         // [_grants] [requestMask]
         // 00001000   11110000
-        Case(_grants.rswizzle(), conditionalType: ConditionalType.unique, [
+        Case(grants.rswizzle(), conditionalType: ConditionalType.unique, [
           for (var i = 0; i < count; i++)
             CaseItem(
                 Const(LogicValue.filled(count, LogicValue.zero)
@@ -110,13 +50,15 @@ class RoundRobinArbiter extends Arbiter {
                 ])
           // In case [_grants] are all 0s, requestMask gets a reset
         ], defaultItem: [
-          for (var g = 0; g < count; g++) _requestMask[g] < 1,
+          // leave request mask as-is if there was no grant
+          //TODO: bug, shouldn't reset masks if no grants!
+          // for (var g = 0; g < count; g++) _requestMask[g] < 1,
         ])
       ])
     ]);
     Combinational([
       for (var g = 0; g < count; g++)
-        _grantMask[g] < _requestMask[g] & _requests[g],
+        _grantMask[g] < _requestMask[g] & requests[g],
       // CaseZ uses [_grantMask] to set the [_grants] based on the
       // least significant bit
       CaseZ(
@@ -127,7 +69,7 @@ class RoundRobinArbiter extends Arbiter {
                 Const(LogicValue.filled(count, LogicValue.z)
                     .withSet(i, LogicValue.one)),
                 [
-                  for (var g = 0; g < count; g++) _grants[g] < (i == g ? 1 : 0),
+                  for (var g = 0; g < count; g++) grants[g] < (i == g ? 1 : 0),
                 ]),
         ],
         // When all bits have been granted, [_grantMask] turns all to 0s because
@@ -135,8 +77,7 @@ class RoundRobinArbiter extends Arbiter {
         // relies on [_request] least significant bit
         defaultItem: [
           for (var g = 0; g < count; g++)
-            _grants[g] <
-                ~_requests.rswizzle().getRange(0, g).or() & _requests[g],
+            grants[g] < ~requests.rswizzle().getRange(0, g).or() & requests[g],
         ],
       ),
     ]);

--- a/lib/src/arbiters/mask_round_robin_arbiter.dart
+++ b/lib/src/arbiters/mask_round_robin_arbiter.dart
@@ -1,7 +1,15 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// mask_round_robin_arbiter.dart
+// Implementation of a masked round-robin arbiter.
+//
+// 2023
+
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
 
-/// Round Robin Arbiter.
+/// A [RoundRobinArbiter] implemented using request and grant masks.
 class MaskRoundRobinArbiter extends StatefulArbiter
     implements RoundRobinArbiter {
   /// Mask to define pending requests to be attended
@@ -51,8 +59,6 @@ class MaskRoundRobinArbiter extends StatefulArbiter
           // In case [_grants] are all 0s, requestMask gets a reset
         ], defaultItem: [
           // leave request mask as-is if there was no grant
-          //TODO: bug, shouldn't reset masks if no grants!
-          // for (var g = 0; g < count; g++) _requestMask[g] < 1,
         ])
       ])
     ]);

--- a/lib/src/arbiters/priority_arbiter.dart
+++ b/lib/src/arbiters/priority_arbiter.dart
@@ -1,0 +1,23 @@
+import 'package:rohd/rohd.dart';
+import 'package:rohd_hcl/rohd_hcl.dart';
+
+/// An [Arbiter] which always picks the lowest-indexed request.
+class PriorityArbiter extends Arbiter {
+  /// Constructs an arbiter where the grant is given to the lowest-indexed
+  /// request.
+  PriorityArbiter(super.requests, {super.name = 'priority_arbiter'}) {
+    Combinational([
+      CaseZ(requests.rswizzle(), conditionalType: ConditionalType.priority, [
+        for (var i = 0; i < count; i++)
+          CaseItem(
+            Const(
+              LogicValue.filled(count, LogicValue.z).withSet(i, LogicValue.one),
+            ),
+            [for (var g = 0; g < count; g++) grants[g] < (i == g ? 1 : 0)],
+          )
+      ], defaultItem: [
+        for (var g = 0; g < count; g++) grants[g] < 0
+      ]),
+    ]);
+  }
+}

--- a/lib/src/arbiters/priority_arbiter.dart
+++ b/lib/src/arbiters/priority_arbiter.dart
@@ -1,3 +1,12 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// priority_arbiter.dart
+// Implementation of a priority arbiter.
+//
+// 2023 March 13
+// Author: Max Korbel <max.korbel@intel.com>
+
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
 

--- a/lib/src/arbiters/rotate_round_robin_arbiter.dart
+++ b/lib/src/arbiters/rotate_round_robin_arbiter.dart
@@ -1,0 +1,31 @@
+import 'package:rohd/rohd.dart';
+import 'package:rohd_hcl/rohd_hcl.dart';
+
+/// A round-robin arbiter.
+class RotateRoundRobinArbiter extends StatefulArbiter
+    implements RoundRobinArbiter {
+  /// Creates an [Arbiter] that fairly takes turns between [requests].
+  RotateRoundRobinArbiter(super.requests,
+      {required super.clk, required super.reset}) {
+    final preference = Logic(name: 'preference', width: log2Ceil(count));
+
+    final rotatedReqs = requests
+        .rswizzle()
+        .rotateRight(preference, maxAmount: count - 1)
+        .elements;
+    final priorityArb = PriorityArbiter(rotatedReqs);
+    final unRotatedGrants = priorityArb.grants
+        .rswizzle()
+        .rotateLeft(preference, maxAmount: count - 1);
+
+    Sequential(clk, reset: reset, [
+      If(unRotatedGrants.or(), then: [
+        preference < TreeOneHotToBinary(unRotatedGrants).binary + 1,
+      ]),
+    ]);
+
+    for (var i = 0; i < count; i++) {
+      grants[i] <= unRotatedGrants[i];
+    }
+  }
+}

--- a/lib/src/arbiters/rotate_round_robin_arbiter.dart
+++ b/lib/src/arbiters/rotate_round_robin_arbiter.dart
@@ -1,7 +1,16 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// rotate_round_robin_arbiter.dart
+// Implementation of arbiters.
+//
+// 2023
+// Author: Max Korbel <max.korbel@intel.com>
+
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
 
-/// A round-robin arbiter.
+/// A [RoundRobinArbiter] implemented using rotations and a [PriorityArbiter].
 class RotateRoundRobinArbiter extends StatefulArbiter
     implements RoundRobinArbiter {
   /// Creates an [Arbiter] that fairly takes turns between [requests].

--- a/lib/src/arbiters/round_robin_arbiter.dart
+++ b/lib/src/arbiters/round_robin_arbiter.dart
@@ -1,7 +1,18 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// round_robin_arbiter.dart
+// Interface for round-robin arbiters.
+//
+// 2023 December
+// Author: Max Korbel <max.korbel@intel.com>
+
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
 
+/// A [StatefulArbiter] which fairly arbitrates between requests.
 abstract class RoundRobinArbiter extends StatefulArbiter {
+  /// By default, creates an instance of a [MaskRoundRobinArbiter].
   factory RoundRobinArbiter(List<Logic> requests,
           {required Logic clk, required Logic reset}) =>
       MaskRoundRobinArbiter(requests, clk: clk, reset: reset);

--- a/lib/src/arbiters/round_robin_arbiter.dart
+++ b/lib/src/arbiters/round_robin_arbiter.dart
@@ -1,0 +1,8 @@
+import 'package:rohd/rohd.dart';
+import 'package:rohd_hcl/rohd_hcl.dart';
+
+abstract class RoundRobinArbiter extends StatefulArbiter {
+  factory RoundRobinArbiter(List<Logic> requests,
+          {required Logic clk, required Logic reset}) =>
+      MaskRoundRobinArbiter(requests, clk: clk, reset: reset);
+}

--- a/lib/src/arbiters/stateful_arbiter.dart
+++ b/lib/src/arbiters/stateful_arbiter.dart
@@ -1,14 +1,31 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// stateful_arbiter.dart
+// Implementation of an arbiter that holds state.
+//
+// 2023 December
+// Author: Max Korbel <max.korbel@intel.com>
+
 import 'package:meta/meta.dart';
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
 
+/// An [Arbiter] which holds state in order to arbitrate.
 abstract class StatefulArbiter extends Arbiter {
+  /// The clock used for sequential elements.
+  ///
+  /// Should only be used by implementations.
   @protected
   late final Logic clk = input('clk');
 
+  /// The reset used for sequential elements (active high).
+  ///
+  /// Should only be used by implementations.
   @protected
   late final Logic reset = input('reset');
 
+  /// Creates a new [StatefulArbiter] with associated [clk] and [reset].
   StatefulArbiter(super.requests, {required Logic clk, required Logic reset}) {
     addInput('clk', clk);
     addInput('reset', reset);

--- a/lib/src/arbiters/stateful_arbiter.dart
+++ b/lib/src/arbiters/stateful_arbiter.dart
@@ -1,0 +1,16 @@
+import 'package:meta/meta.dart';
+import 'package:rohd/rohd.dart';
+import 'package:rohd_hcl/rohd_hcl.dart';
+
+abstract class StatefulArbiter extends Arbiter {
+  @protected
+  late final Logic clk = input('clk');
+
+  @protected
+  late final Logic reset = input('reset');
+
+  StatefulArbiter(super.requests, {required Logic clk, required Logic reset}) {
+    addInput('clk', clk);
+    addInput('reset', reset);
+  }
+}

--- a/lib/src/component_config/components/component_registry.dart
+++ b/lib/src/component_config/components/component_registry.dart
@@ -8,12 +8,14 @@
 // Author: Max Korbel <max.korbel@intel.com>
 
 import 'package:rohd_hcl/rohd_hcl.dart';
+import 'package:rohd_hcl/src/component_config/components/config_round_robin_arbiter.dart';
 
 /// A list of [Configurator]s for ROHD-HCL components.
 List<Configurator> get componentRegistry => [
       RotateConfigurator(),
       FifoConfigurator(),
       PriorityArbiterConfigurator(),
+      RoundRobinArbiterConfigurator(),
       RippleCarryAdderConfigurator(),
       CarrySaveMultiplierConfigurator(),
       BitonicSortConfigurator(),

--- a/lib/src/component_config/components/component_registry.dart
+++ b/lib/src/component_config/components/component_registry.dart
@@ -8,7 +8,6 @@
 // Author: Max Korbel <max.korbel@intel.com>
 
 import 'package:rohd_hcl/rohd_hcl.dart';
-import 'package:rohd_hcl/src/component_config/components/config_round_robin_arbiter.dart';
 
 /// A list of [Configurator]s for ROHD-HCL components.
 List<Configurator> get componentRegistry => [

--- a/lib/src/component_config/components/components.dart
+++ b/lib/src/component_config/components/components.dart
@@ -8,4 +8,5 @@ export 'config_priority_arbiter.dart';
 export 'config_rf.dart';
 export 'config_ripple_carry_adder.dart';
 export 'config_rotate.dart';
+export 'config_round_robin_arbiter.dart';
 export 'config_sort.dart';

--- a/lib/src/component_config/components/config_rotate.dart
+++ b/lib/src/component_config/components/config_rotate.dart
@@ -17,7 +17,7 @@ import 'package:rohd_hcl/rohd_hcl.dart';
 class RotateConfigurator extends Configurator {
   /// A knob controlling the direction of rotation.
   final directionKnob = ChoiceConfigKnob<RotateDirection>(
-    [RotateDirection.left, RotateDirection.right],
+    RotateDirection.values,
     value: RotateDirection.right,
   );
 

--- a/lib/src/component_config/components/config_round_robin_arbiter.dart
+++ b/lib/src/component_config/components/config_round_robin_arbiter.dart
@@ -1,0 +1,53 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// config_round_robin_arbiter.dart
+// Configurator for a PriorityArbiter.
+//
+// 2023 December 26
+// Author: Max Korbel <max.korbel@intel.com>
+
+import 'dart:collection';
+
+import 'package:rohd/rohd.dart';
+import 'package:rohd_hcl/rohd_hcl.dart';
+
+/// The type of round-robin arbiter.
+enum RoundRobinImplmentation {
+  /// A [MaskRoundRobinArbiter].
+  mask,
+
+  /// A [RotateRoundRobinArbiter]
+  rotate
+}
+
+/// A [Configurator] for [PriorityArbiter].
+class RoundRobinArbiterConfigurator extends Configurator {
+  /// A knob controlling the number of requests and grants.
+  final IntConfigKnob numRequestKnob = IntConfigKnob(value: 8);
+
+  /// A knob controlling the implementation.
+  final ChoiceConfigKnob<RoundRobinImplmentation> implementationKnob =
+      ChoiceConfigKnob(RoundRobinImplmentation.values,
+          value: RoundRobinImplmentation.mask);
+
+  @override
+  final String name = 'Round Robin Arbiter';
+
+  @override
+  late final Map<String, ConfigKnob<dynamic>> knobs = UnmodifiableMapView({
+    'Number of Requestors': numRequestKnob,
+    'Implementation': implementationKnob,
+  });
+
+  @override
+  Module createModule() {
+    final reqs = List.generate(numRequestKnob.value, (i) => Logic());
+    switch (implementationKnob.value) {
+      case RoundRobinImplmentation.mask:
+        return MaskRoundRobinArbiter(reqs, clk: Logic(), reset: Logic());
+      case RoundRobinImplmentation.rotate:
+        return RotateRoundRobinArbiter(reqs, clk: Logic(), reset: Logic());
+    }
+  }
+}

--- a/lib/src/component_config/components/config_round_robin_arbiter.dart
+++ b/lib/src/component_config/components/config_round_robin_arbiter.dart
@@ -12,24 +12,15 @@ import 'dart:collection';
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
 
-/// The type of round-robin arbiter.
-enum RoundRobinImplmentation {
-  /// A [MaskRoundRobinArbiter].
-  mask,
-
-  /// A [RotateRoundRobinArbiter]
-  rotate
-}
-
 /// A [Configurator] for [PriorityArbiter].
 class RoundRobinArbiterConfigurator extends Configurator {
   /// A knob controlling the number of requests and grants.
   final IntConfigKnob numRequestKnob = IntConfigKnob(value: 8);
 
   /// A knob controlling the implementation.
-  final ChoiceConfigKnob<RoundRobinImplmentation> implementationKnob =
-      ChoiceConfigKnob(RoundRobinImplmentation.values,
-          value: RoundRobinImplmentation.mask);
+  final ChoiceConfigKnob<Type> implementationKnob = ChoiceConfigKnob(
+      [MaskRoundRobinArbiter, RotateRoundRobinArbiter],
+      value: MaskRoundRobinArbiter);
 
   @override
   final String name = 'Round Robin Arbiter';
@@ -43,11 +34,13 @@ class RoundRobinArbiterConfigurator extends Configurator {
   @override
   Module createModule() {
     final reqs = List.generate(numRequestKnob.value, (i) => Logic());
-    switch (implementationKnob.value) {
-      case RoundRobinImplmentation.mask:
-        return MaskRoundRobinArbiter(reqs, clk: Logic(), reset: Logic());
-      case RoundRobinImplmentation.rotate:
-        return RotateRoundRobinArbiter(reqs, clk: Logic(), reset: Logic());
+
+    if (implementationKnob.value == MaskRoundRobinArbiter) {
+      return MaskRoundRobinArbiter(reqs, clk: Logic(), reset: Logic());
+    } else if (implementationKnob.value == RotateRoundRobinArbiter) {
+      return RotateRoundRobinArbiter(reqs, clk: Logic(), reset: Logic());
     }
+
+    throw RohdHclException('Unknown round robin type.');
   }
 }

--- a/test/arbiter_test.dart
+++ b/test/arbiter_test.dart
@@ -38,129 +38,182 @@ void main() {
     vector.put(bin('00010100'));
     expect(grantVec.value, LogicValue.ofString('00000100'));
   });
-  test('round robin logic', () async {
-    final clk = SimpleClockGenerator(10).clk;
-    const width = 8;
-    final vector = Logic(width: width);
-    final reset = Logic();
-    final reqs = List.generate(width, (i) => vector[i]);
-    final arb = RoundRobinArbiter(reqs, clk: clk, reset: reset);
-    final grants = arb.grants.rswizzle();
-    await arb.build();
-    WaveDumper(arb);
-    unawaited(Simulator.run());
 
-    vector.put(bin('01001001'));
-    reset.put(1); //Reset arbiter
-    await clk.nextNegedge;
-    await clk.nextNegedge;
-    reset.put(0);
-    expect(grants.value, LogicValue.ofString('00000001'));
-    await clk.nextNegedge;
-    expect(grants.value, LogicValue.ofString('00001000'));
-    await clk.nextNegedge;
-    expect(grants.value, LogicValue.ofString('01000000'));
-    await clk.nextNegedge;
-    expect(grants.value, LogicValue.ofString('00000001'));
-    await clk.nextNegedge;
-    expect(grants.value, LogicValue.ofString('00001000'));
-    await clk.nextNegedge;
-    expect(grants.value, LogicValue.ofString('01000000'));
-    await clk.nextNegedge;
-    expect(grants.value, LogicValue.ofString('00000001'));
-    await clk.nextNegedge;
-    vector.put(bin('00000000'));
-    expect(grants.value, LogicValue.ofString('00000000'));
-    await clk.nextNegedge;
-    vector.put(bin('11001010'));
-    expect(grants.value, LogicValue.ofString('00000010'));
-    await clk.nextNegedge;
-    expect(grants.value, LogicValue.ofString('00001000'));
-    await clk.nextNegedge;
-    expect(grants.value, LogicValue.ofString('01000000'));
-    await clk.nextNegedge;
-    expect(grants.value, LogicValue.ofString('10000000'));
-    await clk.nextNegedge;
-    expect(grants.value, LogicValue.ofString('00000010'));
+  group('round robin', () {
+    final rrArbTypes = [
+      (name: 'mask', constructor: MaskRoundRobinArbiter.new),
+      (name: 'rotate', constructor: RotateRoundRobinArbiter.new),
+    ];
 
-    Simulator.endSimulation();
-    await Simulator.simulationEnded;
-  });
+    for (final rrArbType in rrArbTypes) {
+      group(rrArbType.name, () {
+        test('simple directed', () async {
+          final clk = SimpleClockGenerator(10).clk;
+          const width = 8;
+          final vector = Logic(width: width);
+          final reset = Logic();
+          final reqs = List.generate(width, (i) => vector[i]);
+          final arb = rrArbType.constructor(reqs, clk: clk, reset: reset);
+          final grants = arb.grants.rswizzle();
+          await arb.build();
+          unawaited(Simulator.run());
 
-  test('Round Robin dynamic request test', () async {
-    final clk = SimpleClockGenerator(10).clk;
-    const width = 8;
-    final vector = Logic(width: width);
-    final reset = Logic();
-    final reqs = List.generate(width, (i) => vector[i]);
-    final arb = RoundRobinArbiter(reqs, clk: clk, reset: reset);
-    final grants = arb.grants.rswizzle();
-    await arb.build();
-    unawaited(Simulator.run());
-    WaveDumper(arb);
+          vector.put(bin('01001001'));
+          reset.put(1); //Reset arbiter
+          await clk.nextNegedge;
+          await clk.nextNegedge;
+          reset.put(0);
+          expect(grants.value, LogicValue.ofString('00000001'));
+          await clk.nextNegedge;
+          expect(grants.value, LogicValue.ofString('00001000'));
+          await clk.nextNegedge;
+          expect(grants.value, LogicValue.ofString('01000000'));
+          await clk.nextNegedge;
+          expect(grants.value, LogicValue.ofString('00000001'));
+          await clk.nextNegedge;
+          expect(grants.value, LogicValue.ofString('00001000'));
+          await clk.nextNegedge;
+          expect(grants.value, LogicValue.ofString('01000000'));
+          await clk.nextNegedge;
+          expect(grants.value, LogicValue.ofString('00000001'));
+          await clk.nextNegedge;
+          vector.put(bin('00000000'));
+          expect(grants.value, LogicValue.ofString('00000000'));
+          await clk.nextNegedge;
+          vector.put(bin('11001010'));
+          expect(grants.value, LogicValue.ofString('00000010'));
+          await clk.nextNegedge;
+          expect(grants.value, LogicValue.ofString('00001000'));
+          await clk.nextNegedge;
+          expect(grants.value, LogicValue.ofString('01000000'));
+          await clk.nextNegedge;
+          expect(grants.value, LogicValue.ofString('10000000'));
+          await clk.nextNegedge;
+          expect(grants.value, LogicValue.ofString('00000010'));
 
-    reset.put(1); //Reset arbiter
-    await clk.nextNegedge;
-    await clk.nextNegedge;
-    reset.put(0);
-    vector.put(bin('01000111'));
-    expect(grants.value, LogicValue.ofString('00000001'));
-    await clk.nextNegedge;
-    vector.put(bin('10000101'));
-    expect(grants.value, LogicValue.ofString('00000100'));
-    await clk.nextNegedge;
-    vector.put(bin('01001000'));
-    expect(grants.value, LogicValue.ofString('00001000'));
-    await clk.nextNegedge;
-    vector.put(bin('10010001'));
-    expect(grants.value, LogicValue.ofString('00010000'));
-    await clk.nextNegedge;
-    vector.put(bin('10000000'));
-    expect(grants.value, LogicValue.ofString('10000000'));
-    await clk.nextNegedge;
-    expect(grants.value, LogicValue.ofString('10000000'));
-    vector.put(bin('10000000'));
-    expect(grants.value, LogicValue.ofString('10000000'));
-    await clk.nextNegedge;
-    vector.put(bin('10010001'));
-    expect(grants.value, LogicValue.ofString('00000001'));
-    await clk.nextNegedge;
-    expect(grants.value, LogicValue.ofString('00010000'));
-    await clk.nextNegedge;
-    expect(grants.value, LogicValue.ofString('10000000'));
-    await clk.nextNegedge;
-    expect(grants.value, LogicValue.ofString('00000001'));
-    await clk.nextNegedge;
-    expect(grants.value, LogicValue.ofString('00010000'));
-    await clk.nextNegedge;
-    expect(grants.value, LogicValue.ofString('10000000'));
+          Simulator.endSimulation();
+          await Simulator.simulationEnded;
+        });
 
-    Simulator.endSimulation();
-    await Simulator.simulationEnded;
-  });
+        test('dynamic request', () async {
+          final clk = SimpleClockGenerator(10).clk;
+          const width = 8;
+          final vector = Logic(width: width);
+          final reset = Logic();
+          final reqs = List.generate(width, (i) => vector[i]);
+          final arb = rrArbType.constructor(reqs, clk: clk, reset: reset);
+          final grants = arb.grants.rswizzle();
+          await arb.build();
+          unawaited(Simulator.run());
 
-  test('all reqs', () async {
-    final clk = SimpleClockGenerator(10).clk;
-    final reset = Logic();
-    final requests = List.generate(8, (index) => Const(1));
-    final arbiter = RoundRobinArbiter(requests, clk: clk, reset: reset);
-    await arbiter.build();
-    Simulator.setMaxSimTime(5000);
-    unawaited(Simulator.run());
-    WaveDumper(arbiter);
+          reset.put(1); //Reset arbiter
+          await clk.nextNegedge;
+          await clk.nextNegedge;
+          reset.put(0);
+          vector.put(bin('01000111'));
+          expect(grants.value, LogicValue.ofString('00000001'));
+          await clk.nextNegedge;
+          vector.put(bin('10000101'));
+          expect(grants.value, LogicValue.ofString('00000100'));
+          await clk.nextNegedge;
+          vector.put(bin('01001000'));
+          expect(grants.value, LogicValue.ofString('00001000'));
+          await clk.nextNegedge;
+          vector.put(bin('10010001'));
+          expect(grants.value, LogicValue.ofString('00010000'));
+          await clk.nextNegedge;
+          vector.put(bin('10000000'));
+          expect(grants.value, LogicValue.ofString('10000000'));
+          await clk.nextNegedge;
+          expect(grants.value, LogicValue.ofString('10000000'));
+          vector.put(bin('10000000'));
+          expect(grants.value, LogicValue.ofString('10000000'));
+          await clk.nextNegedge;
+          vector.put(bin('10010001'));
+          expect(grants.value, LogicValue.ofString('00000001'));
+          await clk.nextNegedge;
+          expect(grants.value, LogicValue.ofString('00010000'));
+          await clk.nextNegedge;
+          expect(grants.value, LogicValue.ofString('10000000'));
+          await clk.nextNegedge;
+          expect(grants.value, LogicValue.ofString('00000001'));
+          await clk.nextNegedge;
+          expect(grants.value, LogicValue.ofString('00010000'));
+          await clk.nextNegedge;
+          expect(grants.value, LogicValue.ofString('10000000'));
 
-    reset.inject(0);
-    await clk.nextNegedge;
-    reset.inject(1);
-    await clk.nextNegedge;
-    await clk.nextNegedge;
-    reset.inject(0);
-    for (var i = 0; i < 30; i++) {
-      expect(arbiter.grants.rswizzle().value.toInt(), 1 << (i % 8));
-      await clk.nextNegedge;
+          Simulator.endSimulation();
+          await Simulator.simulationEnded;
+        });
+
+        test('all reqs', () async {
+          final clk = SimpleClockGenerator(10).clk;
+          final reset = Logic();
+          final requests = List.generate(8, (index) => Const(1));
+          final arbiter =
+              rrArbType.constructor(requests, clk: clk, reset: reset);
+          await arbiter.build();
+          Simulator.setMaxSimTime(5000);
+          unawaited(Simulator.run());
+
+          reset.inject(0);
+          await clk.nextNegedge;
+          reset.inject(1);
+          await clk.nextNegedge;
+          await clk.nextNegedge;
+          reset.inject(0);
+          for (var i = 0; i < 30; i++) {
+            expect(arbiter.grants.rswizzle().value.toInt(), 1 << (i % 8));
+            await clk.nextNegedge;
+          }
+
+          Simulator.endSimulation();
+          await Simulator.simulationEnded;
+        });
+
+        test('beat pattern 2 request maintain fairness', () async {
+          final clk = SimpleClockGenerator(10).clk;
+          final reset = Logic();
+          final req = Logic()..inject(0);
+          final requests = List.generate(2, (index) => req);
+          final arbiter =
+              rrArbType.constructor(requests, clk: clk, reset: reset);
+          await arbiter.build();
+
+          WaveDumper(arbiter);
+
+          final grantCounts = List.generate(arbiter.count, (_) => 0);
+
+          for (var i = 0; i < arbiter.count; i++) {
+            final grant = arbiter.grants[i];
+            clk.negedge.listen((event) {
+              if (grant.value.isValid && grant.value.toBool()) {
+                grantCounts[i]++;
+              }
+            });
+          }
+
+          Simulator.setMaxSimTime(5000);
+          unawaited(Simulator.run());
+
+          reset.inject(0);
+          await clk.nextNegedge;
+          reset.inject(1);
+          await clk.nextNegedge;
+          await clk.nextNegedge;
+          reset.inject(0);
+          for (var i = 0; i < 32; i++) {
+            req.inject(i % 2);
+            await clk.nextPosedge;
+          }
+
+          Simulator.endSimulation();
+          await Simulator.simulationEnded;
+
+          // expect an equal number of grants between the two
+          expect(grantCounts[0], grantCounts[1]);
+        });
+      });
     }
-
-    Simulator.endSimulation();
-    await Simulator.simulationEnded;
   });
 }

--- a/test/arbiter_test.dart
+++ b/test/arbiter_test.dart
@@ -171,6 +171,32 @@ void main() {
           await Simulator.simulationEnded;
         });
 
+        test('all reqs, non-power-of-2', () async {
+          final clk = SimpleClockGenerator(10).clk;
+          final reset = Logic();
+          final requests = List.generate(5, (index) => Const(1));
+          final arbiter =
+              rrArbType.constructor(requests, clk: clk, reset: reset);
+          await arbiter.build();
+          Simulator.setMaxSimTime(5000);
+          unawaited(Simulator.run());
+
+          reset.inject(0);
+          await clk.nextNegedge;
+          reset.inject(1);
+          await clk.nextNegedge;
+          await clk.nextNegedge;
+          reset.inject(0);
+          for (var i = 0; i < 30; i++) {
+            expect(arbiter.grants.rswizzle().value.toInt(),
+                1 << (i % arbiter.count));
+            await clk.nextNegedge;
+          }
+
+          Simulator.endSimulation();
+          await Simulator.simulationEnded;
+        });
+
         test('beat pattern 2 request maintain fairness', () async {
           final clk = SimpleClockGenerator(10).clk;
           final reset = Logic();


### PR DESCRIPTION

<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

This PR primarily adds a second implementation of a RoundRobinArbiter.  It also includes:
- Fix a bug where RoundRobinArbiter would reset state incorrectly when no grants are given (and adds a test for this)
- Reorganizes arbiter inheritance structure to support more arbiter types more easily

## Related Issue(s)

N/A

## Testing

Added a new test and organized tests to test all round-robin arbiters the same way

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No