### PR TITLE
Fix memory model handling of different edge and latency situations

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -27,6 +27,8 @@ Some in-development items will have opened issues, as well. Feel free to create 
 - Count
   - [Count bit occurence](./components/count.md)
   - Count pattern occurence
+- Detection
+  - Edge detection
 - Sort
   - [Bitonic sort](./components/sort.md#bitonic-sort)
 - Arithmetic
@@ -45,6 +47,8 @@ Some in-development items will have opened issues, as well. Feel free to create 
     - BFloat16 (16-bit)
     - BFloat8 (8-bit)
     - BFloat4 (4-bit)
+  - Fixed point
+  - Binary-Coded Decimal (BCD)
 - [Rotate](./components/rotate.md)
 - Counters
   - Binary counter
@@ -85,8 +89,10 @@ Some in-development items will have opened issues, as well. Feel free to create 
 - Models
   - [APB](./components/apb_bfm.md)
   - [Ready/Valid](./components/ready_valid_bfm.md)
+  - SPI
+  - CXL
 
 ----------------
 
-Copyright (C) 2023 Intel Corporation  
+Copyright (C) 2023-2024 Intel Corporation  
 SPDX-License-Identifier: BSD-3-Clause

--- a/lib/src/models/apb_bfm/apb_tracker.dart
+++ b/lib/src/models/apb_bfm/apb_tracker.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2024 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // apb_tracker.dart
@@ -44,13 +44,15 @@ class ApbTracker extends Tracker<ApbPacket> {
     super.outputFolder,
     int timeColumnWidth = 12,
     int selectColumnWidth = 4,
+    int addrColumnWidth = 12,
+    int dataColumnWidth = 12,
   }) : super(name, [
           TrackerField(timeField, columnWidth: timeColumnWidth),
           if (selectColumnWidth > 0)
             TrackerField(selectField, columnWidth: selectColumnWidth),
           const TrackerField(typeField, columnWidth: 1),
-          const TrackerField(addrField, columnWidth: 12),
-          const TrackerField(dataField, columnWidth: 12),
+          TrackerField(addrField, columnWidth: addrColumnWidth),
+          TrackerField(dataField, columnWidth: dataColumnWidth),
           const TrackerField(strobeField, columnWidth: 4),
           if (intf.includeSlvErr)
             const TrackerField(slverrField, columnWidth: 1),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   meta: ^1.9.1
-  rohd: ^0.5.0
+  rohd: ^0.5.2
   rohd_vf: ^0.5.0
 
 dev_dependencies:

--- a/test/arbiter_test.dart
+++ b/test/arbiter_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2024 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // arbiter_test.dart
@@ -91,8 +91,7 @@ void main() {
           await clk.nextNegedge;
           expect(grants.value, LogicValue.ofString('00000010'));
 
-          Simulator.endSimulation();
-          await Simulator.simulationEnded;
+          await Simulator.endSimulation();
         });
 
         test('dynamic request', () async {
@@ -142,8 +141,7 @@ void main() {
           await clk.nextNegedge;
           expect(grants.value, LogicValue.ofString('10000000'));
 
-          Simulator.endSimulation();
-          await Simulator.simulationEnded;
+          await Simulator.endSimulation();
         });
 
         test('all reqs', () async {
@@ -167,8 +165,7 @@ void main() {
             await clk.nextNegedge;
           }
 
-          Simulator.endSimulation();
-          await Simulator.simulationEnded;
+          await Simulator.endSimulation();
         });
 
         test('all reqs, non-power-of-2', () async {
@@ -193,8 +190,7 @@ void main() {
             await clk.nextNegedge;
           }
 
-          Simulator.endSimulation();
-          await Simulator.simulationEnded;
+          await Simulator.endSimulation();
         });
 
         test('beat pattern 2 request maintain fairness', () async {
@@ -233,8 +229,7 @@ void main() {
             await clk.nextPosedge;
           }
 
-          Simulator.endSimulation();
-          await Simulator.simulationEnded;
+          await Simulator.endSimulation();
 
           // expect an equal number of grants between the two
           expect(grantCounts[0], grantCounts[1]);

--- a/test/fifo_test.dart
+++ b/test/fifo_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2024 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // fifo_test.dart
@@ -123,8 +123,7 @@ void main() {
 
     await clk.nextNegedge;
 
-    Simulator.endSimulation();
-    await Simulator.simulationEnded;
+    await Simulator.endSimulation();
   });
 
   test('fifo with depth 1', () async {
@@ -179,8 +178,7 @@ void main() {
     expect(fifo.empty.value.toBool(), true);
     expect(fifo.error!.value.toBool(), false);
 
-    Simulator.endSimulation();
-    await Simulator.simulationEnded;
+    await Simulator.endSimulation();
   });
 
   test('fifo underflow error without bypass', () async {
@@ -218,8 +216,7 @@ void main() {
 
     expect(fifo.error!.value.toBool(), true);
 
-    Simulator.endSimulation();
-    await Simulator.simulationEnded;
+    await Simulator.endSimulation();
   });
 
   test('fifo underflow error with bypass', () async {
@@ -258,8 +255,7 @@ void main() {
 
     expect(fifo.error!.value.toBool(), true);
 
-    Simulator.endSimulation();
-    await Simulator.simulationEnded;
+    await Simulator.endSimulation();
   });
 
   test('fifo overflow error', () async {
@@ -306,8 +302,7 @@ void main() {
     expect(fifo.error!.value.toBool(), true);
     await clk.nextPosedge;
 
-    Simulator.endSimulation();
-    await Simulator.simulationEnded;
+    await Simulator.endSimulation();
   });
 
   test('fifo empty bypass', () async {
@@ -361,8 +356,7 @@ void main() {
 
     await clk.nextNegedge;
 
-    Simulator.endSimulation();
-    await Simulator.simulationEnded;
+    await Simulator.endSimulation();
   });
 
   test('fifo full write and read simultaneously', () async {
@@ -422,8 +416,7 @@ void main() {
     await clk.nextNegedge;
     expect(fifo.error!.value.toBool(), false);
 
-    Simulator.endSimulation();
-    await Simulator.simulationEnded;
+    await Simulator.endSimulation();
   });
 
   group('fifo peek', () {
@@ -474,8 +467,7 @@ void main() {
       // peek at stable
       expect(rdData.value.toInt(), 0xfeedbeef);
 
-      Simulator.endSimulation();
-      await Simulator.simulationEnded;
+      await Simulator.endSimulation();
     }
 
     test('no bypass', () async {

--- a/test/memory_test.dart
+++ b/test/memory_test.dart
@@ -106,8 +106,7 @@ void main() {
         rdPorts[2].en.put(0);
         await clk.nextNegedge;
 
-        Simulator.endSimulation();
-        await Simulator.simulationEnded;
+        await Simulator.endSimulation();
       });
 
       test('$memGenName wr masked', () async {
@@ -162,8 +161,7 @@ void main() {
         rdPorts[0].en.put(0);
         await clk.nextNegedge;
 
-        Simulator.endSimulation();
-        await Simulator.simulationEnded;
+        await Simulator.endSimulation();
       });
     }
   });

--- a/test/memory_test.dart
+++ b/test/memory_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2024 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // rf_test.dart
@@ -13,6 +13,7 @@ import 'dart:async';
 
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
+import 'package:rohd_vf/rohd_vf.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -29,28 +30,26 @@ void main() {
       'rf': (Logic clk, Logic reset, List<DataPortInterface> wrPorts,
               List<DataPortInterface> rdPorts) =>
           RegisterFile(clk, reset, wrPorts, rdPorts, numEntries: numEntries),
-      'memory model': (Logic clk, Logic reset, List<DataPortInterface> wrPorts,
-              List<DataPortInterface> rdPorts) =>
-          MemoryModel(
-            clk,
-            reset,
-            wrPorts,
-            rdPorts,
-            storage: SparseMemoryStorage(
-              addrWidth: addrWidth,
-              dataWidth: dataWidth,
-              alignAddress: (addr) => addr,
-              onInvalidRead: (addr, dataWidth) =>
-                  LogicValue.filled(dataWidth, LogicValue.zero),
-            ),
-          )
+      for (var latency = 0; latency <= 2; latency++)
+        'memory model (latency $latency)': (Logic clk,
+                Logic reset,
+                List<DataPortInterface> wrPorts,
+                List<DataPortInterface> rdPorts) =>
+            MemoryModel(
+              clk,
+              reset,
+              wrPorts,
+              rdPorts,
+              readLatency: latency,
+              storage: SparseMemoryStorage(
+                addrWidth: addrWidth,
+                dataWidth: dataWidth,
+                alignAddress: (addr) => addr,
+                onInvalidRead: (addr, dataWidth) =>
+                    LogicValue.filled(dataWidth, LogicValue.zero),
+              ),
+            )
     };
-
-    Future<void> waitCycles(Logic clk, int numCycles) async {
-      for (var i = 0; i < numCycles; i++) {
-        await clk.nextNegedge;
-      }
-    }
 
     for (final memGen in memoriesToTestGenerators.entries) {
       final memGenName = memGen.key;
@@ -99,7 +98,7 @@ void main() {
         // read it back out on a different port
         rdPorts[2].en.put(1);
         rdPorts[2].addr.put(3);
-        await waitCycles(clk, mem.readLatency);
+        await clk.waitCycles(mem.readLatency);
         await clk.nextPosedge;
         expect(rdPorts[2].data.value.toInt(), 0xdeadbeef);
 
@@ -155,7 +154,7 @@ void main() {
         // read it back out on a different port
         rdPorts[0].en.put(1);
         rdPorts[0].addr.put(4);
-        await waitCycles(clk, mem.readLatency);
+        await clk.waitCycles(mem.readLatency);
         await clk.nextPosedge;
         expect(rdPorts[0].data.value.toInt(), 0xff00ff00);
 
@@ -194,6 +193,17 @@ void main() {
                 [DataPortInterface(32, 32)],
               ),
           throwsA(const TypeMatcher<RohdHclException>()));
+    });
+
+    test('required minimum ports', () {
+      RegisterFile(Logic(), Logic(), [], [DataPortInterface(32, 32)]);
+      RegisterFile(Logic(), Logic(), [DataPortInterface(32, 32)], []);
+
+      try {
+        RegisterFile(Logic(), Logic(), [], []);
+        fail('Should have failed');
+        // ignore: avoid_catching_errors
+      } on AssertionError catch (_) {}
     });
   });
 }

--- a/test/shift_register_test.dart
+++ b/test/shift_register_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2024 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // shift_register_test.dart
@@ -48,9 +48,7 @@ void main() {
 
     expect(dataOut.value.toInt(), data.last);
 
-    Simulator.endSimulation();
-
-    await Simulator.simulationEnded;
+    await Simulator.endSimulation();
   });
 
   test('shift register naming', () {
@@ -113,9 +111,7 @@ void main() {
 
     expect(dataOut.value.toInt(), 0);
 
-    Simulator.endSimulation();
-
-    await Simulator.simulationEnded;
+    await Simulator.endSimulation();
   });
 
   group('reset shift register', () {
@@ -148,9 +144,7 @@ void main() {
 
       expect(dataOut.value.toInt(), 0x45);
 
-      Simulator.endSimulation();
-
-      await Simulator.simulationEnded;
+      await Simulator.endSimulation();
     }
 
     test('null reset value', () async {
@@ -213,8 +207,6 @@ void main() {
 
     expect(dataOut.value.toInt(), 0);
 
-    Simulator.endSimulation();
-
-    await Simulator.simulationEnded;
+    await Simulator.endSimulation();
   });
 }


### PR DESCRIPTION


## Description & Motivation

This PR:
- Fix bugs related to memory model sampling on negative edges and improper handling of zero-latency accesses.
- Fix error handling and assertions in constructing `Memory` (e.g. bug where assertion fired incorrectly)
- Updates doc/README with more components
- Update APB tracker to have configurable widths for addr and data

## Related Issue(s)

N/A

## Testing

Added new tests

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
