### PR TITLE
bug fix for fp8e4m3

### DIFF
--- a/lib/src/arithmetic/floating_point/floating_point_values/floating_point_8_value.dart
+++ b/lib/src/arithmetic/floating_point/floating_point_values/floating_point_8_value.dart
@@ -61,12 +61,14 @@ class FloatingPoint8E4M3Value extends FloatingPointValue {
   ///  binary representation
   FloatingPoint8E4M3Value.ofBigInts(super.exponent, super.mantissa,
       {super.sign})
-      : super.ofBigInts();
+      : super.ofBigInts(
+            exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
 
   /// [FloatingPoint8E4M3Value] constructor from a set of [int]s of the binary
   /// representation
   FloatingPoint8E4M3Value.ofInts(super.exponent, super.mantissa, {super.sign})
-      : super.ofInts();
+      : super.ofInts(
+            exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
 
   /// Numeric conversion of a [FloatingPoint8E4M3Value] from a host double
   factory FloatingPoint8E4M3Value.ofDouble(double inDouble) {


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

ofInt() and ofBigInt() code was incomplete.

## Related Issue(s)


## Testing

None.  We have parallel tests for other operand types, just not this one.  Will open an issue to create more smoke tests.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

This is a bug fix.
