### PR TITLE
42compress

### DIFF
--- a/lib/src/arithmetic/multiplier.dart
+++ b/lib/src/arithmetic/multiplier.dart
@@ -111,6 +111,7 @@ class CompressionTreeMultiplier extends Multiplier {
       PartialProductGenerator Function(Logic, Logic, RadixEncoder,
               {required bool signed, Logic? selectSigned})
           ppGen = PartialProductGeneratorCompactRectSignExtension.new,
+      bool use42Compressors = false,
       super.signed = false,
       super.name = 'compression_tree_multiplier'}) {
     final internalSelectSigned =
@@ -123,9 +124,13 @@ class CompressionTreeMultiplier extends Multiplier {
     final pp = ppGen(a, b, RadixEncoder(radix),
         selectSigned: internalSelectSigned, signed: signed);
 
-    final compressor =
-        ColumnCompressor(clk: iClk, reset: iReset, enable: iEnable, pp)
-          ..compress();
+    final compressor = ColumnCompressor(
+        clk: iClk,
+        reset: iReset,
+        enable: iEnable,
+        pp,
+        use42Compressors: use42Compressors)
+      ..compress();
     final adder = ParallelPrefixAdder(
         compressor.extractRow(0), compressor.extractRow(1),
         ppGen: ppTree);
@@ -178,6 +183,7 @@ class CompressionTreeMultiplyAccumulate extends MultiplyAccumulate {
       PartialProductGenerator Function(Logic, Logic, RadixEncoder,
               {required bool signed, Logic? selectSigned})
           ppGen = PartialProductGeneratorCompactRectSignExtension.new,
+      bool use42Compressors = false,
       super.name = 'compression_tree_mac'}) {
     final internalSelectSigned =
         (selectSigned != null) ? addInput('selectSigned', selectSigned) : null;
@@ -211,9 +217,13 @@ class CompressionTreeMultiplyAccumulate extends MultiplyAccumulate {
     pp.partialProducts.insert(0, l);
     pp.rowShift.insert(0, 0);
 
-    final compressor =
-        ColumnCompressor(clk: iClk, reset: iReset, enable: iEnable, pp)
-          ..compress();
+    final compressor = ColumnCompressor(
+        clk: iClk,
+        reset: iReset,
+        enable: iEnable,
+        pp,
+        use42Compressors: use42Compressors)
+      ..compress();
     final adder = ParallelPrefixAdder(
         compressor.extractRow(0), compressor.extractRow(1),
         ppGen: ppTree);

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -49,4 +49,11 @@ extension LogicValueMajority on LogicValue {
     }
     return result;
   }
+
+  /// Return the populationCount of 1s in a LogicValue
+  int popCount() {
+    final r = RegExp('1');
+    final matches = r.allMatches(bitString);
+    return matches.length;
+  }
 }

--- a/test/arithmetic/addend_compressor_test.dart
+++ b/test/arithmetic/addend_compressor_test.dart
@@ -7,10 +7,11 @@
 // 2024 June 04
 // Author: Desmond Kirkpatrick <desmond.a.kirkpatrick@intel.com>
 
+// ignore_for_file: avoid_print
+
 import 'dart:async';
 import 'dart:io';
 import 'dart:math';
-import 'package:meta/meta.dart';
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
 import 'package:rohd_hcl/src/arithmetic/evaluate_compressor.dart';
@@ -146,7 +147,16 @@ void main() {
     final bits = Logic(width: 4);
     final cin = [Logic()];
 
-    final compressor = Compressor4(bits, cin);
+    final inputs = [
+      for (var i = 0; i < bits.width; i++)
+        CompressTerm(null, CompressTermType.pp, bits[i], [], 0, 0)
+    ];
+    final carryInputs = [
+      for (var i = 0; i < cin.length; i++)
+        CompressTerm(null, CompressTermType.pp, cin[i], [], 0, 0)
+    ];
+
+    final compressor = Compressor4(inputs, carryInputs);
 
     for (var cVal = 0; cVal < 2; cVal++) {
       cin[0].put(cVal);
@@ -190,8 +200,7 @@ void main() {
                     Logic(name: 'Y', width: width), encoder,
                     signed: signed);
               }
-              // testCompressionRandom(pp, 10, use42Compressors: true);
-              testCompressionExhaustive(pp, use42Compressors: true);
+              testCompressionRandom(pp, 10, use42Compressors: true);
             }
           }
         }
@@ -358,15 +367,10 @@ void main() {
 
     final pp = PartialProductGeneratorStopBitsSignExtension(a, b, encoder);
 
-    // print(pp.representation());
-
     expect(pp.evaluate(), equals(bA * bB));
     final compressor = ColumnCompressor(pp, use42Compressors: true);
-    // print(compressor.representation());
     expect(compressor.evaluate().$1, equals(bA * bB));
     compressor.compress();
-    // print(compressor.representation());
-
-    expect(compressor.evaluate().$1, equals(bA * bB));
+    expect(compressor.evaluate(logic: true).$1, equals(bA * bB));
   });
 }

--- a/test/arithmetic/multiplier_test.dart
+++ b/test/arithmetic/multiplier_test.dart
@@ -595,24 +595,31 @@ void main() {
     expect(ppG0.getAbsolute(1, 9).value, equals(Const(1).value));
     expect(ppG0.getAbsolute(1, 10).value, equals(Const(0).value));
 
-//     final cc = ColumnCompressor(ppG0);
-//     const expectedRep = '''
-// 	pp3,15	pp3,14	pp3,13	pp3,12	pp3,11	pp3,10	pp3,9	pp3,8	pp3,7	pp3,6	pp3,5	pp2,4	pp2,3	pp1,2	pp1,1	pp0,0
-// 			pp2,13	pp2,12	pp1,11	pp2,10	pp2,9	pp2,8	pp2,7	pp2,6	pp2,5	pp0,4	pp0,3	pp0,2	pp0,1
-// 					pp2,11	pp1,10	pp1,9	pp1,8	pp1,7	pp1,6	pp1,5	pp1,4	pp1,3
-// 						pp0,10	pp0,9	pp0,8	pp0,7	pp0,6	pp0,5
-// ''';
-//     expect(cc.representation(), equals(expectedRep));
+    final cc = ColumnCompressor(ppG0);
+    const expectedRep = '''
+	pp3,15	pp3,14	pp3,13	pp3,12	pp3,11	pp3,10	pp3,9	pp3,8	pp3,7	pp3,6	pp3,5	pp2,4	pp2,3	pp1,2	pp1,1	pp0,0
+			pp2,13	pp2,12	pp1,11	pp2,10	pp2,9	pp2,8	pp2,7	pp2,6	pp2,5	pp0,4	pp0,3	pp0,2	pp0,1
+					pp2,11	pp1,10	pp1,9	pp1,8	pp1,7	pp1,6	pp1,5	pp1,4	pp1,3
+						pp0,10	pp0,9	pp0,8	pp0,7	pp0,6	pp0,5
+''';
+    const expectedRep2 = '''
+	pp3,15	pp3,14	pp3,13	pp3,12	pp3,11	pp3,10	pp3,9	pp3,8	pp3,7	pp3,6	pp3,5	pp2,4	pp2,3	pp1,2	pp1,1	pp0,0
+			pp2,13	pp2,12	pp1,11	pp2,10	pp2,9	pp2,8	pp2,7	pp2,6	pp2,5	pp0,4	pp0,3	pp0,2	pp0,1	
+					pp2,11	pp1,10	pp1,9	pp1,8	pp1,7	pp1,6	pp1,5	pp1,4	pp1,3			
+						pp0,10	pp0,9	pp0,8	pp0,7	pp0,6	pp0,5					
+''';
+    // print(cc.representation());
+    expect(cc.representation(), equals(expectedRep2));
 
-//     final (v, ts) = cc.evaluate(printOut: true);
+    final (v, ts) = cc.evaluate(printOut: true);
 
-//     const expectedEval = '''
-//        15      14      13      12      11      10       9       8       7       6       5       4       3       2       1       0
-//         1       I       0       0       0       0       0       0       1       1       0       0       0       1       1       0        = 49350 (-16186)
-//                         1       I       1       0       0       0       0       0       0       0       1       0       0                = 14344 (14344)
-//                                         0       i       1       0       0       0       0       1       1                                = 536 (536)
-//                                                 i       S       S       1       1       0                                                = 960 (960)
-// p       1       1       1       1       1       1       1       0       1       0       1       0       0       1       1       0        = 65190 (-346)''';
-//     expect(ts.toString(), equals(expectedEval));
+    const expectedEval = '''
+       15      14      13      12      11      10       9       8       7       6       5       4       3       2       1       0
+        1       I       0       0       0       0       0       0       1       1       0       0       0       1       1       0        = 49350 (-16186)
+                        1       I       1       0       0       0       0       0       0       0       1       0       0                = 14344 (14344)
+                                        0       i       1       0       0       0       0       1       1                                = 536 (536)
+                                                i       S       S       1       1       0                                                = 960 (960)
+p       1       1       1       1       1       1       1       0       1       0       1       0       0       1       1       0        = 65190 (-346)''';
+    expect(ts.toString(), equals(expectedEval));
   });
 }

--- a/test/arithmetic/multiplier_test.dart
+++ b/test/arithmetic/multiplier_test.dart
@@ -595,24 +595,24 @@ void main() {
     expect(ppG0.getAbsolute(1, 9).value, equals(Const(1).value));
     expect(ppG0.getAbsolute(1, 10).value, equals(Const(0).value));
 
-    final cc = ColumnCompressor(ppG0);
-    const expectedRep = '''
-	pp3,15	pp3,14	pp3,13	pp3,12	pp3,11	pp3,10	pp3,9	pp3,8	pp3,7	pp3,6	pp3,5	pp2,4	pp2,3	pp1,2	pp1,1	pp0,0
-			pp2,13	pp2,12	pp1,11	pp2,10	pp2,9	pp2,8	pp2,7	pp2,6	pp2,5	pp0,4	pp0,3	pp0,2	pp0,1	
-					pp2,11	pp1,10	pp1,9	pp1,8	pp1,7	pp1,6	pp1,5	pp1,4	pp1,3			
-						pp0,10	pp0,9	pp0,8	pp0,7	pp0,6	pp0,5					
-''';
-    expect(cc.representation(), equals(expectedRep));
+//     final cc = ColumnCompressor(ppG0);
+//     const expectedRep = '''
+// 	pp3,15	pp3,14	pp3,13	pp3,12	pp3,11	pp3,10	pp3,9	pp3,8	pp3,7	pp3,6	pp3,5	pp2,4	pp2,3	pp1,2	pp1,1	pp0,0
+// 			pp2,13	pp2,12	pp1,11	pp2,10	pp2,9	pp2,8	pp2,7	pp2,6	pp2,5	pp0,4	pp0,3	pp0,2	pp0,1
+// 					pp2,11	pp1,10	pp1,9	pp1,8	pp1,7	pp1,6	pp1,5	pp1,4	pp1,3
+// 						pp0,10	pp0,9	pp0,8	pp0,7	pp0,6	pp0,5
+// ''';
+//     expect(cc.representation(), equals(expectedRep));
 
-    final (v, ts) = cc.evaluate(printOut: true);
+//     final (v, ts) = cc.evaluate(printOut: true);
 
-    const expectedEval = '''
-       15      14      13      12      11      10       9       8       7       6       5       4       3       2       1       0
-        1       I       0       0       0       0       0       0       1       1       0       0       0       1       1       0        = 49350 (-16186)
-                        1       I       1       0       0       0       0       0       0       0       1       0       0                = 14344 (14344)
-                                        0       i       1       0       0       0       0       1       1                                = 536 (536)
-                                                i       S       S       1       1       0                                                = 960 (960)
-p       1       1       1       1       1       1       1       0       1       0       1       0       0       1       1       0        = 65190 (-346)''';
-    expect(ts.toString(), equals(expectedEval));
+//     const expectedEval = '''
+//        15      14      13      12      11      10       9       8       7       6       5       4       3       2       1       0
+//         1       I       0       0       0       0       0       0       1       1       0       0       0       1       1       0        = 49350 (-16186)
+//                         1       I       1       0       0       0       0       0       0       0       1       0       0                = 14344 (14344)
+//                                         0       i       1       0       0       0       0       1       1                                = 536 (536)
+//                                                 i       S       S       1       1       0                                                = 960 (960)
+// p       1       1       1       1       1       1       1       0       1       0       1       0       0       1       1       0        = 65190 (-346)''';
+//     expect(ts.toString(), equals(expectedEval));
   });
 }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Adds 4:2 compressors option to ColumnCompressor as well as a better delay table for optimizing the compression tree.

Added a popCount as a LogicValue extension which may need to be migrated to ROHD itself (along with majority).  Eventually we will need hardware versions of these.

## Related Issue(s)

#120 #86

## Testing

Modified tests to enable the 4:2 compression option.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

compression trees will take on a different shape with different delay tables as the delay optimization gets more realistic.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Yes.  Code is updated.  We could update the component generation to expose this option as well as we need to update the documentation of multipliers that use this option.
