### PR TITLE
Refactoring of `FloatingPointValue` constructors for ease of use and extension

### DIFF
--- a/lib/src/arithmetic/floating_point/floating_point.dart
+++ b/lib/src/arithmetic/floating_point/floating_point.dart
@@ -4,4 +4,4 @@
 export 'floating_point_adder_round.dart';
 export 'floating_point_adder_simple.dart';
 export 'floating_point_logic.dart';
-export 'floating_point_value.dart';
+export 'floating_point_values/floating_point_values.dart';

--- a/lib/src/arithmetic/floating_point/floating_point_logic.dart
+++ b/lib/src/arithmetic/floating_point/floating_point_logic.dart
@@ -11,8 +11,7 @@
 //
 
 import 'package:rohd/rohd.dart';
-import 'package:rohd_hcl/src/arithmetic/floating_point/floating_point_value.dart';
-import 'package:rohd_hcl/src/exceptions.dart';
+import 'package:rohd_hcl/rohd_hcl.dart';
 
 /// Flexible floating point logic representation
 class FloatingPoint extends LogicStructure {

--- a/lib/src/arithmetic/floating_point/floating_point_values/floating_point_32_value.dart
+++ b/lib/src/arithmetic/floating_point/floating_point_values/floating_point_32_value.dart
@@ -1,0 +1,97 @@
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+import 'package:rohd/rohd.dart';
+import 'package:rohd_hcl/rohd_hcl.dart';
+
+/// A representation of a single precision floating point value
+class FloatingPoint32Value extends FloatingPointValue {
+  /// The exponent width
+  static const int exponentWidth = 8;
+
+  /// The mantissa width
+  static const int mantissaWidth = 23;
+
+  @override
+  @protected
+  int get constrainedExponentWidth => exponentWidth;
+
+  @override
+  @protected
+  int get constrainedMantissaWidth => mantissaWidth;
+
+  /// Constructor for a single precision floating point value
+  FloatingPoint32Value(
+      {required super.sign, required super.exponent, required super.mantissa});
+
+  /// Return the [FloatingPoint32Value] representing the constant specified
+  factory FloatingPoint32Value.getFloatingPointConstant(
+          FloatingPointConstants constantFloatingPoint) =>
+      FloatingPointValue.getFloatingPointConstant(
+              constantFloatingPoint, exponentWidth, mantissaWidth)
+          as FloatingPoint32Value;
+
+  /// [FloatingPoint32Value] constructor from string representation of
+  /// individual bitfields
+  FloatingPoint32Value.ofBinaryStrings(
+      super.sign, super.exponent, super.mantissa)
+      : super.ofBinaryStrings();
+
+  /// [FloatingPoint32Value] constructor from a single string representing
+  /// space-separated bitfields
+  FloatingPoint32Value.ofString(String fp, {super.radix})
+      : super.ofString(fp, exponentWidth, mantissaWidth);
+
+  /// [FloatingPoint32Value] constructor from a set of [BigInt]s of the binary
+  /// representation
+  FloatingPoint32Value.ofBigInts(super.exponent, super.mantissa, {super.sign})
+      : super.ofBigInts();
+
+  /// [FloatingPoint32Value] constructor from a set of [int]s of the binary
+  /// representation
+  factory FloatingPoint32Value.ofInts(int exponent, int mantissa,
+      {bool sign = false}) {
+    final (signLv, exponentLv, mantissaLv) = (
+      LogicValue.ofBigInt(sign ? BigInt.one : BigInt.zero, 1),
+      LogicValue.ofBigInt(BigInt.from(exponent), exponentWidth),
+      LogicValue.ofBigInt(BigInt.from(mantissa), mantissaWidth)
+    );
+
+    return FloatingPoint32Value(
+        sign: signLv, exponent: exponentLv, mantissa: mantissaLv);
+  }
+
+  /// Numeric conversion of a [FloatingPoint32Value] from a host double
+  factory FloatingPoint32Value.fromDouble(double inDouble) {
+    final byteData = ByteData(4)
+      ..setFloat32(0, inDouble)
+      ..buffer.asUint8List();
+    final bytes = byteData.buffer.asUint8List();
+    final lv = bytes.map((b) => LogicValue.ofInt(b, 32));
+
+    final accum = lv.reduce((accum, v) => (accum << 8) | v);
+
+    final sign = accum[-1];
+    final exponent =
+        accum.slice(exponentWidth + mantissaWidth - 1, mantissaWidth);
+    final mantissa = accum.slice(mantissaWidth - 1, 0);
+
+    return FloatingPoint32Value(
+        sign: sign, exponent: exponent, mantissa: mantissa);
+  }
+
+  /// Construct a [FloatingPoint32Value] from a Logic word
+  factory FloatingPoint32Value.fromLogic(LogicValue val) {
+    final sign = (val[-1] == LogicValue.one);
+    final exponent =
+        val.slice(exponentWidth + mantissaWidth - 1, mantissaWidth);
+    final mantissa = val.slice(mantissaWidth - 1, 0);
+    final (signLv, exponentLv, mantissaLv) = (
+      LogicValue.ofBigInt(sign ? BigInt.one : BigInt.zero, 1),
+      exponent,
+      mantissa
+    );
+    return FloatingPoint32Value(
+        sign: signLv, exponent: exponentLv, mantissa: mantissaLv);
+  }
+}

--- a/lib/src/arithmetic/floating_point/floating_point_values/floating_point_64_value.dart
+++ b/lib/src/arithmetic/floating_point/floating_point_values/floating_point_64_value.dart
@@ -1,0 +1,99 @@
+import 'dart:typed_data';
+
+import 'package:rohd/rohd.dart';
+import 'package:rohd_hcl/rohd_hcl.dart';
+
+/// A representation of a double precision floating point value
+class FloatingPoint64Value extends FloatingPointValue {
+  static const int _exponentWidth = 11;
+  static const int _mantissaWidth = 52;
+
+  /// return the exponent width
+  static int get exponentWidth => _exponentWidth;
+
+  /// return the mantissa width
+  static int get mantissaWidth => _mantissaWidth;
+
+  /// Constructor for a double precision floating point value
+  FloatingPoint64Value(
+      {required super.sign, required super.mantissa, required super.exponent})
+      : super.withConstraints(
+            constrainExponentWidth: exponentWidth,
+            constrainMantissaWidth: mantissaWidth);
+
+  /// Return the [FloatingPoint64Value] representing the constant specified
+  factory FloatingPoint64Value.getFloatingPointConstant(
+          FloatingPointConstants constantFloatingPoint) =>
+      FloatingPointValue.getFloatingPointConstant(
+              constantFloatingPoint, _exponentWidth, _mantissaWidth)
+          as FloatingPoint64Value;
+
+  /// [FloatingPoint64Value] constructor from string representation of
+  /// individual bitfields
+  factory FloatingPoint64Value.ofStrings(
+          String sign, String exponent, String mantissa) =>
+      FloatingPoint64Value(
+          sign: LogicValue.of(sign),
+          exponent: LogicValue.of(exponent),
+          mantissa: LogicValue.of(mantissa));
+
+  /// [FloatingPoint64Value] constructor from a single string representing
+  /// space-separated bitfields
+  factory FloatingPoint64Value.ofString(String fp) {
+    final s = fp.split(' ');
+    assert(s.length == 3, 'Wrong FloatingPointValue string length ${s.length}');
+    return FloatingPoint64Value.ofStrings(s[0], s[1], s[2]);
+  }
+
+  /// [FloatingPoint64Value] constructor from a set of [BigInt]s of the binary
+  /// representation
+  factory FloatingPoint64Value.ofBigInts(BigInt exponent, BigInt mantissa,
+          {bool sign = false}) =>
+      FloatingPointValue.ofBigInts(exponent, mantissa,
+          sign: sign,
+          exponentWidth: exponentWidth,
+          mantissaWidth: mantissaWidth) as FloatingPoint64Value;
+
+  /// [FloatingPoint64Value] constructor from a set of [int]s of the binary
+  /// representation
+  factory FloatingPoint64Value.ofInts(int exponent, int mantissa,
+          {bool sign = false}) =>
+      FloatingPointValue.ofInts(exponent, mantissa,
+          sign: sign,
+          exponentWidth: exponentWidth,
+          mantissaWidth: mantissaWidth) as FloatingPoint64Value;
+
+  /// Numeric conversion of a [FloatingPoint64Value] from a host double
+  factory FloatingPoint64Value.fromDouble(double inDouble) {
+    final byteData = ByteData(8)
+      ..setFloat64(0, inDouble)
+      ..buffer.asUint8List();
+    final bytes = byteData.buffer.asUint8List();
+    final lv = bytes.map((b) => LogicValue.ofInt(b, 64));
+
+    final accum = lv.reduce((accum, v) => (accum << 8) | v);
+
+    final sign = accum[-1];
+    final exponent =
+        accum.slice(_exponentWidth + _mantissaWidth - 1, _mantissaWidth);
+    final mantissa = accum.slice(_mantissaWidth - 1, 0);
+
+    return FloatingPoint64Value(
+        sign: sign, mantissa: mantissa, exponent: exponent);
+  }
+
+  /// Construct a [FloatingPoint32Value] from a Logic word
+  factory FloatingPoint64Value.fromLogic(LogicValue val) {
+    final sign = (val[-1] == LogicValue.one);
+    final exponent =
+        val.slice(exponentWidth + mantissaWidth - 1, mantissaWidth).toBigInt();
+    final mantissa = val.slice(mantissaWidth - 1, 0).toBigInt();
+    final (signLv, exponentLv, mantissaLv) = (
+      LogicValue.ofBigInt(sign ? BigInt.one : BigInt.zero, 1),
+      LogicValue.ofBigInt(exponent, exponentWidth),
+      LogicValue.ofBigInt(mantissa, mantissaWidth)
+    );
+    return FloatingPoint64Value(
+        sign: signLv, exponent: exponentLv, mantissa: mantissaLv);
+  }
+}

--- a/lib/src/arithmetic/floating_point/floating_point_values/floating_point_8_value.dart
+++ b/lib/src/arithmetic/floating_point/floating_point_values/floating_point_8_value.dart
@@ -1,0 +1,103 @@
+import 'dart:math';
+
+import 'package:rohd/rohd.dart';
+import 'package:rohd_hcl/rohd_hcl.dart';
+
+/// A representation of a 8-bit floating point value as defined in
+/// [FP8 Formats for Deep Learning](https://arxiv.org/abs/2209.05433).
+class FloatingPoint8Value extends FloatingPointValue {
+  /// The exponent width
+  late final int exponentWidth;
+
+  /// The mantissa width
+  late final int mantissaWidth;
+
+  static double get _e4m3max => 448.toDouble();
+  static double get _e5m2max => 57344.toDouble();
+  static double get _e4m3min => pow(2, -9).toDouble();
+  static double get _e5m2min => pow(2, -16).toDouble();
+
+  /// Return if the exponent and mantissa widths match E4M3 or E5M2
+  static bool isLegal(int exponentWidth, int mantissaWidth) {
+    if (((exponentWidth == 4) & (mantissaWidth == 3)) |
+        ((exponentWidth == 5) & (mantissaWidth == 2))) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /// Constructor for a double precision floating point value
+  FloatingPoint8Value(
+      {required super.sign, required super.mantissa, required super.exponent})
+      : super.withConstraints() {
+    exponentWidth = exponent.width;
+    mantissaWidth = mantissa.width;
+    if (!isLegal(exponentWidth, mantissaWidth)) {
+      throw RohdHclException('FloatingPoint8 must follow E4M3 or E5M2');
+    }
+  }
+
+  /// [FloatingPoint8Value] constructor from string representation of
+  /// individual bitfields
+  factory FloatingPoint8Value.ofStrings(
+          String sign, String exponent, String mantissa) =>
+      FloatingPoint8Value(
+          sign: LogicValue.of(sign),
+          exponent: LogicValue.of(exponent),
+          mantissa: LogicValue.of(mantissa));
+
+  /// [FloatingPoint8Value] constructor from a single string representing
+  /// space-separated bitfields
+  factory FloatingPoint8Value.ofString(String fp) {
+    final s = fp.split(' ');
+    assert(s.length == 3, 'Wrong FloatingPointValue string length ${s.length}');
+    return FloatingPoint8Value.ofStrings(s[0], s[1], s[2]);
+  }
+
+  /// Construct a [FloatingPoint8Value] from a Logic word
+  factory FloatingPoint8Value.fromLogic(LogicValue val, int exponentWidth) {
+    if (val.width != 8) {
+      throw RohdHclException('Width must be 8');
+    }
+
+    final mantissaWidth = 7 - exponentWidth;
+    if (!isLegal(exponentWidth, mantissaWidth)) {
+      throw RohdHclException('FloatingPoint8 must follow E4M3 or E5M2');
+    }
+
+    final sign = (val[-1] == LogicValue.one);
+    final exponent =
+        val.slice(exponentWidth + mantissaWidth - 1, mantissaWidth).toBigInt();
+    final mantissa = val.slice(mantissaWidth - 1, 0).toBigInt();
+    final (signLv, exponentLv, mantissaLv) = (
+      LogicValue.ofBigInt(sign ? BigInt.one : BigInt.zero, 1),
+      LogicValue.ofBigInt(exponent, exponentWidth),
+      LogicValue.ofBigInt(mantissa, mantissaWidth)
+    );
+    return FloatingPoint8Value(
+        sign: signLv, exponent: exponentLv, mantissa: mantissaLv);
+  }
+
+  /// Numeric conversion of a [FloatingPoint8Value] from a host double
+  factory FloatingPoint8Value.fromDouble(double inDouble,
+      {required int exponentWidth}) {
+    final mantissaWidth = 7 - exponentWidth;
+    if (!isLegal(exponentWidth, mantissaWidth)) {
+      throw RohdHclException('FloatingPoint8 must follow E4M3 or E5M2');
+    }
+    if (exponentWidth == 4) {
+      if ((inDouble > _e4m3max) | (inDouble < _e4m3min)) {
+        throw RohdHclException('Number exceeds E4M3 range');
+      }
+    } else if (exponentWidth == 5) {
+      if ((inDouble > _e5m2max) | (inDouble < _e5m2min)) {
+        throw RohdHclException('Number exceeds E5M2 range');
+      }
+    }
+    final fpv = FloatingPointValue.fromDouble(inDouble,
+        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
+    return FloatingPoint8Value(
+        sign: fpv.sign, exponent: fpv.exponent, mantissa: fpv.mantissa);
+  }
+}

--- a/lib/src/arithmetic/floating_point/floating_point_values/floating_point_values.dart
+++ b/lib/src/arithmetic/floating_point/floating_point_values/floating_point_values.dart
@@ -1,0 +1,7 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+
+export 'floating_point_32_value.dart';
+export 'floating_point_64_value.dart';
+export 'floating_point_8_value.dart';
+export 'floating_point_value.dart';


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Making it easier to extend `FloatingPointValue` and reuse constructors, removing `factory`s, etc.

## Related Issue(s)

N/A

## Testing

Existing tests should cover.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
