### PR TITLE
Add tests that configurator modules build

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -16,6 +16,8 @@ tmp*
 *.vcd
 .vscode/*
 confapp/.vscode/*
+*tracker.json
+*tracker.log
 
 # Exceptions
 !.vscode/extensions.json

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # ROHD Hardware Component Libary
 
-A hardware component library developed with [ROHD](https://github.com/intel/rohd). This library aims to collect a set of reusable, configurable components that can be leveraged in other designs. These components are also intended as good examples of ROHD hardware implementations.
+A hardware component library developed with [ROHD](https://intel.github.io/rohd-website/). This library aims to collect a set of reusable, configurable components that can be leveraged in other designs. These components are also intended as good examples of ROHD hardware implementations.
 
 Check out the [generator web app](https://intel.github.io/rohd-hcl/confapp/), which lets you explore some of the available components, configure them, and generate SystemVerilog.
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -8,8 +8,8 @@ Some in-development items will have opened issues, as well. Feel free to create 
 - Encoders & Decoders
   - [1-hot to Binary](./components/onehot.md)
   - [Binary to 1-hot](./components/onehot.md)
-  - Gray to Binary
-  - Binary to Gray
+  - [Binary to Gray](./components/binary_gray.md#binary-to-gray)
+  - [Gray to Binary](./components/binary_gray.md#gray-to-binary)
   - Priority
   - PLAs
 - Arbiters


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Since we have a component registry, we may as well try building all of them to ensure there's no issue with the configurators.

This PR also includes a couple minor updates:
- link to the ROHD website on README
- update .pubignore to ignore some files already in .gitignore
- fix links for gray stuff in component list

## Related Issue(s)

N/A

## Testing

Just added a test

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
