### PR TITLE
Fix `FifoChecker` sampling bugs

### DIFF
--- a/lib/src/fifo.dart
+++ b/lib/src/fifo.dart
@@ -266,11 +266,11 @@ class FifoChecker extends Component {
         .where((e) => !e.name.contains('Data'));
 
     fifo._clk.posedge.listen((event) {
-      if (!fifo._reset.value.isValid) {
+      if (!fifo._reset.previousValue!.isValid) {
         // reset is invalid, bad state
         hasReset = false;
         return;
-      } else if (fifo._reset.value.toBool()) {
+      } else if (fifo._reset.previousValue!.toBool()) {
         // reset is high, track that and move on
         hasReset = true;
         return;
@@ -278,25 +278,26 @@ class FifoChecker extends Component {
         // reset is low, and we've previously reset, should be good to check
 
         if (!fifoPortSignals
-            .map((e) => e.value.isValid)
+            .map((e) => e.previousValue!.isValid)
             .reduce((a, b) => a && b)) {
           final portValuesMap = Map.fromEntries(
-              fifoPortSignals.map((e) => MapEntry(e.name, e.value)));
+              fifoPortSignals.map((e) => MapEntry(e.name, e.previousValue!)));
           logger.severe('Fifo control port has an invalid value after reset.'
               ' Port values: $portValuesMap');
           return;
         }
 
-        if (fifo.full.value.toBool() &&
-            fifo._writeEnable.value.toBool() &&
-            !fifo._readEnable.value.toBool()) {
+        if (fifo.full.previousValue!.toBool() &&
+            fifo._writeEnable.previousValue!.toBool() &&
+            !fifo._readEnable.previousValue!.toBool()) {
           if (enableOverflowCheck) {
             logger
                 .severe('Fifo $fifo received a write that caused an overflow.');
           }
-        } else if (fifo.empty.value.toBool() &&
-            fifo._readEnable.value.toBool()) {
-          if (!(fifo.generateBypass && fifo._writeEnable.value.toBool())) {
+        } else if (fifo.empty.previousValue!.toBool() &&
+            fifo._readEnable.previousValue!.toBool()) {
+          if (!(fifo.generateBypass &&
+              fifo._writeEnable.previousValue!.toBool())) {
             if (enableUnderflowCheck) {
               logger.severe(
                   'Fifo $fifo received a read that caused an underflow.');
@@ -309,8 +310,10 @@ class FifoChecker extends Component {
 
   @override
   void check() {
-    if (!fifo.empty.value.toBool()) {
-      if (enableEndOfTestEmptyCheck) {
+    if (enableEndOfTestEmptyCheck) {
+      if (!fifo.empty.value.isValid) {
+        logger.severe('Fifo empty signal has invalid value at end of test.');
+      } else if (!fifo.empty.value.toBool()) {
         logger.severe('Fifo $fifo is not empty at the end of the test.');
       }
     }

--- a/test/fifo_test.dart
+++ b/test/fifo_test.dart
@@ -597,7 +597,7 @@ void main() {
     });
   });
 
-  test('empty sampling time', () async {
+  test('sampling time', () async {
     final fifoTest = FifoTest((clk, reset, wrEn, wrData, rdEn, rdData) async {
       wrEn.inject(1);
       wrData.inject(0x111);
@@ -613,7 +613,7 @@ void main() {
       await clk.nextPosedge;
     });
 
-    FifoChecker(fifoTest.fifo, enableEndOfTestEmptyCheck: false);
+    FifoChecker(fifoTest.fifo, parent: fifoTest);
 
     fifoTest.printLevel = Level.OFF;
 

--- a/test/fifo_test.dart
+++ b/test/fifo_test.dart
@@ -597,6 +597,30 @@ void main() {
     });
   });
 
+  test('empty sampling time', () async {
+    final fifoTest = FifoTest((clk, reset, wrEn, wrData, rdEn, rdData) async {
+      wrEn.inject(1);
+      wrData.inject(0x111);
+
+      await clk.nextPosedge;
+      await clk.nextPosedge;
+      wrEn.inject(0);
+      rdEn.inject(1);
+      await clk.nextPosedge;
+      await clk.nextPosedge;
+      rdEn.inject(0);
+      await clk.nextPosedge;
+      await clk.nextPosedge;
+    });
+
+    FifoChecker(fifoTest.fifo, enableEndOfTestEmptyCheck: false);
+
+    fifoTest.printLevel = Level.OFF;
+
+    await fifoTest.start();
+    expect(fifoTest.failureDetected, false);
+  });
+
   test('fifo logger', () async {
     final fifoTest = FifoTest((clk, reset, wrEn, wrData, rdEn, rdData) async {
       wrEn.put(1);


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

There were some bugs in the way the `FifoChecker` sampled signals at clock edges, causing false failures.  This PR fixes those.

## Related Issue(s)

N/A

## Testing

Added a new test that catches these issues, confirmed fix fixes them.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
