### PR TITLE
Fix schematic generation and links

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -1,1 +1,0 @@
-This directory is for Verilog output and HTML conversion of components.

--- a/gen/generate.dart
+++ b/gen/generate.dart
@@ -15,9 +15,10 @@ import 'dart:io';
 import 'package:rohd_hcl/src/component_config/components/component_registry.dart';
 
 void main() async {
+  Directory('build').createSync(recursive: true);
   for (final configurator in componentRegistry) {
     final sv = await configurator.generateSV();
-    final name = configurator.sanitaryName;
+    final name = configurator.createModule().definitionName;
     File('build/$name.v').writeAsStringSync(sv);
   }
 }

--- a/lib/src/arbiters/mask_round_robin_arbiter.dart
+++ b/lib/src/arbiters/mask_round_robin_arbiter.dart
@@ -84,7 +84,6 @@ class MaskRoundRobinArbiter extends StatefulArbiter
         defaultItem: [
           for (var g = 0; g < count; g++)
             grants[g] <
-                //TODO: test
                 (g == 0
                     ? requests[g]
                     : ~requests.rswizzle().getRange(0, g).or() & requests[g]),

--- a/lib/src/arbiters/mask_round_robin_arbiter.dart
+++ b/lib/src/arbiters/mask_round_robin_arbiter.dart
@@ -83,7 +83,11 @@ class MaskRoundRobinArbiter extends StatefulArbiter
         // relies on [_request] least significant bit
         defaultItem: [
           for (var g = 0; g < count; g++)
-            grants[g] < ~requests.rswizzle().getRange(0, g).or() & requests[g],
+            grants[g] <
+                //TODO: test
+                (g == 0
+                    ? requests[g]
+                    : ~requests.rswizzle().getRange(0, g).or() & requests[g]),
         ],
       ),
     ]);

--- a/tool/gh_actions/create_htmls.sh
+++ b/tool/gh_actions/create_htmls.sh
@@ -7,6 +7,8 @@
 
 dart gen/generate.dart
 
+mkdir -p build
+
 # Convert Verilog into an HTML-based schematic for each
 for i in build/*.v
 do

--- a/tool/gh_actions/install_opencadsuite.sh
+++ b/tool/gh_actions/install_opencadsuite.sh
@@ -20,6 +20,6 @@ sudo apt-get install -y \
 cd /
 sudo  wget -O oss-cad-suite-build.tgz https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2023-05-12/oss-cad-suite-linux-x64-20230512.tgz
 
-sudo tar -xvzf oss-cad-suite-build.tgz
+sudo tar -xzf oss-cad-suite-build.tgz
 
 # Trim if needed

--- a/tool/gh_codespaces/run_setup.sh
+++ b/tool/gh_codespaces/run_setup.sh
@@ -11,6 +11,9 @@
 
 set -euo pipefail
 
+# Initialize submodules
+git submodule update --init --recursive
+
 # Install Dart SDK.
 tool/gh_codespaces/install_dart.sh
 


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

A recent change broke the schematic generation (the name of the module was wrong in the script).  This PR fixes that.

## Related Issue(s)

N/A

## Testing

Ran in codespace

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
