### PR TITLE
parallel prefix documentation updates

### DIFF
--- a/confapp/lib/hcl/view/screen/content_widget.dart
+++ b/confapp/lib/hcl/view/screen/content_widget.dart
@@ -25,9 +25,9 @@ class SVGenerator extends StatefulWidget {
   final SidebarXController controller;
 
   const SVGenerator({
-    Key? key,
+    super.key,
     required this.controller,
-  }) : super(key: key);
+  });
 
   @override
   State createState() => _SVGeneratorState();

--- a/confapp/lib/hcl/view/screen/sidebar_widget.dart
+++ b/confapp/lib/hcl/view/screen/sidebar_widget.dart
@@ -24,11 +24,10 @@ class ComponentsSidebar extends StatefulWidget {
   final Function(void) updateForm;
 
   const ComponentsSidebar({
-    Key? key,
+    super.key,
     required SidebarXController controller,
     required this.updateForm,
-  })  : _controller = controller,
-        super(key: key);
+  }) : _controller = controller;
 
   final SidebarXController _controller;
 

--- a/confapp/pubspec.yaml
+++ b/confapp/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   sidebarx: ^0.16.0
   flutter_bloc: ^8.1.3
   bloc: ^8.1.2
-  google_fonts: ^6.1.0
+  google_fonts: 6.1.0
 
 dependency_overrides:
   rohd_hcl:

--- a/confapp/pubspec.yaml
+++ b/confapp/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   sidebarx: ^0.16.0
   flutter_bloc: ^8.1.3
   bloc: ^8.1.2
-  google_fonts: 6.1.0
+  google_fonts: ^6.1.0
 
 dependency_overrides:
   rohd_hcl:

--- a/confapp/pubspec.yaml
+++ b/confapp/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   sidebarx: ^0.16.0
   flutter_bloc: ^8.1.3
   bloc: ^8.1.2
-  google_fonts: ^6.0.0
+  google_fonts: ^6.2.0
 
 dependency_overrides:
   rohd_hcl:

--- a/confapp/pubspec.yaml
+++ b/confapp/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   sidebarx: ^0.16.0
   flutter_bloc: ^8.1.3
   bloc: ^8.1.2
-  google_fonts: ^6.2.0
+  google_fonts: 6.1.0
 
 dependency_overrides:
   rohd_hcl:
@@ -30,7 +30,7 @@ dev_dependencies:
     sdk: flutter
   test: ^1.20.0
 
-  flutter_lints: ^2.0.0
+  flutter_lints: ^3.0.1
 
 flutter:
   uses-material-design: true

--- a/doc/README.md
+++ b/doc/README.md
@@ -32,7 +32,7 @@ Some in-development items will have opened issues, as well. Feel free to create 
 - Sort
   - [Bitonic sort](./components/sort.md#bitonic-sort)
 - Arithmetic
-  - Prefix Trees
+  - [Prefix Trees](./components/parallel_prefix_operations.md)
   - [Adders](./components/adder.md)
   - Subtractors
   - Multipliers

--- a/doc/components/parallel_prefix_operations.md
+++ b/doc/components/parallel_prefix_operations.md
@@ -43,4 +43,3 @@ types:
 
 Here is an example adder schematic:
 [ParallelPrefixAdder Schematic](https://intel.github.io/rohd-hcl/ParallelPrefixAdder.html)
-

--- a/doc/components/parallel_prefix_operations.md
+++ b/doc/components/parallel_prefix_operations.md
@@ -1,12 +1,46 @@
 # Parallel Prefix Operations
 
-ROHD HCL implements a set of parallel prefix compute operations using different parallel prefix computation trees based on the ['ParallelPrefix'] node class carrying carry/save or generate/propagate bits.
+Parallel prefix or 'scan' trees are useful for efficient
+implementation of computations which involve associative
+operators. They are used in computations like encoding, or-reduction,
+and addition. By leveraging advanced programming idioms, like
+functors, allowing for passing of function that generates prefix trees
+into an scan-based generator for that computation, we can have a wide
+variety of that computation supported by our component library. For
+example, we have tree patterns defined by ripple, Sklanksy,
+Kogge-Stone, and Brent-Kung which gives us those four varieties of
+prefix reduction trees we can use across addition, or-reduction, and
+priority encoding.
 
-For example, we have unary operations like a word-level 'or' [`ParallelPrefixOrScan`] class, and a priority encoder [`ParallelPrefixPriorityEncoder`] class which computes the position of the first bit set to '1'. We have simple unary arithmetic operations like an increment [`ParallelPrefixIncr`] class, and a decrement [`ParallelPrefixDecr`] class. Finally, we have a binary adder [`ParallelPrefixAdder`] class. For background on basic parallel prefix adder structures, see <https://en.wikipedia.org/wiki/Kogge%E2%80%93Stone_adder>.
+ROHD HCL implements a set of parallel prefix compute operations using
+different parallel prefix computation trees based on the
+['ParallelPrefix'](https://intel.github.io/rohd-hcl/rohd_hcl/ParallelPrefix-class.html)
+node class.
 
-Each of these operations can be implemented with different ['ParallelPrefix'] types:
+For example, we have unary operations like a word-level 'or'
+[`ParallelPrefixOrScan`](https://intel.github.io/rohd-hcl/rohd_hcl/ParallelPrefixOrScan-class.html)
+class, and a priority encoder
+[`ParallelPrefixPriorityEncoder`](https://intel.github.io/rohd-hcl/rohd_hcl/ParallelPrefixPriorityEncoder-class.html)
+class which computes the position of the first bit set to '1'. We have
+simple unary arithmetic operations like an increment
+[`ParallelPrefixIncr`](https://intel.github.io/rohd-hcl/rohd_hcl/ParallelPrefixIncr-class.html)
+class, and a decrement
+[`ParallelPrefixDecr`](https://intel.github.io/rohd-hcl/rohd_hcl/ParallelPrefixDecr-class.html)
+class. Finally, we have a binary adder
+[`ParallelPrefixAdder`](https://intel.github.io/rohd-hcl/rohd_hcl/ParallelPrefixAdder-class.html)
+class. For background on basic parallel prefix adder structures, see
+<https://en.wikipedia.org/wiki/Kogge%E2%80%93Stone_adder>. In this
+case, the prefix trees are carrying two-bit words at each node.
 
-- ['Ripple']
-- ['Sklansky]
-- ['KoggeStone']
-- ['BrentKung]
+Each of these operations can be implemented with different
+['ParallelPrefix'](https://intel.github.io/rohd-hcl/rohd_hcl/ParallelPrefix-class.html)
+types:
+
+- ['Ripple'](https://intel.github.io/rohd-hcl/rohd_hcl/Ripple-class.html)
+- ['Sklansky](https://intel.github.io/rohd-hcl/rohd_hcl/Sklansky-class.html)
+- ['KoggeStone'](https://intel.github.io/rohd-hcl/rohd_hcl/KoggeStone-class.html)
+- ['BrentKung](https://intel.github.io/rohd-hcl/rohd_hcl/BrentKung-class.html)
+
+Here is an example adder schematic:
+[ParallelPrefixAdder Schematic](https://intel.github.io/rohd-hcl/ParallelPrefixAdder.html)
+

--- a/lib/src/component_config/components/config_parallel_prefix_adder.dart
+++ b/lib/src/component_config/components/config_parallel_prefix_adder.dart
@@ -26,10 +26,10 @@ class ParallelPrefixAdderConfigurator extends Configurator {
 
   /// Controls the type of [ParallelPrefix] tree used in the adder.
   final prefixTreeKnob =
-      ChoiceConfigKnob(generatorMap.keys.toList(), value: BrentKung);
+      ChoiceConfigKnob(generatorMap.keys.toList(), value: KoggeStone);
 
   /// Controls the width of the data.!
-  final IntConfigKnob dataWidthKnob = IntConfigKnob(value: 8);
+  final IntConfigKnob dataWidthKnob = IntConfigKnob(value: 4);
 
   @override
   Module createModule() => ParallelPrefixAdder(

--- a/lib/src/parallel_prefix_operations.dart
+++ b/lib/src/parallel_prefix_operations.dart
@@ -251,4 +251,3 @@ class ParallelPrefixDecr extends Module {
             .rswizzle());
   }
 }
-

--- a/lib/src/parallel_prefix_operations.dart
+++ b/lib/src/parallel_prefix_operations.dart
@@ -252,8 +252,6 @@ class ParallelPrefixDecr extends Module {
   }
 }
 
-
-
 void testAdder(int n, ParallelPrefixAdder Function(Logic a, Logic b) fn) {
   test('adder_$n', () async {
     final a = Logic(name: 'a', width: n);
@@ -278,5 +276,3 @@ void testAdder(int n, ParallelPrefixAdder Function(Logic a, Logic b) fn) {
     }
   });
 }
-
-

--- a/lib/src/parallel_prefix_operations.dart
+++ b/lib/src/parallel_prefix_operations.dart
@@ -252,27 +252,3 @@ class ParallelPrefixDecr extends Module {
   }
 }
 
-void testAdder(int n, ParallelPrefixAdder Function(Logic a, Logic b) fn) {
-  test('adder_$n', () async {
-    final a = Logic(name: 'a', width: n);
-    final b = Logic(name: 'b', width: n);
-
-    final mod = fn(a, b);
-    await mod.build();
-
-    int computeAdder(int aa, int bb) => (aa + bb) & ((1 << n) - 1);
-
-    // put/expect testing
-
-    for (var aa = 0; aa < (1 << n); ++aa) {
-      for (var bb = 0; bb < (1 << n); ++bb) {
-        final golden = computeAdder(aa, bb);
-        a.put(aa);
-        b.put(bb);
-        final result = mod.out.value.toInt();
-        //print("adder: $aa $bb $result $golden");
-        expect(result, equals(golden));
-      }
-    }
-  });
-}

--- a/lib/src/parallel_prefix_operations.dart
+++ b/lib/src/parallel_prefix_operations.dart
@@ -251,3 +251,32 @@ class ParallelPrefixDecr extends Module {
             .rswizzle());
   }
 }
+
+
+
+void testAdder(int n, ParallelPrefixAdder Function(Logic a, Logic b) fn) {
+  test('adder_$n', () async {
+    final a = Logic(name: 'a', width: n);
+    final b = Logic(name: 'b', width: n);
+
+    final mod = fn(a, b);
+    await mod.build();
+
+    int computeAdder(int aa, int bb) => (aa + bb) & ((1 << n) - 1);
+
+    // put/expect testing
+
+    for (var aa = 0; aa < (1 << n); ++aa) {
+      for (var bb = 0; bb < (1 << n); ++bb) {
+        final golden = computeAdder(aa, bb);
+        a.put(aa);
+        b.put(bb);
+        final result = mod.out.value.toInt();
+        //print("adder: $aa $bb $result $golden");
+        expect(result, equals(golden));
+      }
+    }
+  });
+}
+
+


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

This PR updates parallel prefix documentation and links to classes that were not possible on first check-in.

During CI: discovered problem with google-fonts where the BKM is to lock it to a recent but not latest version:
https://stackoverflow.com/questions/78090711/error-type-fontfeature-not-found-flutter-google-fonts-package-error

During CI: discovered a problem with flutter code shadowing arguments of a parent class triggering an error entitled use_super_parameters:
https://dart.dev/tools/linter-rules/use_super_parameters

## Related Issue(s)

None

## Testing

I've tested the documentation links in my fork.   I've also added a linear adder test for narrow adders to complement the random test.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Changes are to the documentation, so they are included.
