### PR TITLE
Full set of sign variants (signed/unsigned/selected) for multiplier operands

### DIFF
--- a/doc/components/multiplier.md
+++ b/doc/components/multiplier.md
@@ -82,12 +82,14 @@ digital signal processing.
 The parameters of the
 `CompressionTreeMultiplier` are:
 
-- Two input terms `a` and `b` which can be different widths
-- The radix used for Booth encoding (2, 4, 8, and 16 are currently supported)
-- The type of `ParallelPrefix` tree used in the final `ParallelPrefixAdder` (optional)
-- `signed` parameter: whether the operands should be treated as signed (2s complement) or unsigned
+- Two input terms `a` and `b` which can be different widths.
+- The radix used for Booth encoding (2, 4, 8, and 16 are currently supported).
+- The type of `ParallelPrefix` tree used in the final `ParallelPrefixAdder` (optional).
 - `ppGen` parameter: the type of `PartialProductGenerator` to use which has derived classes for different styles of sign extension. In some cases this adds an extra row to hold a sign bit.
-- An optional `selectSigned` control signal which overrides the `signed` configuration allowing for runtime control of signed or unsigned operation with the same hardware. `signed` must be false if using this control signal.
+- `signedMultiplicand` parameter: whether the multiplicand (first arg) should be treated as signed (2s complement) or unsigned.
+- `signedMultiplier` parameter: whether the multiplier (second arg) should be treated as signed (2s complement) or unsigned.
+- An optional `selectSignedMultiplicand` control signal which overrides the `signedMultiplicand` parameter allowing for runtime control of signed or unsigned operation with the same hardware. `signedMultiplicand` must be false if using this control signal.
+- An optional `selectSignedMultiplier` control signal which overrides the `signedMultiplier` parameter allowing for runtime control of signed or unsigned operation with the same hardware. `signedMultiplier` must be false if using this control signal.
 - An optional `clk`, as well as `enable` and `reset` that are used to add a pipestage in the `ColumnCompressor` to allow for pipelined operation.
 
 Here is an example of use of the `CompressionTreeMultiplier`:
@@ -123,9 +125,13 @@ The parameters of the
 - The accumulate input term `c` which must have width as sum of the two operand widths + 1.
 - The radix used for Booth encoding (2, 4, 8, and 16 are currently supported)
 - The type of `ParallelPrefix` tree used in the final `ParallelPrefixAdder` (default Kogge-Stone).
-- `signed` parameter: whether the operands should be treated as signed (2s complement) or unsigned
 - `ppGen` parameter: the type of `PartialProductGenerator` to use which has derived classes for different styles of sign extension. In some cases this adds an extra row to hold a sign bit (default `PartialProductGeneratorCompactRectSignExtension`).
-- An optional `selectSigned` control signal which overrides the `signed` configuration allowing for runtime control of signed or unsigned operation with the same hardware. `signed` must be false if using this control signal.
+- `signedMultiplicand` parameter: whether the multiplicand (first arg) should be treated as signed (2s complement) or unsigned
+- `signedMultiplier` parameter: whether the multiplier (second arg) should be treated as signed (2s complement) or unsigned
+- `signedAddend` parameter: whether the addend (third arg) should be treated as signed (2s complement) or unsigned
+- An optional `selectSignedMultiplicand` control signal which overrides the `signedMultiplicand` parameter allowing for runtime control of signed or unsigned operation with the same hardware. `signedMultiplicand` must be false if using this control signal.
+- An optional `selectSignedMultiplier` control signal which overrides the `signedMultiplier` parameter allowing for runtime control of signed or unsigned operation with the same hardware. `signedMultiplier` must be false if using this control signal.
+- An optional `selectSignedAddend` control signal which overrides the `signedAddend` parameter allowing for runtime control of signed or unsigned operation with the same hardware. `signedAddend` must be false if using this control signal.
 - An optional `clk`, as well as `enable` and `reset` that are used to add a pipestage in the `ColumnCompressor` to allow for pipelined operation.
 
 Here is an example of using the `CompressionTreeMultiplyAccumulate`:

--- a/doc/components/multiplier.md
+++ b/doc/components/multiplier.md
@@ -21,7 +21,7 @@ as two `Logic`s and adds the result to a third `Logic` with width
 equal to the sum of the widths of the main inputs. Similar to the `Multiplier`,
 the signs of the operands are either fixed by a parameter,
 or runtime selectable, e.g.:   `signedMultiplicand` or `selectSignedMultiplicand`.
-The output of the multiplier also has a signal telling us if the result is to be
+The output of the multiply-accumulate also has a signal telling us if the result is to be
 treated as signed.
 
 We have a
@@ -33,7 +33,7 @@ The compression tree based arithmetic units are built from a set of components f
 
 ## Carry Save Multiplier
 
-Carry save multiplier is a digital circuit used for performing multiplication operations. It
+The carry-save multiplier is a digital circuit used for performing multiplication operations. It
 is particularly useful in applications that require high speed
 multiplication, such as digital signal processing.
 
@@ -42,7 +42,8 @@ The
 module in ROHD-HCL accept input parameters the clock `clk` signal,
 reset `reset` signal, `Logic`s' a and b as the input pin and the name
 of the module `name`. Note that the width of the inputs must be the
-same or `RohdHclException` will be thrown.
+same or `RohdHclException` will be thrown.  The output latency is equal to the width of the inputs
+given by `latency` on the component.
 
 An example is shown below to multiply two inputs of signals that have 4-bits of width.
 
@@ -103,7 +104,7 @@ The parameters of the
 - An optional `selectSignedMultiplier` control signal which overrides the `signedMultiplier` parameter allowing for runtime control of signed or unsigned operation with the same hardware. `signedMultiplier` must be false if using this control signal.
 - An optional `clk`, as well as `enable` and `reset` that are used to add a pipestage in the `ColumnCompressor` to allow for pipelined operation.
 
-Here is an example of use of the `CompressionTreeMultiplier`:
+Here is an example of use of the `CompressionTreeMultiplier` with one signed input:
 
 ```dart
     const widthA = 6;
@@ -116,7 +117,7 @@ Here is an example of use of the `CompressionTreeMultiplier`:
     b.put(3);
 
     final multiplier =
-        CompressionTreeMultiplier(a, b, radix, signed: true);
+        CompressionTreeMultiplier(a, b, radix, signedMultiplicand: true);
 
     final product = multiplier.product;
 
@@ -145,7 +146,7 @@ The parameters of the
 - An optional `selectSignedAddend` control signal which overrides the `signedAddend` parameter allowing for runtime control of signed or unsigned operation with the same hardware. `signedAddend` must be false if using this control signal.
 - An optional `clk`, as well as `enable` and `reset` that are used to add a pipestage in the `ColumnCompressor` to allow for pipelined operation.
 
-Here is an example of using the `CompressionTreeMultiplyAccumulate`:
+Here is an example of using the `CompressionTreeMultiplyAccumulate` with all inputs as signed:
 
 ```dart
     const widthA = 6;
@@ -159,7 +160,7 @@ Here is an example of using the `CompressionTreeMultiplyAccumulate`:
     b.put(3);
     c.put(5);
 
-    final multiplier = CompressionTreeMultiplyAccumulate(a, b, c, radix, signed: true);
+    final multiplier = CompressionTreeMultiplyAccumulate(a, b, c, radix, signedMultiplicand: true, signedMultiplier: true, signedAddend: true);
 
     final accumulate = multiplier.accumulate;
     

--- a/doc/components/multiplier.md
+++ b/doc/components/multiplier.md
@@ -4,7 +4,12 @@ ROHD-HCL provides an abstract `Multiplier` module which multiplies two
 numbers represented as two `Logic`s, potentially of different widths,
 treating them as either signed (2s complement) or unsigned. It
 produces the product as a `Logic` with width equal to the sum of the
-widths of the inputs. As of now, we have the following implementations
+widths of the inputs. The signs of the operands are either fixed by a parameter,
+or runtime selectable, e.g.:   `signedMultiplicand` or `selectSignedMultiplicand`.
+The output of the multiplier also has a signal telling us if the result is to be
+treated as signed.
+
+As of now, we have the following implementations
 of this abstract `Module`:
 
 - [Carry Save Multiplier](#carry-save-multiplier)
@@ -13,7 +18,13 @@ of this abstract `Module`:
 An additional kind of abstract module provided is a
 `MultiplyAccumulate` module which multiplies two numbers represented
 as two `Logic`s and adds the result to a third `Logic` with width
-equal to the sum of the widths of the main inputs. We have a
+equal to the sum of the widths of the main inputs. Similar to the `Multiplier`,
+the signs of the operands are either fixed by a parameter,
+or runtime selectable, e.g.:   `signedMultiplicand` or `selectSignedMultiplicand`.
+The output of the multiplier also has a signal telling us if the result is to be
+treated as signed.
+
+We have a
 high-performance implementation:
 
 - [Compression Tree Multiply Accumulate](#compression-tree-multiply-accumulate)

--- a/doc/components/multiplier_components.md
+++ b/doc/components/multiplier_components.md
@@ -51,7 +51,7 @@ row  slice  mult
 
 A few things to note: first, that we are negating by 1s complement (so we need a -0) and second, these rows do not add up to (18: 10010). For Booth encoded rows to add up properly, they need to be in 2s complement form, and they need to be sign-extended.
 
- Here is the matrix with crude sign extension (this formatting is available from our `PartialProductGenerator` component). With 2s complementation, and sign bits folded in (note the LSB of each row has a sign term from the previous row), these addends are correctly formed and add to (18: 10010).
+ Here is the matrix with a crude sign extension `brute` (the table formatting is available from our `PartialProductGenerator` component). With 2s complementation, and sign bits folded in (note the LSB of each row has a sign term from the previous row), these addends are correctly formed and add to (18: 10010).
 
 ```text
             7  6  5  4  3  2  1  0  
@@ -64,7 +64,7 @@ A few things to note: first, that we are negating by 1s complement (so we need a
             0  0  0  1  0  0  1  0  : 00010010 = 18 (18)
  ```
 
- There are more compact ways of doing sign-extension which result in far fewer additions. Here is an example of compact sign-extension:  
+ There are more compact ways of doing sign-extension which result in far fewer additions. Here is an example of `compact` sign-extension, where the last row which carries only a sign bit is folded into the previous row:  
 
 ```text
             7  6  5  4  3  2  1  0  
@@ -86,7 +86,7 @@ And of course, with higher radix-encoding, we select more bits at a time from th
             0  0  0  1  0  0  1  0  : 00010010 = 18 (18)
 ```
 
-Note that radix-4 shifts by 2 positions each row, but with only two rows and with sign-extension adding an LSB bit, you only see a shift of 1 in row 1.
+Note that radix-4 shifts by 2 positions each row, but with only two rows and with sign-extension adding an LSB bit to each row, you only see a shift of 1 in row 1, but in a larger example you would see the two-bit shift in the following rows.
 
 ## Partial Product Generator
 
@@ -222,7 +222,7 @@ Finally, we produce the product.
 
 ```dart
     final pp =
-        PartialProductGeneratorCompactRectSignExtension(a, b, RadixEncoder(radix), signed: true);
+        PartialProductGeneratorCompactRectSignExtension(a, b, RadixEncoder(radix), signedMultiplicand: true, signedMultiplier: true);
     final compressor = ColumnCompressor(pp)..compress();
     final adder = ParallelPrefixAdder(
         compressor.exractRow(0), compressor.extractRow(1), BrentKung.new);

--- a/lib/src/arithmetic/carry_save_mutiplier.dart
+++ b/lib/src/arithmetic/carry_save_mutiplier.dart
@@ -42,8 +42,8 @@ class CarrySaveMultiplier extends Multiplier {
   CarrySaveMultiplier(super.a, super.b,
       {required Logic clk,
       required Logic reset,
-      required super.signed,
-      super.name = 'carry_save_multiplier'}) {
+      super.name = 'carry_save_multiplier'})
+      : super(signedMultiplicand: false, signedMultiplier: false) {
     if (a.width != b.width) {
       throw RohdHclException('inputs of a and b should have same width.');
     }

--- a/lib/src/arithmetic/evaluate_partial_product.dart
+++ b/lib/src/arithmetic/evaluate_partial_product.dart
@@ -10,6 +10,22 @@
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
 
+/// The following routines are useful only during testing
+extension TestPartialProductSignage on PartialProductGenerator {
+  /// Return true if multiplicand is truly signed (fixed or runtime)
+  bool isSignedMultiplicand() => (selectSignedMultiplicand == null)
+      ? signedMultiplicand
+      : !selectSignedMultiplicand!.value.isZero;
+
+  /// Return true if multiplier is truly signed (fixed or runtime)
+  bool isSignedMultiplier() => (selectSignedMultiplier == null)
+      ? signedMultiplier
+      : !selectSignedMultiplier!.value.isZero;
+
+  /// Return true if accumulate result is truly signed (fixed or runtime)
+  bool isSignedResult() => isSignedMultiplicand() | isSignedMultiplier();
+}
+
 /// Debug routines for printing out partial product matrix during
 /// simulation with live logic values
 extension EvaluateLivePartialProduct on PartialProductGenerator {

--- a/lib/src/arithmetic/evaluate_partial_product.dart
+++ b/lib/src/arithmetic/evaluate_partial_product.dart
@@ -25,11 +25,9 @@ extension EvaluateLivePartialProduct on PartialProductGenerator {
       }
     }
     final sum = LogicValue.ofBigInt(accum, maxW).toBigInt();
-    return signed
+    return isSignedMultiplicand() | isSignedMultiplier()
         ? sum.toSigned(maxW)
-        : (selectSigned != null && !selectSigned!.value.isZero)
-            ? sum.toSigned(maxW)
-            : sum;
+        : sum;
   }
 
   /// Print out the partial product matrix

--- a/lib/src/arithmetic/multiplicand_selector.dart
+++ b/lib/src/arithmetic/multiplicand_selector.dart
@@ -12,7 +12,7 @@ import 'package:rohd_hcl/rohd_hcl.dart';
 
 /// A class accessing the multiples of the multiplicand at a position
 class MultiplicandSelector {
-  /// radix of the selector
+  /// The radix of the selector
   int radix;
 
   /// The bit shift of the selector (typically overlaps 1)
@@ -21,17 +21,25 @@ class MultiplicandSelector {
   /// New width of partial products generated from the multiplicand
   int get width => multiplicand.width + shift - 1;
 
-  /// Access the multiplicand
+  /// The base multiplicand from which to generate multiples to select.
   Logic multiplicand = Logic();
 
-  /// Place to store multiples of the multiplicand
+  /// Place to store [multiples] of the [multiplicand] (e.g. *1, *2, *-1, *-2..)
   late LogicArray multiples;
 
-  /// Generate required multiples of multiplicand
+  /// Build a [MultiplicandSelector] generationg required [multiples] of
+  /// [multiplicand] to [select] using a [RadixEncoder] argument.
+  ///
+  /// [multiplicand] is base multiplicand multiplied by Booth encodings of
+  /// the [RadixEncoder] during [select].
+  ///
+  /// [signedMultiplicand] generates a fixed signed selector versus using
+  /// [selectSignedMultiplicand] which is a runtime sign selection [Logic]
+  /// in which case [signedMultiplicand] must be false.
   MultiplicandSelector(this.radix, this.multiplicand,
-      {Logic? selectSigned, bool signed = false})
+      {Logic? selectSignedMultiplicand, bool signedMultiplicand = false})
       : shift = log2Ceil(radix) {
-    if (signed && (selectSigned != null)) {
+    if (signedMultiplicand && (selectSignedMultiplicand != null)) {
       throw RohdHclException('sign reconfiguration requires signed=false');
     }
     if (radix > 16) {
@@ -41,15 +49,16 @@ class MultiplicandSelector {
     final numMultiples = radix ~/ 2;
     multiples = LogicArray([numMultiples], width);
     final Logic extendedMultiplicand;
-    if (selectSigned == null) {
-      extendedMultiplicand = signed
+    if (selectSignedMultiplicand == null) {
+      extendedMultiplicand = signedMultiplicand
           ? multiplicand.signExtend(width)
           : multiplicand.zeroExtend(width);
     } else {
       final len = multiplicand.width;
       final sign = multiplicand[len - 1];
       final extension = [
-        for (var i = len; i < width; i++) mux(selectSigned, sign, Const(0))
+        for (var i = len; i < width; i++)
+          mux(selectSignedMultiplicand, sign, Const(0))
       ];
       extendedMultiplicand = (multiplicand.elements + extension).rswizzle();
     }

--- a/lib/src/arithmetic/multiplier.dart
+++ b/lib/src/arithmetic/multiplier.dart
@@ -15,23 +15,53 @@ import 'package:rohd_hcl/src/arithmetic/partial_product_sign_extend.dart';
 
 /// An abstract class for all multiplier implementations.
 abstract class Multiplier extends Module {
-  /// The input to the multiplier pin [a].
+  /// The multiplicand input [a].
   @protected
   late final Logic a;
 
-  /// The input to the multiplier pin [b].
+  /// The multiplier input [b].
   @protected
   late final Logic b;
 
-  /// The multiplier treats operands and output as signed
-  bool signed;
+  /// The multiplier treats input [a] always as a signed input.
+  bool signedMultiplicand;
+
+  /// The multiplier treats input [b] always as a signed input.
+  bool signedMultiplier;
+
+  /// If not null, use this signal to select between signed and unsigned
+  /// multiplicand [a].
+  late Logic? selectSignedMultiplicand;
+
+  /// If not null, use this signal to select between signed and unsigned
+  /// multiplier [b]
+  late Logic? selectSignedMultiplier;
 
   /// The multiplication results of the multiplier.
   Logic get product;
 
   /// Take input [a] and input [b] and return the
   /// [product] of the multiplication result.
-  Multiplier(Logic a, Logic b, {required this.signed, super.name}) {
+  ///
+  /// [signedMultiplicand] parameter configures the multiplicand [a] as a signed
+  /// multiplier (default is unsigned).
+  ///
+  /// [signedMultiplier] parameter configures the multiplier [b] as a signed
+  /// multiplier (default is unsigned).
+  ///
+  /// Optional [selectSignedMultiplicand] allows for runtime configuration of
+  /// signed or unsigned operation, overriding the [signedMultiplicand] static
+  /// configuration.
+  ///
+  /// Optional [selectSignedMultiplier] allows for runtime configuration of
+  /// signed or unsigned operation, overriding the [signedMultiplier] static
+  /// configuration.
+  Multiplier(Logic a, Logic b,
+      {required this.signedMultiplicand,
+      required this.signedMultiplier,
+      this.selectSignedMultiplicand,
+      this.selectSignedMultiplier,
+      super.name}) {
     this.a = addInput('a', a, width: a.width);
     this.b = addInput('b', b, width: b.width);
   }
@@ -51,16 +81,52 @@ abstract class MultiplyAccumulate extends Module {
   @protected
   late final Logic c;
 
-  /// The multiplier treats operands and output as signed
-  bool signed;
+  /// The MAC treats multiplicand [a] as always signed.
+  bool signedMultiplicand;
+
+  /// The MAC treats multiplier [b] as always signed.
+  bool signedMultiplier;
+
+  /// The MAC treats addend [c] as always signed.
+  bool signedAddend;
+
+  /// If not null, use this signal to select between signed and unsigned
+  /// multiplicand [a].
+  late Logic? selectSignedMultiplicand;
+
+  /// If not null, use this signal to select between signed and unsigned
+  /// multiplier [b]
+  late Logic? selectSignedMultiplier;
+
+  /// If not null, use this signal to select between signed and unsigned
+  /// addend [c]
+  late Logic? selectSignedAddend;
 
   /// The multiplication results of the multiply-accumulate.
   Logic get accumulate;
 
   /// Take input [a] and input [b], compute their
   /// product, add input [c] to produce the [accumulate] result.
+  ///
+  /// Optional [selectSignedMultiplicand] allows for runtime configuration of
+  /// signed or unsigned operation, overriding the [signedMultiplicand] static
+  /// configuration.
+  ///
+  /// Optional [selectSignedMultiplier] allows for runtime configuration of
+  /// signed or unsigned operation, overriding the [signedMultiplier] static
+  /// configuration.
+  ///
+  /// Optional [selectSignedAddend] allows for runtime configuration of
+  /// signed or unsigned operation, overriding the [signedAddend] static
+  /// configuration.
   MultiplyAccumulate(Logic a, Logic b, Logic c,
-      {required this.signed, super.name}) {
+      {required this.signedMultiplicand,
+      required this.signedMultiplier,
+      required this.signedAddend,
+      this.selectSignedMultiplicand,
+      this.selectSignedMultiplier,
+      this.selectSignedAddend,
+      super.name}) {
     this.a = addInput('a', a, width: a.width);
     this.b = addInput('b', b, width: b.width);
     this.c = addInput('c', c, width: c.width);
@@ -88,14 +154,22 @@ class CompressionTreeMultiplier extends Multiplier {
   /// Sign extension methodology is defined by the partial product generator
   /// supplied via [ppGen].
   ///
-  /// [a] and [b] are the product terms and they can be different widths
-  /// allowing for rectangular multiplication.
+  /// [a] multiplicand and [b] multiplier are the product terms and they can
+  /// be different widths allowing for rectangular multiplication.
   ///
-  /// [signed] parameter configures the multiplier as a signed multiplier
-  /// (default is unsigned).
+  /// [signedMultiplicand] parameter configures the multiplicand [a] as a signed
+  /// multiplier (default is unsigned).
   ///
-  /// Optional [selectSigned] allows for runtime configuration of signed
-  /// or unsigned operation, overriding the [signed] static configuration.
+  /// [signedMultiplier] parameter configures the multiplier [b] as a signed
+  /// multiplier (default is unsigned).
+  ///
+  /// Optional [selectSignedMultiplicand] allows for runtime configuration of
+  /// signed or unsigned operation, overriding the [signedMultiplicand] static
+  /// configuration.
+  ///
+  /// Optional [selectSignedMultiplier] allows for runtime configuration of
+  /// signed or unsigned operation, overriding the [signedMultiplier] static
+  /// configuration.
   ///
   /// If [clk] is not null then a set of flops are used to latch the output
   /// after compression.  [reset] and [enable] are optional
@@ -105,26 +179,42 @@ class CompressionTreeMultiplier extends Multiplier {
       {this.clk,
       this.reset,
       this.enable,
-      Logic? selectSigned,
+      super.signedMultiplicand = false,
+      super.signedMultiplier = false,
+      super.selectSignedMultiplicand,
+      super.selectSignedMultiplier,
       ParallelPrefix Function(List<Logic>, Logic Function(Logic, Logic))
           ppTree = KoggeStone.new,
       PartialProductGenerator Function(Logic, Logic, RadixEncoder,
-              {required bool signed, Logic? selectSigned})
+              {required bool signedMultiplier,
+              required bool signedMultiplicand,
+              Logic? selectSignedMultiplier,
+              Logic? selectSignedMultiplicand})
           ppGen = PartialProductGeneratorCompactRectSignExtension.new,
-      super.signed = false,
       super.name = 'compression_tree_multiplier'}) {
-    final internalSelectSigned =
-        (selectSigned != null) ? addInput('selectSigned', selectSigned) : null;
-    final iClk = (clk != null) ? addInput('clk', clk!) : null;
-    final iReset = (reset != null) ? addInput('reset', reset!) : null;
-    final iEnable = (enable != null) ? addInput('enable', enable!) : null;
+    selectSignedMultiplicand = (selectSignedMultiplicand != null)
+        ? addInput('selectSignedMultiplicand', selectSignedMultiplicand!)
+        : null;
+    selectSignedMultiplier = (selectSignedMultiplier != null)
+        ? addInput('selectSignedMultiplier', selectSignedMultiplier!)
+        : null;
+    clk = (clk != null) ? addInput('clk', clk!) : null;
+    reset = (reset != null) ? addInput('reset', reset!) : null;
+    enable = (enable != null) ? addInput('enable', enable!) : null;
 
     final product = addOutput('product', width: a.width + b.width);
-    final pp = ppGen(a, b, RadixEncoder(radix),
-        selectSigned: internalSelectSigned, signed: signed);
+    final pp = ppGen(
+      a,
+      b,
+      RadixEncoder(radix),
+      selectSignedMultiplicand: selectSignedMultiplicand,
+      signedMultiplicand: signedMultiplicand,
+      selectSignedMultiplier: selectSignedMultiplier,
+      signedMultiplier: signedMultiplier,
+    );
 
     final compressor =
-        ColumnCompressor(clk: iClk, reset: iReset, enable: iEnable, pp)
+        ColumnCompressor(clk: clk, reset: reset, enable: enable, pp)
           ..compress();
     final adder = ParallelPrefixAdder(
         compressor.extractRow(0), compressor.extractRow(1),
@@ -154,14 +244,29 @@ class CompressionTreeMultiplyAccumulate extends MultiplyAccumulate {
   /// [a] and [b] are the product terms, [c] is the accumulate term which
   /// must be the sum of the widths plus 1.
   ///
-  /// [signed] parameter configures the multiplier as a signed multiplier
-  /// (default is unsigned).
+  /// [signedMultiplicand] parameter configures the multiplicand [a] as
+  /// always signed (default is unsigned).
+  ///
+  /// [signedMultiplier] parameter configures the multiplier [b] as
+  /// always signed (default is unsigned).
+  ///
+  /// [signedAddend] parameter configures the addend [c] as
+  /// always signed (default is unsigned).
   ///
   /// Sign extension methodology is defined by the partial product generator
   /// supplied via [ppGen].
   ///
-  /// Optional [selectSigned] allows for runtime configuration of signed
-  /// or unsigned operation, overriding the [signed] static configuration.
+  /// Optional [selectSignedMultiplicand] allows for runtime configuration of
+  /// signed or unsigned operation, overriding the [signedMultiplicand] static
+  /// configuration.
+  ///
+  /// Optional [selectSignedMultiplier] allows for runtime configuration of
+  /// signed or unsigned operation, overriding the [signedMultiplier] static
+  /// configuration.
+  ///
+  /// Optional [selectSignedAddend] allows for runtime configuration of
+  /// signed or unsigned operation, overriding the [signedAddend] static
+  /// configuration.
   ///
   /// If[clk] is not null then a set of flops are used to latch the output
   /// after compression.  [reset] and [enable] are optional
@@ -171,31 +276,52 @@ class CompressionTreeMultiplyAccumulate extends MultiplyAccumulate {
       {this.clk,
       this.reset,
       this.enable,
-      super.signed = false,
-      Logic? selectSigned,
+      super.signedMultiplicand = false,
+      super.signedMultiplier = false,
+      super.signedAddend = false,
+      super.selectSignedMultiplicand,
+      super.selectSignedMultiplier,
+      super.selectSignedAddend,
       ParallelPrefix Function(List<Logic>, Logic Function(Logic, Logic))
           ppTree = KoggeStone.new,
       PartialProductGenerator Function(Logic, Logic, RadixEncoder,
-              {required bool signed, Logic? selectSigned})
+              {required bool signedMultiplier,
+              required bool signedMultiplicand,
+              Logic? selectSignedMultiplier,
+              Logic? selectSignedMultiplicand})
           ppGen = PartialProductGeneratorCompactRectSignExtension.new,
       super.name = 'compression_tree_mac'}) {
-    final internalSelectSigned =
-        (selectSigned != null) ? addInput('selectSigned', selectSigned) : null;
+    selectSignedMultiplicand = (selectSignedMultiplicand != null)
+        ? addInput('selectSignedMultiplicand', selectSignedMultiplicand!)
+        : null;
+    selectSignedMultiplier = (selectSignedMultiplier != null)
+        ? addInput('selectSignedMultiplier', selectSignedMultiplier!)
+        : null;
+    selectSignedAddend = (selectSignedAddend != null)
+        ? addInput('selectSignedAddend', selectSignedAddend!)
+        : null;
     final iClk = (clk != null) ? addInput('clk', clk!) : null;
     final iReset = (reset != null) ? addInput('reset', reset!) : null;
     final iEnable = (enable != null) ? addInput('enable', enable!) : null;
 
     final accumulate = addOutput('accumulate', width: a.width + b.width + 1);
-    final pp = ppGen(a, b, RadixEncoder(radix),
-        selectSigned: internalSelectSigned, signed: signed);
+    final pp = ppGen(
+      a,
+      b,
+      RadixEncoder(radix),
+      selectSignedMultiplicand: selectSignedMultiplicand,
+      signedMultiplicand: signedMultiplicand,
+      selectSignedMultiplier: selectSignedMultiplier,
+      signedMultiplier: signedMultiplier,
+    );
 
     final lastLength =
         pp.partialProducts[pp.rows - 1].length + pp.rowShift[pp.rows - 1];
 
     final sign = mux(
-        (internalSelectSigned != null)
-            ? internalSelectSigned
-            : (signed ? Const(1) : Const(0)),
+        (selectSignedAddend != null)
+            ? selectSignedAddend!
+            : (signedAddend ? Const(1) : Const(0)),
         c[c.width - 1],
         Const(0));
     final l = [for (var i = 0; i < c.width; i++) c[i]];
@@ -227,31 +353,64 @@ class MutiplyOnly extends MultiplyAccumulate {
   @override
   Logic get accumulate => output('accumulate');
 
+  static String _genName(
+          Multiplier Function(Logic a, Logic b,
+                  {Logic? selectSignedMultiplicand,
+                  Logic? selectSignedMultiplier})
+              fn,
+          Logic a,
+          Logic b,
+          Logic? selectSignedMultiplicand,
+          Logic? selectSignedMultiplier) =>
+      fn(a, b,
+              selectSignedMultiplicand: selectSignedMultiplicand,
+              selectSignedMultiplier: selectSignedMultiplier)
+          .name;
+
   /// Construct a MultiplyAccumulate that only multiplies to enable
   /// using the same tester with zero accumulate addend [c].
-  MutiplyOnly(super.a, super.b, super.c,
-      Multiplier Function(Logic a, Logic b, {Logic? selectSigned}) mulGen,
-      {super.signed = false,
-      Logic? selectSigned}) // Will be overrwridden by multiplyGenerator
-      : super(
-            name: 'Multiply Only: '
-                '${mulGen.call(a, b, selectSigned: selectSigned).name}') {
-    final Logic? internalSelectSigned;
+  MutiplyOnly(
+    super.a,
+    super.b,
+    super.c,
+    Multiplier Function(Logic a, Logic b,
+            {Logic? selectSignedMultiplicand, Logic? selectSignedMultiplier})
+        mulGen, {
+    super.signedMultiplicand = false,
+    super.signedMultiplier = false,
+    super.signedAddend = false,
+    super.selectSignedMultiplicand,
+    super.selectSignedMultiplier,
+    super.selectSignedAddend,
+  }) // Will be overrwridden by multiplyGenerator
+  : super(
+            // ignore: prefer_interpolation_to_compose_strings
+            name: 'Multiply Only: ' +
+                _genName(mulGen, a, b, selectSignedMultiplicand,
+                    selectSignedMultiplier)) {
+    if (selectSignedMultiplicand != null) {
+      selectSignedMultiplicand =
+          addInput('selectSignedMultiplicand', selectSignedMultiplicand!);
+    }
 
-    if (selectSigned != null) {
-      internalSelectSigned = addInput('selectSigned', selectSigned);
-    } else {
-      internalSelectSigned = null;
+    if (selectSignedMultiplier != null) {
+      selectSignedMultiplier =
+          addInput('selectSignedMultiplier', selectSignedMultiplier!);
+    }
+    if (selectSignedAddend != null) {
+      selectSignedAddend = addInput('selectSignedAddend', selectSignedAddend!);
     }
     final accumulate = addOutput('accumulate', width: a.width + b.width + 1);
 
-    final multiply = mulGen(a, b, selectSigned: internalSelectSigned);
-    signed = multiply.signed;
+    final multiply = mulGen(a, b,
+        selectSignedMultiplicand: selectSignedMultiplicand,
+        selectSignedMultiplier: selectSignedMultiplier);
+    final signed = multiply.signedMultiplicand | multiply.signedMultiplier;
 
     accumulate <=
         mux(
-            (internalSelectSigned != null)
-                ? internalSelectSigned
+            (selectSignedMultiplier != null)
+                ? selectSignedMultiplier!
                 : (signed ? Const(1) : Const(0)),
             [multiply.product[multiply.product.width - 1], multiply.product]
                 .swizzle(),

--- a/lib/src/arithmetic/partial_product_generator.dart
+++ b/lib/src/arithmetic/partial_product_generator.dart
@@ -269,16 +269,6 @@ abstract class PartialProductGenerator extends PartialProductArray {
     }
   }
 
-  /// Return true if [multiplicand] is truly signed (fixed or runtime)
-  bool isSignedMultiplicand() => (selectSignedMultiplicand == null)
-      ? signedMultiplicand
-      : !selectSignedMultiplicand!.value.isZero;
-
-  /// Return true if [multiplier] is truly signed (fixed or runtime)
-  bool isSignedMultiplier() => (selectSignedMultiplier == null)
-      ? signedMultiplier
-      : !selectSignedMultiplier!.value.isZero;
-
   /// Helper function for sign extension routines:
   /// For signed operands, set the MSB to [sign], otherwise add this [sign] bit.
   void addStopSign(List<Logic> addend, SignBit sign) {

--- a/lib/src/arithmetic/partial_product_generator.dart
+++ b/lib/src/arithmetic/partial_product_generator.dart
@@ -203,21 +203,21 @@ abstract class PartialProductGenerator extends PartialProductArray {
   late final MultiplicandSelector selector;
 
   /// [multiplicand] operand is always signed
-  late final bool signedMultiplicand;
+  final bool signedMultiplicand;
 
   /// [multiplier] operand is always signed
-  late final bool signedMultiplier;
+  final bool signedMultiplier;
 
   /// Used to avoid sign extending more than once
   bool isSignExtended = false;
 
   /// If not null, use this signal to select between signed and unsigned
   /// [multiplicand].
-  late final Logic? selectSignedMultiplicand;
+  final Logic? selectSignedMultiplicand;
 
   /// If not null, use this signal to select between signed and unsigned
   /// [multiplier].
-  late final Logic? selectSignedMultiplier;
+  final Logic? selectSignedMultiplier;
 
   /// Construct a [PartialProductGenerator] -- the partial product matrix.
   ///
@@ -300,8 +300,8 @@ class PartialProductGeneratorNoneSignExtension extends PartialProductGenerator {
   /// Construct a basic Partial Product Generator
   PartialProductGeneratorNoneSignExtension(
       super.multiplicand, super.multiplier, super.radixEncoder,
-      {required super.signedMultiplicand,
-      required super.signedMultiplier,
+      {super.signedMultiplicand,
+      super.signedMultiplier,
       super.selectSignedMultiplicand,
       super.selectSignedMultiplier});
 

--- a/lib/src/arithmetic/partial_product_sign_extend.dart
+++ b/lib/src/arithmetic/partial_product_sign_extend.dart
@@ -48,7 +48,7 @@ PPGFunction curryPartialProductGenerator(SignExtension signExtension) =>
       SignExtension.compact => PartialProductGeneratorCompactSignExtension.new,
       SignExtension.compactRect =>
         PartialProductGeneratorCompactRectSignExtension.new,
-    } as PPGFunction;
+    };
 
 /// These other sign extensions are for assisting with testing and debugging.
 /// More robust and simpler sign extensions in case

--- a/lib/src/arithmetic/partial_product_sign_extend.dart
+++ b/lib/src/arithmetic/partial_product_sign_extend.dart
@@ -21,7 +21,7 @@ enum SignExtension {
   brute,
 
   /// Extend using stop bits in each row (and an extra row for final sign)
-  stop,
+  stopBits,
 
   /// Fold in last row sign bit (Mohanty, B.K., Choubey, A.)
   compact,
@@ -33,29 +33,24 @@ enum SignExtension {
 /// Used to test different sign extension methods
 typedef PPGFunction = PartialProductGenerator Function(
     Logic a, Logic b, RadixEncoder radixEncoder,
-    {Logic? selectSigned, bool signed});
+    {bool signedMultiplicand,
+    Logic? selectSignedMultiplicand,
+    bool signedMultiplier,
+    Logic? selectSignedMultiplier});
 
 /// Used to test different sign extension methods
 PPGFunction curryPartialProductGenerator(SignExtension signExtension) =>
-    (a, b, encoder, {selectSigned, signed = false}) => switch (signExtension) {
-          SignExtension.none => PartialProductGeneratorNoSignExtension(
-              a, b, encoder,
-              signed: signed),
-          SignExtension.brute => PartialProductGeneratorBruteSignExtension(
-              a, b, encoder,
-              selectSigned: selectSigned, signed: signed),
-          SignExtension.stop => PartialProductGeneratorStopBitsSignExtension(
-              a, b, encoder,
-              selectSigned: selectSigned, signed: signed),
-          SignExtension.compact => PartialProductGeneratorCompactSignExtension(
-              a, b, encoder,
-              signed: signed),
-          SignExtension.compactRect =>
-            PartialProductGeneratorCompactRectSignExtension(a, b, encoder,
-                signed: signed),
-        };
+    switch (signExtension) {
+      SignExtension.none => PartialProductGeneratorNoneSignExtension.new,
+      SignExtension.brute => PartialProductGeneratorBruteSignExtension.new,
+      SignExtension.stopBits =>
+        PartialProductGeneratorStopBitsSignExtension.new,
+      SignExtension.compact => PartialProductGeneratorCompactSignExtension.new,
+      SignExtension.compactRect =>
+        PartialProductGeneratorCompactRectSignExtension.new,
+    } as PPGFunction;
 
-/// These other sign extensions are for asssisting with testing and debugging.
+/// These other sign extensions are for assisting with testing and debugging.
 /// More robust and simpler sign extensions in case
 /// complex sign extension routines obscure other bugs.
 
@@ -65,13 +60,18 @@ class PartialProductGeneratorBruteSignExtension
   /// Construct a brute-force sign extending Partial Product Generator
   PartialProductGeneratorBruteSignExtension(
       super.multiplicand, super.multiplier, super.radixEncoder,
-      {super.signed, super.selectSigned, super.name = 'brute'});
+      {super.signedMultiplicand,
+      super.signedMultiplier,
+      super.selectSignedMultiplicand,
+      super.selectSignedMultiplier,
+      super.name = 'brute'});
 
   /// Fully sign extend the PP array: useful for reference only
   @override
   void signExtend() {
-    if (signed && (selectSigned != null)) {
-      throw RohdHclException('sign reconfiguration requires signed=false');
+    if (signedMultiplicand && (selectSignedMultiplicand != null)) {
+      throw RohdHclException('multiplicand sign reconfiguration requires '
+          'signedMultiplicand=false');
     }
     if (isSignExtended) {
       throw RohdHclException('Partial Product array already sign-extended');
@@ -80,12 +80,11 @@ class PartialProductGeneratorBruteSignExtension
     final signs = [for (var r = 0; r < rows; r++) encoder.getEncoding(r).sign];
     for (var row = 0; row < rows; row++) {
       final addend = partialProducts[row];
-      // final sign = SignBit(signed ? addend.last : signs[row]);
       final Logic sign;
-      if (selectSigned != null) {
-        sign = mux(selectSigned!, addend.last, signs[row]);
+      if (selectSignedMultiplicand != null) {
+        sign = mux(selectSignedMultiplicand!, addend.last, signs[row]);
       } else {
-        sign = signed ? addend.last : signs[row];
+        sign = signedMultiplicand ? addend.last : signs[row];
       }
       addend.addAll(List.filled((rows - row) * shift, SignBit(sign)));
       if (row > 0) {
@@ -108,7 +107,11 @@ class PartialProductGeneratorCompactSignExtension
   /// Construct a compact sign extending Partial Product Generator
   PartialProductGeneratorCompactSignExtension(
       super.multiplicand, super.multiplier, super.radixEncoder,
-      {super.signed, super.selectSigned, super.name = 'compact'});
+      {super.signedMultiplicand,
+      super.selectSignedMultiplicand,
+      super.signedMultiplier,
+      super.selectSignedMultiplier,
+      super.name = 'compact'});
 
   /// Sign extend the PP array using stop bits without adding a row.
   @override
@@ -117,8 +120,9 @@ class PartialProductGeneratorCompactSignExtension
     // Mohanty, B.K., Choubey, A. Efficient Design for Radix-8 Booth Multiplier
     // and Its Application in Lifting 2-D DWT. Circuits Syst Signal Process 36,
     // 1129–1149 (2017). https://doi.org/10.1007/s00034-016-0349-9
-    if (signed && (selectSigned != null)) {
-      throw RohdHclException('sign reconfiguration requires signed=false');
+    if (signedMultiplicand && (selectSignedMultiplicand != null)) {
+      throw RohdHclException('multiplicand sign reconfiguration requires '
+          'signedMultiplicand=false');
     }
     if (isSignExtended) {
       throw RohdHclException('Partial Product array already sign-extended');
@@ -129,7 +133,7 @@ class PartialProductGeneratorCompactSignExtension
     final firstAddend = partialProducts[0];
     final lastAddend = partialProducts[lastRow];
 
-    final firstRowQStart = selector.width - (signed ? 1 : 0);
+    final firstRowQStart = selector.width - (signedMultiplicand ? 1 : 0);
     final lastRowSignPos = shift * lastRow;
     final alignRow0Sign = firstRowQStart - lastRowSignPos;
 
@@ -137,10 +141,18 @@ class PartialProductGeneratorCompactSignExtension
 
     final propagate =
         List.generate(rows, (i) => List.filled(0, Logic(), growable: true));
+
     for (var row = 0; row < rows; row++) {
       propagate[row].add(signs[row]);
       for (var col = 0; col < 2 * (shift - 1); col++) {
         propagate[row].add(partialProducts[row][col]);
+      }
+      // Last row has extend sign propagation to Q start
+      if (row == lastRow) {
+        var col = 2 * (shift - 1);
+        while (propagate[lastRow].length <= alignRow0Sign) {
+          propagate[lastRow].add(SignBit(partialProducts[row][col++]));
+        }
       }
       for (var col = 1; col < propagate[row].length; col++) {
         propagate[row][col] = propagate[row][col] & propagate[row][col - 1];
@@ -154,6 +166,9 @@ class PartialProductGeneratorCompactSignExtension
       }
       m[row].addAll(List.filled(shift - 1, Logic()));
     }
+    while (m[lastRow].length < alignRow0Sign) {
+      m[lastRow].add(Logic());
+    }
 
     for (var i = shift - 1; i < m[lastRow].length; i++) {
       m[lastRow][i] = lastAddend[i] ^
@@ -164,15 +179,16 @@ class PartialProductGeneratorCompactSignExtension
     for (var row = 0; row < lastRow; row++) {
       remainders[row] = propagate[row][shift - 1];
     }
-    remainders[lastRow] <= propagate[lastRow][alignRow0Sign];
+    remainders[lastRow] <= propagate[lastRow][max(alignRow0Sign, 0)];
 
     // Compute Sign extension for row==0
-    // final firstSign = !signed ? signs[0] : firstAddend.last;
     final Logic firstSign;
-    if (selectSigned == null) {
-      firstSign = signed ? SignBit(firstAddend.last) : SignBit(signs[0]);
+    if (selectSignedMultiplicand == null) {
+      firstSign =
+          signedMultiplicand ? SignBit(firstAddend.last) : SignBit(signs[0]);
     } else {
-      firstSign = SignBit(mux(selectSigned!, firstAddend.last, signs[0]));
+      firstSign =
+          SignBit(mux(selectSignedMultiplicand!, firstAddend.last, signs[0]));
     }
     final q = [
       firstSign ^ remainders[lastRow],
@@ -183,7 +199,7 @@ class PartialProductGeneratorCompactSignExtension
     for (var row = 0; row < rows; row++) {
       final addend = partialProducts[row];
       if (row > 0) {
-        final mLimit = (row == lastRow) ? 2 * (shift - 1) : shift - 1;
+        final mLimit = (row == lastRow) ? alignRow0Sign : shift - 1;
         for (var i = 0; i < mLimit; i++) {
           addend[i] = m[row][i];
         }
@@ -196,7 +212,7 @@ class PartialProductGeneratorCompactSignExtension
         for (var i = 0; i < shift - 1; i++) {
           firstAddend[i] = m[0][i];
         }
-        if (!signed) {
+        if (!signedMultiplicand) {
           firstAddend.add(q[0]);
         } else {
           firstAddend.last = q[0];
@@ -216,17 +232,23 @@ class PartialProductGeneratorStopBitsSignExtension
   /// Construct a stop bits sign extending Partial Product Generator
   PartialProductGeneratorStopBitsSignExtension(
       super.multiplicand, super.multiplier, super.radixEncoder,
-      {super.signed, super.selectSigned, super.name = 'stop_bits'});
+      {super.signedMultiplicand,
+      super.selectSignedMultiplicand,
+      super.signedMultiplier,
+      super.selectSignedMultiplier,
+      super.name = 'stop_bits'});
 
   /// Sign extend the PP array using stop bits.
   /// If possible, fold the final carry into another row (only when rectangular
   /// enough that carry bit lands outside another row).
   /// This technique can then be combined with a first-row extension technique
   /// for folding in the final carry.
+  ///
   @override
   void signExtend() {
-    if (signed && (selectSigned != null)) {
-      throw RohdHclException('sign reconfiguration requires signed=false');
+    if (signedMultiplicand && (selectSignedMultiplicand != null)) {
+      throw RohdHclException('multiplicand sign reconfiguration requires '
+          'signedMultiplicand=false');
     }
     if (isSignExtended) {
       throw RohdHclException('Partial Product array already sign-extended');
@@ -246,15 +268,16 @@ class PartialProductGeneratorStopBitsSignExtension
     for (var row = 0; row < rows; row++) {
       final addend = partialProducts[row];
       final Logic sign;
-      if (selectSigned != null) {
-        sign = mux(selectSigned!, addend.last, signs[row]);
+      if (selectSignedMultiplicand != null) {
+        sign = mux(selectSignedMultiplicand!, addend.last, signs[row]);
       } else {
-        sign = signed ? addend.last : signs[row];
+        sign = signedMultiplicand ? addend.last : signs[row];
       }
       if (row == 0) {
-        if (!signed) {
+        if (!signedMultiplicand) {
           addend.addAll(List.filled(shift, SignBit(sign)));
         } else {
+          // either is signed?
           addend.addAll(List.filled(shift - 1, SignBit(sign))); // signed only?
         }
         addend.add(SignBit(~sign, inverted: true));
@@ -275,7 +298,7 @@ class PartialProductGeneratorStopBitsSignExtension
             finalCarryPos - (extensionRow.length + rowShift[finalCarryRow]),
             Const(0)))
         ..add(SignBit(signs[rows - 1]));
-    } else if (signed | (selectSigned != null)) {
+    } else if (signedMultiplier | (selectSignedMultiplier != null)) {
       // Create an extra row to hold the final carry bit
       partialProducts
           .add(List.filled(selector.width, Const(0), growable: true));
@@ -284,7 +307,8 @@ class PartialProductGeneratorStopBitsSignExtension
 
       // Hack for radix-2
       if (shift == 1) {
-        partialProducts.last.last = ~partialProducts.last.last;
+        addStopSignFlip(
+            partialProducts.last, SignBit(Const(1), inverted: true));
       }
     }
   }
@@ -296,7 +320,11 @@ class PartialProductGeneratorCompactRectSignExtension
   /// Construct a compact rect sign extending Partial Product Generator
   PartialProductGeneratorCompactRectSignExtension(
       super.multiplicand, super.multiplier, super.radixEncoder,
-      {required super.signed, super.selectSigned, super.name = 'compact_rect'});
+      {super.signedMultiplicand,
+      super.signedMultiplier,
+      super.selectSignedMultiplicand,
+      super.selectSignedMultiplier,
+      super.name = 'compact_rect'});
 
   /// Sign extend the PP array using stop bits without adding a row
   /// This routine works with different widths of multiplicand/multiplier,
@@ -304,8 +332,9 @@ class PartialProductGeneratorCompactRectSignExtension
   /// Desmond A. Kirkpatrick
   @override
   void signExtend() {
-    if (signed && (selectSigned != null)) {
-      throw RohdHclException('sign reconfiguration requires signed=false');
+    if (signedMultiplicand && (selectSignedMultiplicand != null)) {
+      throw RohdHclException('multiplicand sign reconfiguration requires '
+          'signedMultiplicand=false');
     }
     if (isSignExtended) {
       throw RohdHclException('Partial Product array already sign-extended');
@@ -316,7 +345,7 @@ class PartialProductGeneratorCompactRectSignExtension
     final firstAddend = partialProducts[0];
     final lastAddend = partialProducts[lastRow];
 
-    final firstRowQStart = selector.width - (signed ? 1 : 0);
+    final firstRowQStart = selector.width - (signedMultiplicand ? 1 : 0);
     final lastRowSignPos = shift * lastRow;
 
     final align = firstRowQStart - lastRowSignPos;
@@ -354,6 +383,7 @@ class PartialProductGeneratorCompactRectSignExtension
       }
       m[row].addAll(List.filled(shift - 1, Logic()));
     }
+
     while (m[lastRow].length < align) {
       m[lastRow].add(Logic());
     }
@@ -392,14 +422,13 @@ class PartialProductGeneratorCompactRectSignExtension
 
     // Insert the lastRow sign:  Either in firstRow's Q if there is a
     // collision or in another row if it lands beyond the Q sign extension
-
-    // final firstSign = signed ? SignBit(firstAddend.last) : SignBit(signs[0]);
-
     final Logic firstSign;
-    if (selectSigned == null) {
-      firstSign = signed ? SignBit(firstAddend.last) : SignBit(signs[0]);
+    if (selectSignedMultiplicand == null) {
+      firstSign =
+          signedMultiplicand ? SignBit(firstAddend.last) : SignBit(signs[0]);
     } else {
-      firstSign = SignBit(mux(selectSigned!, firstAddend.last, signs[0]));
+      firstSign =
+          SignBit(mux(selectSignedMultiplicand!, firstAddend.last, signs[0]));
     }
     final lastSign = SignBit(remainders[lastRow]);
     // Compute Sign extension MSBs for firstRow
@@ -423,13 +452,14 @@ class PartialProductGeneratorCompactRectSignExtension
     if (-align >= q.length) {
       q.last = SignBit(~firstSign, inverted: true);
     }
-
     addStopSign(firstAddend, SignBit(q[0]));
     firstAddend.addAll(q.getRange(1, q.length));
 
     if (-align >= q.length) {
-      final finalCarryRelPos =
-          lastRowSignPos - selector.width - shift + (signed ? 1 : 0);
+      final finalCarryRelPos = lastRowSignPos -
+          selector.width -
+          shift +
+          (signedMultiplicand ? 1 : 0);
       final finalCarryRow = (finalCarryRelPos / shift).floor();
       final curRowLength =
           partialProducts[finalCarryRow].length + rowShift[finalCarryRow];

--- a/lib/src/component_config/components/config_carry_save_multiplier.dart
+++ b/lib/src/component_config/components/config_carry_save_multiplier.dart
@@ -16,20 +16,16 @@ class CarrySaveMultiplierConfigurator extends Configurator {
   /// A knob controlling the width of the inputs to a [CarrySaveMultiplier].
   final IntConfigKnob logicWidthKnob = IntConfigKnob(value: 8);
 
-  /// A knob controling the sign of a [CarrySaveMultiplier]
-  final signChoiceKnob = ChoiceConfigKnob([false, true], value: false);
-
   @override
   final String name = 'Carry Save Multiplier';
 
   @override
   CarrySaveMultiplier createModule() => CarrySaveMultiplier(
       Logic(width: logicWidthKnob.value), Logic(width: logicWidthKnob.value),
-      clk: Logic(), reset: Logic(), signed: true);
+      clk: Logic(), reset: Logic());
 
   @override
   late final Map<String, ConfigKnob<dynamic>> knobs = UnmodifiableMapView({
     'Width': logicWidthKnob,
-    'Sign': signChoiceKnob,
   });
 }

--- a/lib/src/component_config/components/config_compression_tree_multiplier.dart
+++ b/lib/src/component_config/components/config_compression_tree_multiplier.dart
@@ -40,6 +40,14 @@ class CompressionTreeMultiplierConfigurator extends Configurator {
   /// Controls the width of the multiplier.!
   final IntConfigKnob multiplierWidthKnob = IntConfigKnob(value: 5);
 
+  /// A knob controlling the sign of the multiplicand
+  final ChoiceConfigKnob<dynamic> signMultiplicandValueKnob =
+      ChoiceConfigKnob(['unsigned', 'signed', 'selected'], value: 'unsigned');
+
+  /// A knob controlling the sign of the multiplier
+  final ChoiceConfigKnob<dynamic> signMultiplierValueKnob =
+      ChoiceConfigKnob(['unsigned', 'signed', 'selected'], value: 'unsigned');
+
   /// Controls whether the adder is pipelined
   final ToggleConfigKnob pipelinedKnob = ToggleConfigKnob(value: false);
 
@@ -49,6 +57,12 @@ class CompressionTreeMultiplierConfigurator extends Configurator {
       Logic(name: 'a', width: multiplicandWidthKnob.value),
       Logic(name: 'b', width: multiplierWidthKnob.value),
       radixKnob.value,
+      signedMultiplicand: signMultiplicandValueKnob.value == 'signed',
+      signedMultiplier: signMultiplierValueKnob.value == 'signed',
+      selectSignedMultiplicand:
+          signMultiplicandValueKnob.value == 'selected' ? Logic() : null,
+      selectSignedMultiplier:
+          signMultiplierValueKnob.value == 'selected' ? Logic() : null,
       ppTree: generatorMap[prefixTreeKnob.value]!);
 
   @override
@@ -56,7 +70,9 @@ class CompressionTreeMultiplierConfigurator extends Configurator {
     'Tree type': prefixTreeKnob,
     'Radix': radixKnob,
     'Multiplicand width': multiplicandWidthKnob,
+    'Multiplicand sign': signMultiplicandValueKnob,
     'Multiplier width': multiplierWidthKnob,
+    'Multiplier sign': signMultiplierValueKnob,
     'Pipelined': pipelinedKnob,
   });
 

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -50,3 +50,16 @@ extension LogicValueMajority on LogicValue {
     return result;
   }
 }
+
+/// This extension will provide conversion to Signed or Unsigned BigInt
+extension SignedBigInt on BigInt {
+  /// Convert a BigInt to Signed when [signed] is true
+  BigInt toCondSigned(int width, {bool signed = false}) =>
+      signed ? toSigned(width) : toUnsigned(width);
+
+  /// Construct a Signed BigInt from an int when [signed] is true
+  static BigInt fromSignedInt(int value, int width, {bool signed = false}) =>
+      signed
+          ? BigInt.from(value).toSigned(width)
+          : BigInt.from(value).toUnsigned(width);
+}

--- a/test/arithmetic/addend_compressor_test.dart
+++ b/test/arithmetic/addend_compressor_test.dart
@@ -8,8 +8,6 @@
 // Author: Desmond Kirkpatrick <desmond.a.kirkpatrick@intel.com>
 
 import 'dart:async';
-import 'dart:io';
-import 'dart:math';
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
 import 'package:rohd_hcl/src/arithmetic/evaluate_compressor.dart';
@@ -17,6 +15,8 @@ import 'package:rohd_hcl/src/arithmetic/evaluate_partial_product.dart';
 import 'package:rohd_hcl/src/arithmetic/partial_product_sign_extend.dart';
 import 'package:test/test.dart';
 
+/// This [CompressorTestMod] module is used to test instantiation, where we can
+/// catch trace errors (IO not added) not found in a simple test instantiation.
 class CompressorTestMod extends Module {
   late final PartialProductGenerator pp;
 
@@ -37,7 +37,7 @@ class CompressorTestMod extends Module {
     }
 
     pp = PartialProductGeneratorCompactRectSignExtension(a, b, encoder,
-        signed: signed);
+        signedMultiplicand: signed, signedMultiplier: signed);
     compressor = ColumnCompressor(pp, clk: clk);
     compressor.compress();
     final r0 = addOutput('r0', width: compressor.columns.length);
@@ -48,158 +48,9 @@ class CompressorTestMod extends Module {
   }
 }
 
-void testCompressionExhaustive(PartialProductGenerator pp) {
-  final widthX = pp.selector.multiplicand.width;
-  final widthY = pp.encoder.multiplier.width;
-
-  final signed =
-      (pp.selectSigned == null) ? pp.signed : !pp.selectSigned!.value.isZero;
-
-  final limitX = pow(2, widthX);
-  final limitY = pow(2, widthY);
-  for (var i = 0; i < limitX; i++) {
-    for (var j = 0; j < limitY; j++) {
-      final X = signed
-          ? BigInt.from(i).toSigned(widthX)
-          : BigInt.from(i).toUnsigned(widthX);
-      final Y = signed
-          ? BigInt.from(j).toSigned(widthY)
-          : BigInt.from(j).toUnsigned(widthY);
-
-      checkCompressor(pp, X, Y);
-    }
-  }
-}
-
-void testCompressionRandom(PartialProductGenerator pp, int iterations) {
-  final widthX = pp.selector.multiplicand.width;
-  final widthY = pp.encoder.multiplier.width;
-
-  final value = Random(47);
-  for (var i = 0; i < iterations; i++) {
-    final X = pp.signed
-        ? value.nextLogicValue(width: widthX).toBigInt().toSigned(widthX)
-        : value.nextLogicValue(width: widthX).toBigInt().toUnsigned(widthX);
-    final Y = pp.signed
-        ? value.nextLogicValue(width: widthY).toBigInt().toSigned(widthY)
-        : value.nextLogicValue(width: widthY).toBigInt().toUnsigned(widthY);
-
-    checkCompressor(pp, X, Y);
-  }
-}
-
-void checkCompressor(PartialProductGenerator pp, BigInt X, BigInt Y) {
-  final widthX = pp.selector.multiplicand.width;
-  final widthY = pp.encoder.multiplier.width;
-  final compressor = ColumnCompressor(pp);
-
-  final product = X * Y;
-
-  pp.multiplicand.put(X);
-  pp.multiplier.put(Y);
-  final value = pp.evaluate();
-  expect(value, equals(product),
-      reason: 'Fail: $X * $Y: $value '
-          'vs expected $product'
-          '\n$pp');
-  final evaluateValue = compressor.evaluate();
-  if (evaluateValue.$1 != product) {
-    stdout
-      ..write('Fail:  $X)$widthX] * $Y[$widthY]: $evaluateValue '
-          'vs expected $product\n')
-      ..write(pp);
-  }
-  compressor.compress();
-  final compressedValue = compressor.evaluate().$1;
-  expect(compressedValue, equals(product),
-      reason: 'Fail:  $X[$widthX] * $Y[$widthY]: $compressedValue '
-          'vs expected $product'
-          '\n$pp');
-  final compressedLogicValue = compressor.evaluate(logic: true).$1;
-  expect(compressedLogicValue, equals(product),
-      reason: 'Fail:  $X[$widthX] * $Y[$widthY]: $compressedLogicValue '
-          'vs expected $product'
-          '\n$pp');
-
-  final a = compressor.extractRow(0);
-  final b = compressor.extractRow(1);
-
-  final adder = ParallelPrefixAdder(a, b);
-  final adderValue =
-      adder.sum.value.toBigInt().toSigned(compressor.columns.length);
-  expect(adderValue, equals(product),
-      reason: 'Fail:  $X[$widthX] * $Y[$widthY]: '
-          '$adderValue vs expected $product'
-          '\n$pp');
-}
-
 void main() {
   tearDown(() async {
     await Simulator.reset();
-  });
-  test('ColumnCompressor: random evaluate: square radix-4, just CompactRect',
-      () async {
-    for (final signed in [false, true]) {
-      for (var radix = 4; radix < 8; radix *= 2) {
-        final encoder = RadixEncoder(radix);
-        // stdout.write('encoding with radix=$radix\n');
-        final shift = log2Ceil(encoder.radix);
-        for (var width = shift + 1; width < 2 * shift + 1; width++) {
-          for (final signExtension in SignExtension.values) {
-            if (signExtension != SignExtension.compactRect) {
-              continue;
-            }
-            final ppg = curryPartialProductGenerator(signExtension);
-            for (final useSelect in [false, true]) {
-              final PartialProductGenerator pp;
-              if (useSelect) {
-                final selectSigned = Logic();
-                // ignore: cascade_invocations
-                selectSigned.put(signed ? 1 : 0);
-                pp = ppg(Logic(name: 'X', width: width),
-                    Logic(name: 'Y', width: width), encoder,
-                    selectSigned: selectSigned);
-              } else {
-                pp = ppg(Logic(name: 'X', width: width),
-                    Logic(name: 'Y', width: width), encoder,
-                    signed: signed);
-              }
-              testCompressionRandom(pp, 10);
-            }
-          }
-        }
-      }
-    }
-  });
-  test('Column Compressor: single compressor evaluate', () async {
-    const widthX = 6;
-    const widthY = 9;
-    final a = Logic(name: 'a', width: widthX);
-    final b = Logic(name: 'b', width: widthY);
-
-    const av = 4;
-    const bv = 14;
-    for (final signed in [true, false]) {
-      final bA = signed
-          ? BigInt.from(av).toSigned(widthX)
-          : BigInt.from(av).toUnsigned(widthX);
-      final bB = signed
-          ? BigInt.from(bv).toSigned(widthY)
-          : BigInt.from(bv).toUnsigned(widthY);
-
-      // Set these so that printing inside module build will have Logic values
-      a.put(bA);
-      b.put(bB);
-      const radix = 2;
-      final encoder = RadixEncoder(radix);
-      final pp = PartialProductGeneratorCompactRectSignExtension(a, b, encoder,
-          signed: signed);
-      expect(pp.evaluate(), equals(BigInt.from(av * bv)));
-      final compressor = ColumnCompressor(pp);
-      expect(compressor.evaluate().$1, equals(BigInt.from(av * bv)));
-      compressor.compress();
-      expect(compressor.evaluate().$1, equals(BigInt.from(av * bv)));
-    }
   });
 
   test('Column Compressor: evaluate flopped', () async {
@@ -211,8 +62,8 @@ void main() {
 
     var av = 3;
     const bv = 6;
-    var bA = BigInt.from(av).toSigned(widthX);
-    final bB = BigInt.from(bv).toSigned(widthY);
+    var bA = SignedBigInt.fromSignedInt(av, widthX, signed: true);
+    final bB = SignedBigInt.fromSignedInt(bv, widthY, signed: true);
 
     // Set these so that printing inside module build will have Logic values
     a.put(bA);
@@ -236,79 +87,36 @@ void main() {
         equals(BigInt.from(av * bv)));
     await Simulator.endSimulation();
   });
-
-  test('example multiplier', () async {
-    const widthX = 10;
-    const widthY = 10;
-    final a = Logic(name: 'a', width: widthX);
-    final b = Logic(name: 'b', width: widthY);
-
-    const av = 37;
-    const bv = 6;
-    for (final signed in [false, true]) {
-      final bA = signed
-          ? BigInt.from(av).toSigned(widthX)
-          : BigInt.from(av).toUnsigned(widthX);
-      final bB = signed
-          ? BigInt.from(bv).toSigned(widthY)
-          : BigInt.from(bv).toUnsigned(widthY);
-
-      // Set these so that printing inside module build will have Logic values
-      a.put(bA);
-      b.put(bB);
-      const radix = 8;
-      final encoder = RadixEncoder(radix);
-      final selectSigned = Logic();
-      // ignore: cascade_invocations
-      selectSigned.put(signed ? 1 : 0);
-      final pp = PartialProductGeneratorStopBitsSignExtension(a, b, encoder,
-          // final pp = PartialProductGeneratorCompactRectSignExtension(a, b,
-          // encoder,
-          // signed: signed);
-          selectSigned: selectSigned);
-
-      expect(pp.evaluate(), equals(bA * bB));
-      final compressor = ColumnCompressor(pp)..compress();
-      expect(compressor.evaluate().$1, equals(bA * bB));
-    }
-  });
-
-  test('single sign agnostic compressor evaluate', () async {
+  test('Column Compressor: single compressor evaluate', () async {
     const widthX = 3;
     const widthY = 3;
     final a = Logic(name: 'a', width: widthX);
     final b = Logic(name: 'b', width: widthY);
 
-    const av = 1;
-    const bv = 4;
-    for (final signed in [false, true]) {
-      final bA = signed
-          ? BigInt.from(av).toSigned(widthX)
-          : BigInt.from(av).toUnsigned(widthX);
-      final bB = signed
-          ? BigInt.from(bv).toSigned(widthY)
-          : BigInt.from(bv).toUnsigned(widthY);
+    const av = -3;
+    const bv = -3;
+    for (final signed in [true, false]) {
+      final bA = SignedBigInt.fromSignedInt(av, widthX, signed: signed);
+      final bB = SignedBigInt.fromSignedInt(bv, widthY, signed: signed);
 
+      // Set these so that printing inside module build will have Logic values
+      a.put(bA);
+      b.put(bB);
       const radix = 4;
       final encoder = RadixEncoder(radix);
-      // for (final useSelect in [true]) {
       for (final useSelect in [false, true]) {
-        // Set these so that printing inside module build will have Logic values
-        a.put(bA);
-        b.put(bB);
-
-        final selectSigned = Logic();
-        // ignore: cascade_invocations
-        selectSigned.put(signed ? 1 : 0);
-
-        final pp = useSelect
-            ? PartialProductGeneratorBruteSignExtension(a, b, encoder,
-                selectSigned: selectSigned)
-            : PartialProductGeneratorBruteSignExtension(a, b, encoder,
-                signed: signed);
-
-        // print(pp.representation());
-
+        final selectSignedMultiplicand = useSelect ? Logic() : null;
+        final selectSignedMultiplier = useSelect ? Logic() : null;
+        if (useSelect) {
+          selectSignedMultiplicand!.put(signed ? 1 : 0);
+          selectSignedMultiplier!.put(signed ? 1 : 0);
+        }
+        final pp = PartialProductGeneratorCompactRectSignExtension(
+            a, b, encoder,
+            signedMultiplicand: !useSelect & signed,
+            signedMultiplier: !useSelect & signed,
+            selectSignedMultiplicand: selectSignedMultiplicand,
+            selectSignedMultiplier: selectSignedMultiplier);
         expect(pp.evaluate(), equals(bA * bB));
         final compressor = ColumnCompressor(pp);
         expect(compressor.evaluate().$1, equals(bA * bB));

--- a/test/arithmetic/carry_save_multiplier_test.dart
+++ b/test/arithmetic/carry_save_multiplier_test.dart
@@ -25,8 +25,7 @@ void main() {
     final clk = SimpleClockGenerator(10).clk;
     final reset = Logic(name: 'reset');
 
-    expect(
-        () => CarrySaveMultiplier(clk: clk, reset: reset, signed: true, a, b),
+    expect(() => CarrySaveMultiplier(clk: clk, reset: reset, a, b),
         throwsA(const TypeMatcher<RohdHclException>()));
   });
 
@@ -37,7 +36,7 @@ void main() {
     final reset = Logic(name: 'reset');
     final clk = SimpleClockGenerator(10).clk;
 
-    final csm = CarrySaveMultiplier(clk: clk, reset: reset, signed: true, a, b);
+    final csm = CarrySaveMultiplier(clk: clk, reset: reset, a, b);
 
     await csm.build();
 

--- a/test/arithmetic/multiplier_test.dart
+++ b/test/arithmetic/multiplier_test.dart
@@ -20,12 +20,12 @@ extension TestMultiplierSignage on Multiplier {
   /// Return true if multiplicand [a] is truly signed (fixed or runtime)
   bool isSignedMultiplicand() => (selectSignedMultiplicand == null)
       ? signedMultiplicand
-      : selectSignedMultiplicand!.value.isZero;
+      : !selectSignedMultiplicand!.value.isZero;
 
   /// Return true if multiplier [b] is truly signed (fixed or runtime)
   bool isSignedMultiplier() => (selectSignedMultiplier == null)
       ? signedMultiplier
-      : selectSignedMultiplier!.value.isZero;
+      : !selectSignedMultiplier!.value.isZero;
 
   /// Return true if accumulate result is truly signed (fixed or runtime)
   bool isSignedResult() => isSignedMultiplicand() | isSignedMultiplier();

--- a/test/configurator_test.dart
+++ b/test/configurator_test.dart
@@ -136,8 +136,8 @@ void main() {
     test('should return both Int knobs to be configured', () {
       final multiplier = CarrySaveMultiplierConfigurator();
       expect(multiplier.knobs.values.whereType<IntConfigKnob>().length, 1);
-      expect(multiplier.knobs.values.whereType<ChoiceConfigKnob<bool>>().length,
-          1);
+      expect(
+          multiplier.knobs.values.whereType<ConfigKnob<dynamic>>().length, 1);
     });
 
     test('should return rtl code when invoke generate() with default value',

--- a/test/configurator_test.dart
+++ b/test/configurator_test.dart
@@ -136,8 +136,6 @@ void main() {
     test('should return both Int knobs to be configured', () {
       final multiplier = CarrySaveMultiplierConfigurator();
       expect(multiplier.knobs.values.whereType<IntConfigKnob>().length, 1);
-      expect(
-          multiplier.knobs.values.whereType<ConfigKnob<dynamic>>().length, 1);
     });
 
     test('should return rtl code when invoke generate() with default value',
@@ -157,6 +155,42 @@ void main() {
 
       expect(multiplierDefaultRTL.length > multiplierCustomRTL.length,
           equals(true));
+    });
+  });
+
+  group('compression_tree_multiplier', () {
+    test('should return Compression Tree Multiplier for component name', () {
+      final multiplier = CompressionTreeMultiplierConfigurator();
+      expect(multiplier.name, 'Comp. Tree Multiplier');
+    });
+
+    test('should return both Int knobs to be configured', () {
+      final multiplier = CompressionTreeMultiplierConfigurator();
+      expect(multiplier.knobs.values.whereType<IntConfigKnob>().length, 2);
+      expect(
+          multiplier.knobs.values.whereType<ChoiceConfigKnob<dynamic>>().length,
+          4);
+      expect(multiplier.knobs.values.whereType<ToggleConfigKnob>().length, 1);
+    });
+
+    test('should return rtl code when invoke generate() with default value',
+        () async {
+      final multiplier = CompressionTreeMultiplierConfigurator();
+      expect(
+          await multiplier.generateSV(), contains('CompressionTreeMultiplier'));
+    });
+
+    test('should return rtl code when invoke generate() with custom value',
+        () async {
+      final multiplierDefault = CompressionTreeMultiplierConfigurator();
+      final multiplierCustom = CompressionTreeMultiplierConfigurator();
+      multiplierCustom.knobs.values.toList()[1].value = 4;
+
+      final multiplierDefaultRTL = await multiplierDefault.generateSV();
+      final multiplierCustomRTL = await multiplierCustom.generateSV();
+
+      expect(multiplierDefaultRTL.length > multiplierCustomRTL.length,
+          equals(false));
     });
   });
 


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

This updates the compression tree mulitplication components to fully handle variations in sign for multiplicand and multiplier.
This includes separate fixed signs for both, as well as a select signal for both and all valid combinations.  When select is enabled for an operand, the fixed sign input parameter is false..

The core parameters are:
- signedMultiplicand
- signedMultiplier
- selectSignedMultiplicand
- selectSignedMultiplier

These parameters are enabled for the CompressionTreeMultiplier and CompressionTreeMultiplyAccumulate.

Major cleanup of the testing routines to ensure solid coverage and reduce testing time.

## Related Issue(s)

#143 

## Testing

Sweep testing of the PartialProductGenerators for all combinations of signed/selected operands and all sign extension methods, across all radix settings.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

Yes.  The signed parameter is now split into signedMultiplicand and signedMultiplier.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Yes.  Documentation for the Multipliers is updated.  The configurator is also updated.
