### PR TITLE
Bug fix for pipelined multiplication signals

### DIFF
--- a/confapp/README.md
+++ b/confapp/README.md
@@ -2,6 +2,13 @@
 
 This is a web app that allows RTL generation (SystemVerilog) based on the specific configuration.
 
+For local testing:
+
+```shell
+cd confapp
+flutter run --profile -d web-server --web-hostname=0.0.0.0 --web-port=3000
+```
+
 ## Widget Tree
 
 ```mermaid

--- a/doc/components/multiplier.md
+++ b/doc/components/multiplier.md
@@ -86,7 +86,9 @@ The parameters of the
 - The radix used for Booth encoding (2, 4, 8, and 16 are currently supported)
 - The type of `ParallelPrefix` tree used in the final `ParallelPrefixAdder` (optional)
 - `signed` parameter: whether the operands should be treated as signed (2s complement) or unsigned
-- An optional `selectSigned` control signal which overrides the `signed` configuration allowing for runtime control of signed or unsigned operation with the same hardware.
+- `ppGen` parameter: the type of `PartialProductGenerator` to use which has derived classes for different styles of sign extension. In some cases this adds an extra row to hold a sign bit.
+- An optional `selectSigned` control signal which overrides the `signed` configuration allowing for runtime control of signed or unsigned operation with the same hardware. `signed` must be false if using this control signal.
+- An optional `clk`, as well as `enable` and `reset` that are used to add a pipestage in the `ColumnCompressor` to allow for pipelined operation.
 
 Here is an example of use of the `CompressionTreeMultiplier`:
 
@@ -122,7 +124,9 @@ The parameters of the
 - The radix used for Booth encoding (2, 4, 8, and 16 are currently supported)
 - The type of `ParallelPrefix` tree used in the final `ParallelPrefixAdder` (default Kogge-Stone).
 - `signed` parameter: whether the operands should be treated as signed (2s complement) or unsigned
-- An optional `selectSigned` control signal which overrides the `signed` configuration allowing for runtime control of signed or unsigned operation with the same hardware.
+- `ppGen` parameter: the type of `PartialProductGenerator` to use which has derived classes for different styles of sign extension. In some cases this adds an extra row to hold a sign bit (default `PartialProductGeneratorCompactRectSignExtension`).
+- An optional `selectSigned` control signal which overrides the `signed` configuration allowing for runtime control of signed or unsigned operation with the same hardware. `signed` must be false if using this control signal.
+- An optional `clk`, as well as `enable` and `reset` that are used to add a pipestage in the `ColumnCompressor` to allow for pipelined operation.
 
 Here is an example of using the `CompressionTreeMultiplyAccumulate`:
 

--- a/lib/src/arithmetic/multiplicand_selector.dart
+++ b/lib/src/arithmetic/multiplicand_selector.dart
@@ -53,7 +53,6 @@ class MultiplicandSelector {
       ];
       extendedMultiplicand = (multiplicand.elements + extension).rswizzle();
     }
-
     for (var pos = 0; pos < numMultiples; pos++) {
       final ratio = pos + 1;
       multiples.elements[pos] <=

--- a/lib/src/arithmetic/multiplier.dart
+++ b/lib/src/arithmetic/multiplier.dart
@@ -113,19 +113,18 @@ class CompressionTreeMultiplier extends Multiplier {
           ppGen = PartialProductGeneratorCompactRectSignExtension.new,
       super.signed = false,
       super.name = 'compression_tree_multiplier'}) {
-    final Logic? internalSelectSigned;
-    if (selectSigned != null) {
-      internalSelectSigned = addInput('selectSigned', selectSigned);
-    } else {
-      internalSelectSigned = null;
-    }
+    final internalSelectSigned =
+        (selectSigned != null) ? addInput('selectSigned', selectSigned) : null;
+    final iClk = (clk != null) ? addInput('clk', clk!) : null;
+    final iReset = (reset != null) ? addInput('reset', reset!) : null;
+    final iEnable = (enable != null) ? addInput('enable', enable!) : null;
 
     final product = addOutput('product', width: a.width + b.width);
     final pp = ppGen(a, b, RadixEncoder(radix),
         selectSigned: internalSelectSigned, signed: signed);
 
     final compressor =
-        ColumnCompressor(clk: clk, reset: reset, enable: enable, pp)
+        ColumnCompressor(clk: iClk, reset: iReset, enable: iEnable, pp)
           ..compress();
     final adder = ParallelPrefixAdder(
         compressor.extractRow(0), compressor.extractRow(1),
@@ -180,12 +179,12 @@ class CompressionTreeMultiplyAccumulate extends MultiplyAccumulate {
               {required bool signed, Logic? selectSigned})
           ppGen = PartialProductGeneratorCompactRectSignExtension.new,
       super.name = 'compression_tree_mac'}) {
-    final Logic? internalSelectSigned;
-    if (selectSigned != null) {
-      internalSelectSigned = addInput('selectSigned', selectSigned);
-    } else {
-      internalSelectSigned = null;
-    }
+    final internalSelectSigned =
+        (selectSigned != null) ? addInput('selectSigned', selectSigned) : null;
+    final iClk = (clk != null) ? addInput('clk', clk!) : null;
+    final iReset = (reset != null) ? addInput('reset', reset!) : null;
+    final iEnable = (enable != null) ? addInput('enable', enable!) : null;
+
     final accumulate = addOutput('accumulate', width: a.width + b.width + 1);
     final pp = ppGen(a, b, RadixEncoder(radix),
         selectSigned: internalSelectSigned, signed: signed);
@@ -213,7 +212,7 @@ class CompressionTreeMultiplyAccumulate extends MultiplyAccumulate {
     pp.rowShift.insert(0, 0);
 
     final compressor =
-        ColumnCompressor(clk: clk, reset: reset, enable: enable, pp)
+        ColumnCompressor(clk: iClk, reset: iReset, enable: iEnable, pp)
           ..compress();
     final adder = ParallelPrefixAdder(
         compressor.extractRow(0), compressor.extractRow(1),

--- a/lib/src/component_config/components/config_compression_tree_multiplier.dart
+++ b/lib/src/component_config/components/config_compression_tree_multiplier.dart
@@ -40,8 +40,12 @@ class CompressionTreeMultiplierConfigurator extends Configurator {
   /// Controls the width of the multiplier.!
   final IntConfigKnob multiplierWidthKnob = IntConfigKnob(value: 5);
 
+  /// Controls whether the adder is pipelined
+  final ToggleConfigKnob pipelinedKnob = ToggleConfigKnob(value: false);
+
   @override
   Module createModule() => CompressionTreeMultiplier(
+      clk: pipelinedKnob.value ? Logic() : null,
       Logic(name: 'a', width: multiplicandWidthKnob.value),
       Logic(name: 'b', width: multiplierWidthKnob.value),
       radixKnob.value,
@@ -53,6 +57,7 @@ class CompressionTreeMultiplierConfigurator extends Configurator {
     'Radix': radixKnob,
     'Multiplicand width': multiplicandWidthKnob,
     'Multiplier width': multiplierWidthKnob,
+    'Pipelined': pipelinedKnob,
   });
 
   @override

--- a/test/arithmetic/addend_compressor_test.dart
+++ b/test/arithmetic/addend_compressor_test.dart
@@ -139,7 +139,6 @@ void main() {
   });
   test('ColumnCompressor: random evaluate: square radix-4, just CompactRect',
       () async {
-    stdout.write('\n');
     for (final signed in [false, true]) {
       for (var radix = 4; radix < 8; radix *= 2) {
         final encoder = RadixEncoder(radix);
@@ -165,7 +164,7 @@ void main() {
                     Logic(name: 'Y', width: width), encoder,
                     signed: signed);
               }
-              testCompressionExhaustive(pp);
+              testCompressionRandom(pp, 10);
             }
           }
         }

--- a/test/arithmetic/multiplier_encoder_test.dart
+++ b/test/arithmetic/multiplier_encoder_test.dart
@@ -151,9 +151,9 @@ void main() {
     }
   });
 
-  test('full rectangular test,', () async {
+  test('Multiplier encoder rectangular test,', () async {
     for (final signed in [false, true]) {
-      for (var radix = 2; radix < 32; radix *= 2) {
+      for (var radix = 2; radix < 8; radix *= 2) {
         final encoder = RadixEncoder(radix);
         final shift = log2Ceil(encoder.radix);
         for (var width = 3 + shift + 1; width < 3 + shift * 2 + 1; width++) {
@@ -179,7 +179,7 @@ void main() {
                       Logic(name: 'Y', width: width), encoder,
                       signed: signed);
                 }
-                checkEvaluateRandom(pp, 20);
+                checkEvaluateRandom(pp, 10);
               }
             }
           }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Missed creating addInput for clk,reset, enable; resulting in a trace error upon instantiation.

## Related Issue(s)

#136   We need to find a more comprehensive way to avoid as natural testing does not instantiate components with a module.

## Testing

None.  Direct instantiation tests don't seem to create the trace error consistently.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No.  Bug fix.
