### PR TITLE
`Find` Configurator

### DIFF
--- a/lib/src/component_config/components/component_registry.dart
+++ b/lib/src/component_config/components/component_registry.dart
@@ -22,4 +22,5 @@ List<Configurator> get componentRegistry => [
       OneHotConfigurator(),
       RegisterFileConfigurator(),
       EdgeDetectorConfigurator(),
+      FindConfigurator(),
     ];

--- a/lib/src/component_config/components/components.dart
+++ b/lib/src/component_config/components/components.dart
@@ -5,6 +5,7 @@ export 'config_carry_save_multiplier.dart';
 export 'config_ecc.dart';
 export 'config_edge_detector.dart';
 export 'config_fifo.dart';
+export 'config_find.dart';
 export 'config_one_hot.dart';
 export 'config_priority_arbiter.dart';
 export 'config_rf.dart';

--- a/lib/src/component_config/components/config_edge_detector.dart
+++ b/lib/src/component_config/components/config_edge_detector.dart
@@ -31,6 +31,7 @@ class EdgeDetectorConfigurator extends Configurator {
         Logic(),
         clk: Logic(),
         reset: hasResetKnob.value ? Logic() : null,
+        edgeType: edgeTypeKnob.value,
         resetValue: hasResetKnob.value
             ? resetValueKnob.value == 'Input'
                 ? Logic()

--- a/lib/src/component_config/components/config_find.dart
+++ b/lib/src/component_config/components/config_find.dart
@@ -1,0 +1,49 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// config_priority_arbiter.dart
+// Configurator for a PriorityArbiter.
+//
+// 2024 February 7
+// Author: Max Korbel <max.korbel@intel.com>
+
+import 'dart:collection';
+
+import 'package:rohd/rohd.dart';
+import 'package:rohd_hcl/rohd_hcl.dart';
+
+/// A [Configurator] for [Find].
+class FindConfigurator extends Configurator {
+  /// A knob controlling the width of the bus.
+  final IntConfigKnob busWidthKnob = IntConfigKnob(value: 8);
+
+  /// A knob controlling whether it should count ones or zeros.
+  final ToggleConfigKnob countOneKnob = ToggleConfigKnob(value: true);
+
+  /// A knob controlling the generation of an error signal.
+  final ToggleConfigKnob generateErrorKnob = ToggleConfigKnob(value: false);
+
+  /// A knob controlling whether it should have `n` as an input.
+  final ToggleConfigKnob includeNKnob = ToggleConfigKnob(value: false);
+
+  @override
+  late final Map<String, ConfigKnob<dynamic>> knobs = UnmodifiableMapView({
+    'Bus Width': busWidthKnob,
+    'Count Ones': countOneKnob,
+    'Generate Error': generateErrorKnob,
+    'Include N': includeNKnob,
+  });
+
+  @override
+  Module createModule() => Find(
+        Logic(width: busWidthKnob.value),
+        countOne: countOneKnob.value,
+        generateError: generateErrorKnob.value,
+        n: includeNKnob.value
+            ? Logic(width: log2Ceil(busWidthKnob.value))
+            : null,
+      );
+
+  @override
+  final String name = 'Find';
+}

--- a/test/configurator_test.dart
+++ b/test/configurator_test.dart
@@ -257,4 +257,12 @@ void main() {
     final sv = await cfg.generateSV();
     expect(sv, contains('input logic [15:0] transmission'));
   });
+
+  test('find configurator', () async {
+    final cfg = FindConfigurator();
+    cfg.includeNKnob.value = true;
+    cfg.generateErrorKnob.value = true;
+    final sv = await cfg.generateSV();
+    expect(sv, contains('module Find'));
+  });
 }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

The `Find` was not available as a configurator or in the web-app, so this adds it.

Also, small bug fix in the edge detector configurator where it didn't use the type.

## Related Issue(s)

N/A

## Testing

Added sanity test

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
