### PR TITLE
migrate parallel_prefix to new branch

### DIFF
--- a/doc/components/parallel_prefix_operations.md
+++ b/doc/components/parallel_prefix_operations.md
@@ -1,0 +1,14 @@
+# Parallel Prefix Operations
+
+ROHD HCL implements a set of parallel prefix compute operations using different parallel prefix computation trees based on the ['ParallelPrefix'] node class carrying carry/save or generate/propagate bits.
+
+For example, we have unary operations like a word-level 'or' [`ParallelPrefixOrScan`] class, and a priority encoder [`ParallelPrefixPriorityEncoder`] class which computes the position of the first bit set to '1'. We have simple unary arithmetic operations like an increment [`ParallelPrefixIncr`] class, and a decrement [`ParallelPrefixDecr`] class. Finally, we have a binary adder [`ParallelPrefixAdder`] class. For background on basic parallel prefix adder structures, see <https://en.wikipedia.org/wiki/Kogge%E2%80%93Stone_adder>.
+
+Each of these operations can be implemented with different ['ParallelPrefix'] types:
+
+- ['Ripple'](https://intel.github.io/rohd-hcl/rohd_hcl/Ripple-class.html)
+- ['Sklansky](https://intel.github.io/rohd-hcl/rohd_hcl/Sklansky-class.html)
+- ['KoggeStone'](https://intel.github.io/rohd-hcl/rohd_hcl/KoggeStone-class.html)
+- ['BrentKung](https://intel.github.io/rohd-hcl/rohd_hcl/BrentKung-class.html)
+
+[PPAdder_BrentKung Schematic](https://intel.github.io/rohd-hcl/PPAdder_BrentKung.html)

--- a/doc/components/parallel_prefix_operations.md
+++ b/doc/components/parallel_prefix_operations.md
@@ -6,9 +6,7 @@ For example, we have unary operations like a word-level 'or' [`ParallelPrefixOrS
 
 Each of these operations can be implemented with different ['ParallelPrefix'] types:
 
-- ['Ripple'](https://intel.github.io/rohd-hcl/rohd_hcl/Ripple-class.html)
-- ['Sklansky](https://intel.github.io/rohd-hcl/rohd_hcl/Sklansky-class.html)
-- ['KoggeStone'](https://intel.github.io/rohd-hcl/rohd_hcl/KoggeStone-class.html)
-- ['BrentKung](https://intel.github.io/rohd-hcl/rohd_hcl/BrentKung-class.html)
-
-[PPAdder_BrentKung Schematic](https://intel.github.io/rohd-hcl/PPAdder_BrentKung.html)
+- ['Ripple']
+- ['Sklansky]
+- ['KoggeStone']
+- ['BrentKung]

--- a/lib/rohd_hcl.dart
+++ b/lib/rohd_hcl.dart
@@ -16,6 +16,7 @@ export 'src/interfaces/interfaces.dart';
 export 'src/memory/memories.dart';
 export 'src/models/models.dart';
 export 'src/multiplier.dart';
+export 'src/parallel_prefix_operations.dart';
 export 'src/ripple_carry_adder.dart';
 export 'src/rotate.dart';
 export 'src/shift_register.dart';

--- a/lib/src/component_config/components/component_registry.dart
+++ b/lib/src/component_config/components/component_registry.dart
@@ -22,4 +22,5 @@ List<Configurator> get componentRegistry => [
       OneHotConfigurator(),
       RegisterFileConfigurator(),
       EdgeDetectorConfigurator(),
+      ParallelPrefixAdderConfigurator(),
     ];

--- a/lib/src/component_config/components/components.dart
+++ b/lib/src/component_config/components/components.dart
@@ -6,6 +6,7 @@ export 'config_ecc.dart';
 export 'config_edge_detector.dart';
 export 'config_fifo.dart';
 export 'config_one_hot.dart';
+export 'config_parallel_prefix_adder.dart';
 export 'config_priority_arbiter.dart';
 export 'config_rf.dart';
 export 'config_ripple_carry_adder.dart';

--- a/lib/src/component_config/components/config_parallel_prefix_adder.dart
+++ b/lib/src/component_config/components/config_parallel_prefix_adder.dart
@@ -19,6 +19,7 @@ class ParallelPrefixAdderConfigurator extends Configurator {
           ParallelPrefix Function(List<Logic>, Logic Function(Logic, Logic))>
       prefixTreeKnob = ChoiceConfigKnob(
           [Ripple.new, Sklansky.new, KoggeStone.new, BrentKung.new],
+          value: BrentKung.new);
 
   /// Controls the width of the data.
   final IntConfigKnob dataWidthKnob = IntConfigKnob(value: 8);

--- a/lib/src/component_config/components/config_parallel_prefix_adder.dart
+++ b/lib/src/component_config/components/config_parallel_prefix_adder.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-24 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // config_parallel-prefix_adder.dart
@@ -14,21 +14,28 @@ import 'package:rohd_hcl/rohd_hcl.dart';
 
 /// A [Configurator] for [ParallelPrefixAdder]s.
 class ParallelPrefixAdderConfigurator extends Configurator {
-  /// Controls the type of [ParallelPrefix] tree used in the adder.
-  final ChoiceConfigKnob<
+  /// Map from Type to Function for Parallel Prefix generator
+  static Map<Type,
           ParallelPrefix Function(List<Logic>, Logic Function(Logic, Logic))>
-      prefixTreeKnob = ChoiceConfigKnob(
-          [Ripple.new, Sklansky.new, KoggeStone.new, BrentKung.new],
-          value: BrentKung.new);
+      generatorMap = {
+    Ripple: Ripple.new,
+    Sklansky: Sklansky.new,
+    KoggeStone: KoggeStone.new,
+    BrentKung: BrentKung.new
+  };
 
-  /// Controls the width of the data.
+  /// Controls the type of [ParallelPrefix] tree used in the adder.
+  final prefixTreeKnob =
+      ChoiceConfigKnob(generatorMap.keys.toList(), value: BrentKung);
+
+  /// Controls the width of the data.!
   final IntConfigKnob dataWidthKnob = IntConfigKnob(value: 8);
 
   @override
   Module createModule() => ParallelPrefixAdder(
       Logic(name: 'a', width: dataWidthKnob.value),
       Logic(name: 'b', width: dataWidthKnob.value),
-      prefixTreeKnob.value);
+      generatorMap[prefixTreeKnob.value]!);
 
   @override
   late final Map<String, ConfigKnob<dynamic>> knobs = UnmodifiableMapView({

--- a/lib/src/component_config/components/config_parallel_prefix_adder.dart
+++ b/lib/src/component_config/components/config_parallel_prefix_adder.dart
@@ -1,0 +1,40 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// config_parallel-prefix_adder.dart
+// Configurator for a Parallel Prefix Adder.
+//
+// 2024 February 5
+// Author: Desmond Kirkpatrick <desmond.a.kirkpatrick@intel.com>
+
+import 'dart:collection';
+
+import 'package:rohd/rohd.dart';
+import 'package:rohd_hcl/rohd_hcl.dart';
+
+/// A [Configurator] for [ParallelPrefixAdder]s.
+class ParallelPrefixAdderConfigurator extends Configurator {
+  /// Controls the type of [ParallelPrefix] tree used in the adder.
+  final ChoiceConfigKnob<
+          ParallelPrefix Function(List<Logic>, Logic Function(Logic, Logic))>
+      prefixTreeKnob = ChoiceConfigKnob(
+          [Ripple.new, Sklansky.new, KoggeStone.new, BrentKung.new],
+
+  /// Controls the width of the data.
+  final IntConfigKnob dataWidthKnob = IntConfigKnob(value: 8);
+
+  @override
+  Module createModule() => ParallelPrefixAdder(
+      Logic(name: 'a', width: dataWidthKnob.value),
+      Logic(name: 'b', width: dataWidthKnob.value),
+      prefixTreeKnob.value);
+
+  @override
+  late final Map<String, ConfigKnob<dynamic>> knobs = UnmodifiableMapView({
+    'Tree type': prefixTreeKnob,
+    'Data width': dataWidthKnob,
+  });
+
+  @override
+  final String name = 'Parallel Prefix Adder';
+}

--- a/lib/src/parallel_prefix_operations.dart
+++ b/lib/src/parallel_prefix_operations.dart
@@ -1,0 +1,255 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// parallel_prefix_operations.dart
+// Implementation of operators using various parallel-prefix trees.
+//
+// 2023 Sep 29
+// Author: Desmond Kirkpatrick <desmond.a.kirkpatrick@intel.com>
+//   Borrowed from https://github.com/stevenmburns/rohd_sklansky.git
+
+import 'dart:math';
+
+import 'package:collection/collection.dart';
+import 'package:rohd/rohd.dart';
+import 'package:rohd_hcl/rohd_hcl.dart';
+
+/// This computes the power of 2 less than x
+int largestPow2LessThan(int x) => pow(2, log2Ceil(x) - 1).toInt();
+
+/// [ParallelPrefix] is the core parallel prefix tree structure node
+/// The output is a List of multi-bit Logic vectors (typically 2-bit) that
+/// represent things like carry-save or generate-propagate signaling in adder
+/// networks.  Each node in a parallel prefix tree transforms a row of inputs
+/// to an equal length row of outputs of these multi-bit Logic values.
+class ParallelPrefix extends Module {
+  final List<Logic> _oseq = [];
+
+  /// Output sequence value
+  List<Logic> get val => UnmodifiableListView(_oseq);
+
+  /// ParallePrefix recursion
+  ParallelPrefix(List<Logic> inps, String name) : super(name: name) {
+    if (inps.isEmpty) {
+      throw Exception("Don't use {name} with an empty sequence");
+    }
+  }
+}
+
+/// Ripple shaped ParallelPrefix tree
+class Ripple extends ParallelPrefix {
+  /// Ripple constructor
+  Ripple(List<Logic> inps, Logic Function(Logic, Logic) op)
+      : super(inps, 'ripple') {
+    final iseq = <Logic>[];
+
+    inps.forEachIndexed((i, el) {
+      iseq.add(addInput('i$i', el, width: el.width));
+      _oseq.add(addOutput('o$i', width: el.width));
+    });
+
+    for (var i = 0; i < iseq.length; ++i) {
+      if (i == 0) {
+        _oseq[i] <= iseq[i];
+      } else {
+        _oseq[i] <= op(_oseq[i - 1], iseq[i]);
+      }
+    }
+  }
+}
+
+/// Sklansky shaped ParallelPrefix tree
+class Sklansky extends ParallelPrefix {
+  /// Sklansky constructor
+  Sklansky(List<Logic> inps, Logic Function(Logic, Logic) op)
+      : super(inps, 'sklansky') {
+    final iseq = <Logic>[];
+
+    inps.forEachIndexed((i, el) {
+      iseq.add(addInput('i$i', el, width: el.width));
+      _oseq.add(addOutput('o$i', width: el.width));
+    });
+
+    if (iseq.length == 1) {
+      _oseq[0] <= iseq[0];
+    } else {
+      final n = iseq.length;
+      final m = largestPow2LessThan(n);
+      final u = Sklansky(iseq.getRange(0, m).toList(), op).val;
+      final v = Sklansky(iseq.getRange(m, n).toList(), op).val;
+      u.forEachIndexed((i, el) {
+        _oseq[i] <= el;
+      });
+      v.forEachIndexed((i, el) {
+        _oseq[m + i] <= op(u[m - 1], el);
+      });
+    }
+  }
+}
+
+/// KoggeStone shaped ParallelPrefix tree
+class KoggeStone extends ParallelPrefix {
+  /// KoggeStone constructor
+  KoggeStone(List<Logic> inps, Logic Function(Logic, Logic) op)
+      : super(inps, 'kogge_stone') {
+    final iseq = <Logic>[];
+
+    inps.forEachIndexed((i, el) {
+      iseq.add(addInput('i$i', el, width: el.width));
+      _oseq.add(addOutput('o$i', width: el.width));
+    });
+
+    var skip = 1;
+
+    while (skip < inps.length) {
+      for (var i = inps.length - 1; i >= skip; --i) {
+        iseq[i] = op(iseq[i - skip], iseq[i]);
+      }
+      skip *= 2;
+    }
+
+    iseq.forEachIndexed((i, el) {
+      _oseq[i] <= el;
+    });
+  }
+}
+
+/// BrentKung shaped ParallelPrefix tree
+class BrentKung extends ParallelPrefix {
+  /// BrentKung constructor
+  BrentKung(List<Logic> inps, Logic Function(Logic, Logic) op)
+      : super(inps, 'brent_kung') {
+    final iseq = <Logic>[];
+
+    inps.forEachIndexed((i, el) {
+      iseq.add(addInput('i$i', el, width: el.width));
+      _oseq.add(addOutput('o$i', width: el.width));
+    });
+
+    // Reduce phase
+    var skip = 2;
+    while (skip <= inps.length) {
+      for (var i = skip - 1; i < inps.length; i += skip) {
+        iseq[i] = op(iseq[i - skip ~/ 2], iseq[i]);
+      }
+      skip *= 2;
+    }
+
+    // Prefix Phase
+    skip = largestPow2LessThan(inps.length);
+    while (skip > 2) {
+      for (var i = 3 * (skip ~/ 2) - 1; i < inps.length; i += skip) {
+        iseq[i] = op(iseq[i - skip ~/ 2], iseq[i]);
+      }
+      skip ~/= 2;
+    }
+
+    // Final row
+    for (var i = 2; i < inps.length; i += 2) {
+      iseq[i] = op(iseq[i - 1], iseq[i]);
+    }
+
+    iseq.forEachIndexed((i, el) {
+      _oseq[i] <= el;
+    });
+  }
+}
+
+/// Or scan based on ParallelPrefix tree
+class ParallelPrefixOrScan extends Module {
+  /// Output [out] is the or of bits of the input
+  Logic get out => output('out');
+
+  /// OrScan constructor
+  ParallelPrefixOrScan(
+      Logic inp,
+      ParallelPrefix Function(List<Logic>, Logic Function(Logic, Logic))
+          ppGen) {
+    inp = addInput('inp', inp, width: inp.width);
+    final u =
+        ppGen(List<Logic>.generate(inp.width, (i) => inp[i]), (a, b) => a | b);
+    addOutput('out', width: inp.width) <= u.val.rswizzle();
+  }
+}
+
+/// Priority Encoder based on ParallelPrefix tree
+class ParallelPrefixPriorityEncoder extends Module {
+  /// Output [out] is the bit position of the first '1' in the Logic input
+  /// Search is counted from the LSB
+  Logic get out => output('out');
+
+  /// PriorityEncoder constructor
+  ParallelPrefixPriorityEncoder(
+      Logic inp,
+      ParallelPrefix Function(List<Logic>, Logic Function(Logic, Logic))
+          ppGen) {
+    inp = addInput('inp', inp, width: inp.width);
+    final u = ParallelPrefixOrScan(inp, ppGen);
+    addOutput('out', width: inp.width) <= (u.out & ~(u.out << Const(1)));
+  }
+}
+
+/// Adder based on ParallelPrefix tree
+class ParallelPrefixAdder extends Module {
+  /// Output [out] the arithmetic sum of the two Logic inputs
+  Logic get out => output('out');
+
+  /// Adder constructor
+  ParallelPrefixAdder(
+      Logic a,
+      Logic b,
+      ParallelPrefix Function(List<Logic>, Logic Function(Logic, Logic))
+          ppGen) {
+    a = addInput('a', a, width: a.width);
+    b = addInput('b', b, width: b.width);
+    final u = ppGen(
+        //                                    generate,    propagate or generate
+        List<Logic>.generate(
+            a.width, (i) => [a[i] & b[i], a[i] | b[i]].swizzle()),
+        (lhs, rhs) => [rhs[1] | rhs[0] & lhs[1], rhs[0] & lhs[0]].swizzle());
+    addOutput('out', width: a.width) <=
+        List<Logic>.generate(a.width,
+                (i) => (i == 0) ? a[i] ^ b[i] : a[i] ^ b[i] ^ u.val[i - 1][1])
+            .rswizzle();
+  }
+}
+
+/// Incrementer based on ParallelPrefix tree
+class ParallelPrefixIncr extends Module {
+  /// Output is '1' added to the Logic input
+  Logic get out => output('out');
+
+  /// Increment constructor
+  ParallelPrefixIncr(
+      Logic inp,
+      ParallelPrefix Function(List<Logic>, Logic Function(Logic, Logic))
+          ppGen) {
+    inp = addInput('inp', inp, width: inp.width);
+    final u = ppGen(List<Logic>.generate(inp.width, (i) => inp[i]),
+        (lhs, rhs) => rhs & lhs);
+    addOutput('out', width: inp.width) <=
+        (List<Logic>.generate(
+                inp.width, (i) => ((i == 0) ? ~inp[i] : inp[i] ^ u.val[i - 1]))
+            .rswizzle());
+  }
+}
+
+/// Decrementer based on ParallelPrefix tree
+class ParallelPrefixDecr extends Module {
+  /// Output is '1' subtracted from the Logic input
+  Logic get out => output('out');
+
+  /// Decrement constructor
+  ParallelPrefixDecr(
+      Logic inp,
+      ParallelPrefix Function(List<Logic>, Logic Function(Logic, Logic))
+          ppGen) {
+    inp = addInput('inp', inp, width: inp.width);
+    final u = ppGen(List<Logic>.generate(inp.width, (i) => ~inp[i]),
+        (lhs, rhs) => rhs & lhs);
+    addOutput('out', width: inp.width) <=
+        (List<Logic>.generate(
+                inp.width, (i) => ((i == 0) ? ~inp[i] : inp[i] ^ u.val[i - 1]))
+            .rswizzle());
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
   sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
+  collection: ^1.18.0
   meta: ^1.9.1
   rohd: ^0.5.2
   rohd_vf: ^0.5.0

--- a/test/configurator_test.dart
+++ b/test/configurator_test.dart
@@ -257,4 +257,12 @@ void main() {
     final sv = await cfg.generateSV();
     expect(sv, contains('input logic [15:0] transmission'));
   });
+
+  test('prefix tree adder configurator', () async {
+    final cfg = ParallelPrefixAdderConfigurator();
+    // final json = cfg.toJson(pretty: true);
+
+    final sv = await cfg.generateSV();
+    expect(sv, contains('swizzle'));
+  });
 }

--- a/test/configurator_test.dart
+++ b/test/configurator_test.dart
@@ -261,6 +261,7 @@ void main() {
   test('prefix tree adder configurator', () async {
     final cfg = ParallelPrefixAdderConfigurator();
     // final json = cfg.toJson(pretty: true);
+    // print(json);
 
     final sv = await cfg.generateSV();
     expect(sv, contains('swizzle'));

--- a/test/parallel_prefix_operations_test.dart
+++ b/test/parallel_prefix_operations_test.dart
@@ -1,0 +1,226 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// parallel-prefix_operations.dart
+// Implementation of operations using various parallel-prefix trees.
+//
+// 2023 Sep 29
+// Author: Desmond Kirkpatrick <desmond.a.kirkpatrick@intel.com>
+
+import 'dart:math';
+import 'package:rohd/rohd.dart';
+import 'package:rohd_hcl/src/parallel_prefix_operations.dart';
+import 'package:test/test.dart';
+
+void testOrScan(int n, ParallelPrefixOrScan Function(Logic a) fn) {
+  test('or_scan_$n', () async {
+    final inp = Logic(name: 'inp', width: n);
+    final mod = fn(inp);
+    await mod.build();
+
+    int computeOrScan(int j) {
+      var result = 0;
+      var found = false;
+      for (var i = 0; i < n; ++i) {
+        if (found || ((1 << i) & j) != 0) {
+          result |= 1 << i;
+          found = true;
+        }
+      }
+      return result;
+    }
+
+    // put/expect testing
+
+    for (var j = 0; j < (1 << n); ++j) {
+      final golden = computeOrScan(j);
+      inp.put(j);
+      final result = mod.out.value.toInt();
+      //print("$j ${result} ${golden}");
+      expect(result, equals(golden));
+    }
+  });
+}
+
+void testPriorityEncoder(
+    int n, ParallelPrefixPriorityEncoder Function(Logic a) fn) {
+  test('priority_encoder_$n', () async {
+    final inp = Logic(name: 'inp', width: n);
+    final mod = fn(inp);
+    await mod.build();
+
+    int computePriorityEncoding(int j) {
+      for (var i = 0; i < n; ++i) {
+        if (((1 << i) & j) != 0) {
+          return 1 << i;
+        }
+      }
+      return 0;
+    }
+
+    // put/expect testing
+
+    for (var j = 0; j < (1 << n); ++j) {
+      final golden = computePriorityEncoding(j);
+      inp.put(j);
+      final result = mod.out.value.toInt();
+      // print("priority_encoder: $j ${result} ${golden}");
+      expect(result, equals(golden));
+    }
+  });
+}
+
+void testAdder(int n, ParallelPrefixAdder Function(Logic a, Logic b) fn) {
+  test('adder_$n', () async {
+    final a = Logic(name: 'a', width: n);
+    final b = Logic(name: 'b', width: n);
+
+    final mod = fn(a, b);
+    await mod.build();
+
+    int computeAdder(int aa, int bb) => (aa + bb) & ((1 << n) - 1);
+
+    // put/expect testing
+
+    for (var aa = 0; aa < (1 << n); ++aa) {
+      for (var bb = 0; bb < (1 << n); ++bb) {
+        final golden = computeAdder(aa, bb);
+        a.put(aa);
+        b.put(bb);
+        final result = mod.out.value.toInt();
+        //print("adder: $aa $bb $result $golden");
+        expect(result, equals(golden));
+      }
+    }
+  });
+}
+
+void testAdderRandom(
+    int n, int nSamples, ParallelPrefixAdder Function(Logic a, Logic b) fn) {
+  test('adder_$n', () async {
+    final a = Logic(name: 'a', width: n);
+    final b = Logic(name: 'b', width: n);
+
+    final mod = fn(a, b);
+    await mod.build();
+
+    LogicValue computeAdder(LogicValue aa, LogicValue bb) =>
+        (aa + bb) & LogicValue.ofBigInt(BigInt.from((1 << n) - 1), n);
+    // put/expect testing
+
+    for (var i = 0; i < nSamples; ++i) {
+      final aa = Random().nextLogicValue(width: n);
+      final bb = Random().nextLogicValue(width: n);
+      final golden = computeAdder(aa, bb);
+      a.put(aa);
+      b.put(bb);
+      final result = mod.out.value;
+      expect(result, equals(golden));
+    }
+  });
+}
+
+void testIncr(int n, ParallelPrefixIncr Function(Logic a) fn) {
+  test('incr_$n', () async {
+    final inp = Logic(name: 'inp', width: n);
+    final mod = fn(inp);
+    await mod.build();
+
+    int computeIncr(int aa) => (aa + 1) & ((1 << n) - 1);
+
+    // put/expect testing
+
+    for (var aa = 0; aa < (1 << n); ++aa) {
+      final golden = computeIncr(aa);
+      inp.put(aa);
+      final result = mod.out.value.toInt();
+      //print("incr: $aa $result $golden");
+      expect(result, equals(golden));
+    }
+  });
+}
+
+void testDecr(int n, ParallelPrefixDecr Function(Logic a) fn) {
+  test('decr_$n', () async {
+    final inp = Logic(name: 'inp', width: n);
+    final mod = fn(inp);
+    await mod.build();
+
+    int computeDecr(int aa) => (aa - 1) % (1 << n);
+
+    // put/expect testing
+
+    for (var aa = 0; aa < (1 << n); ++aa) {
+      final golden = computeDecr(aa);
+      inp.put(aa);
+      final result = mod.out.value.toInt();
+      //print("decr: $aa $result $golden");
+      expect(result, equals(golden));
+    }
+  });
+}
+
+void main() {
+  tearDown(() async {
+    await Simulator.reset();
+  });
+
+  group('largest_pow2_less_than', () {
+    test('largest_pow2_less_than', () async {
+      expect(largestPow2LessThan(5), equals(4));
+      expect(largestPow2LessThan(4), equals(2));
+      expect(largestPow2LessThan(3), equals(2));
+    });
+  });
+
+  final generators = [Ripple.new, Sklansky.new, KoggeStone.new, BrentKung.new];
+
+  group('or_scan', () {
+    for (final n in [7, 8, 9]) {
+      for (final ppGen in generators) {
+        testOrScan(n, (inp) => ParallelPrefixOrScan(inp, ppGen));
+      }
+    }
+  });
+
+  group('priority_encoder', () {
+    for (final n in [7, 8, 9]) {
+      for (final ppGen in generators) {
+        testPriorityEncoder(
+            n, (inp) => ParallelPrefixPriorityEncoder(inp, ppGen));
+      }
+    }
+  });
+
+  group('adder', () {
+    for (final n in [3, 4, 5]) {
+      for (final ppGen in generators) {
+        testAdder(n, (a, b) => ParallelPrefixAdder(a, b, ppGen));
+      }
+    }
+  });
+
+  group('adderRandom', () {
+    for (final n in [127, 128, 129]) {
+      for (final ppGen in generators) {
+        testAdderRandom(n, 10, (a, b) => ParallelPrefixAdder(a, b, ppGen));
+      }
+    }
+  });
+
+  group('incr', () {
+    for (final n in [7, 8, 9]) {
+      for (final ppGen in generators) {
+        testIncr(n, (inp) => ParallelPrefixIncr(inp, ppGen));
+      }
+    }
+  });
+
+  group('decr', () {
+    for (final n in [7, 8, 9]) {
+      for (final ppGen in generators) {
+        testDecr(n, (inp) => ParallelPrefixDecr(inp, ppGen));
+      }
+    }
+  });
+}


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Parallel prefix trees implementing adders, priorityencoder, incrementer, decrementer, and orscan

## Related Issue(s)

#12 

## Testing

Tests included for each component with each flavor of prefix tree.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Yes.  The new components have updated documentation, and an attempt at making the configurator work with the adder.
