### PR TITLE
remove redundant assignment statement in fpadder

### DIFF
--- a/lib/src/arithmetic/floating_point/floating_point_adder_round.dart
+++ b/lib/src/arithmetic/floating_point/floating_point_adder_round.dart
@@ -154,7 +154,6 @@ class FloatingPointAdderRound extends Module {
 
     final smallerFullRPath =
         [smallShift, Const(0, width: extendWidthRPath)].swizzle();
-    smallerFullRPath <= smallerFullRPath.withSet(extendWidthRPath, smallShift);
 
     final smallerAlignRPath = smallerFullRPath >>> exponentSubtractor.sum;
     final smallerOperandRPath = smallerAlignRPath.slice(


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

A redundant assignment statement in the FP adder was caught by more checks in the baseline ROHD code.

## Related Issue(s)

None.

## Testing

Ran the suite of FP regressions.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No change in behavior or API.
