### PR TITLE
Compatibility with ROHD v0.6.0, plus some minor fixes

### DIFF
--- a/confapp/pubspec.yaml
+++ b/confapp/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  rohd: ^0.5.0
+  rohd: ^0.6.0
   rohd_hcl:
     git: 
       url: https://github.com/intel/rohd-hcl

--- a/example/clock_gating_example.dart
+++ b/example/clock_gating_example.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // clock_gating_example.dart
@@ -61,7 +61,7 @@ class CounterWithSimpleClockGate extends Module {
 }
 
 /// A reference to an external SystemVerilog clock-gating macro.
-class CustomClockGateMacro extends Module with CustomSystemVerilog {
+class CustomClockGateMacro extends Module with SystemVerilog {
   Logic get gatedClk => output('gatedClk');
 
   CustomClockGateMacro({
@@ -84,13 +84,13 @@ class CustomClockGateMacro extends Module with CustomSystemVerilog {
   // define how to instantiate this custom SystemVerilog
   @override
   String instantiationVerilog(String instanceType, String instanceName,
-          Map<String, String> inputs, Map<String, String> outputs) =>
+          Map<String, String> ports) =>
       '`CUSTOM_CLOCK_GATE('
-      '${outputs['gatedClk']}, '
-      '${inputs['clk']}, '
-      '${inputs['en']}, '
-      '${inputs['override']}, '
-      '${inputs['another_override']}'
+      '${ports['gatedClk']}, '
+      '${ports['clk']}, '
+      '${ports['en']}, '
+      '${ports['override']}, '
+      '${ports['another_override']}'
       ')';
 }
 

--- a/lib/src/arithmetic/carry_save_mutiplier.dart
+++ b/lib/src/arithmetic/carry_save_mutiplier.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // carry_save_multiplier.dart
@@ -100,7 +100,6 @@ class CarrySaveMultiplier extends Multiplier {
             ],
       ],
       reset: reset,
-      resetValues: {product: Const(0)},
     );
 
     final nBitAdder = RippleCarryAdder(

--- a/lib/src/arithmetic/sign_magnitude_adder.dart
+++ b/lib/src/arithmetic/sign_magnitude_adder.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // sign_magnitude_adder.dart
@@ -29,11 +29,12 @@ class SignMagnitudeAdder extends Adder {
   /// the argument with a negative sign.
   bool largestMagnitudeFirst;
 
-  /// [SignMagnitudeAdder] constructor with an adder functor [adderGen]
-  ///Inputs are (sign, magnitude) pairs: ([aSign], [a]) and ([bSign], [b]).
-  /// If the caller can guarantee that the larger magnitude value
-  ///  is provided first in [a], then they can set [largestMagnitudeFirst]
-  /// too 'true' to avoid a comparator.
+  /// [SignMagnitudeAdder] constructor with an adder functor [adderGen].
+  ///
+  /// Inputs are (sign, magnitude) pairs: ([aSign], [a]) and ([bSign], [b]). If
+  /// the caller can guarantee that the larger magnitude value is provided first
+  /// in [a], then they can set [largestMagnitudeFirst] too 'true' to avoid a
+  /// comparator.
   // TODO(desmonddak): this adder may need a carry-in for rounding
   SignMagnitudeAdder(this.aSign, super.a, this.bSign, super.b,
       Adder Function(Logic, Logic, {Logic? carryIn}) adderGen,

--- a/lib/src/clock_gating.dart
+++ b/lib/src/clock_gating.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // clock_gating.dart
@@ -146,9 +146,9 @@ class ClockGate extends Module {
   // override the addInput and addOutput functions for uniquification purposes
 
   @override
-  Logic addInput(String name, Logic x, {int width = 1}) {
+  Logic addInput(String name, Logic source, {int width = 1}) {
     _uniquifier.getUniqueName(initialName: name, reserved: true);
-    return super.addInput(name, x, width: width);
+    return super.addInput(name, source, width: width);
   }
 
   @override

--- a/lib/src/count.dart
+++ b/lib/src/count.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // count.dart
@@ -18,7 +18,11 @@ class Count extends Module {
   late Logic _output;
 
   /// [index] is an getter for output of Count
+  @Deprecated('Use `count` instead')
   Logic get index => _output;
+
+  /// The resulting count.
+  Logic get count => _output;
 
   /// [Count] `1` or `0`.
   ///
@@ -26,7 +30,7 @@ class Count extends Module {
   /// if [countOne] is `false` will count `0`
   Count(Logic bus, {bool countOne = true}) {
     bus = addInput('bus', bus, width: bus.width);
-    Logic count = Const(0, width: max(1, log2Ceil(bus.width) + 1));
+    Logic count = Const(0, width: max(1, log2Ceil(bus.width + 1)));
     for (var i = 0; i < bus.width; i++) {
       count += (countOne ? bus[i] : ~bus[i]).zeroExtend(count.width);
     }

--- a/lib/src/find.dart
+++ b/lib/src/find.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // find.dart
@@ -52,7 +52,7 @@ class Find extends Module {
       final count = Count(bus.getRange(0, i + 1), countOne: countOne);
 
       // Below code will make `n` comparable to `count`
-      var paddedCountValue = count.index;
+      var paddedCountValue = count.count;
       var paddedNValue = (n ?? Const(0)) + 1;
 
       if (paddedNValue.width < paddedCountValue.width) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,8 +12,8 @@ environment:
 dependencies:
   collection: ^1.18.0
   meta: ^1.9.1
-  rohd: ^0.5.3
-  rohd_vf: ^0.5.0
+  rohd: ^0.6.0
+  rohd_vf: ^0.6.0
 
 dev_dependencies:
   logging: ^1.0.1

--- a/test/clock_gating_test.dart
+++ b/test/clock_gating_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // clock_gating_test.dart
@@ -14,7 +14,7 @@ import 'package:rohd_hcl/src/clock_gating.dart';
 import 'package:rohd_vf/rohd_vf.dart';
 import 'package:test/test.dart';
 
-class CustomClockGateMacro extends Module with CustomSystemVerilog {
+class CustomClockGateMacro extends Module with SystemVerilog {
   Logic get gatedClk => output('gatedClk');
 
   CustomClockGateMacro({
@@ -36,13 +36,13 @@ class CustomClockGateMacro extends Module with CustomSystemVerilog {
 
   @override
   String instantiationVerilog(String instanceType, String instanceName,
-          Map<String, String> inputs, Map<String, String> outputs) =>
+          Map<String, String> ports) =>
       '`CUSTOM_CLOCK_GATE('
-      '${outputs['gatedClk']}, '
-      '${inputs['clk']}, '
-      '${inputs['en']}, '
-      '${inputs['override']}, '
-      '${inputs['another_override']}'
+      '${ports['gatedClk']}, '
+      '${ports['clk']}, '
+      '${ports['en']}, '
+      '${ports['override']}, '
+      '${ports['another_override']}'
       ')';
 }
 

--- a/test/count_test.dart
+++ b/test/count_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // count_test.dart
@@ -16,33 +16,42 @@ void main() {
   test('count all 1s', () {
     final bus = Const(bin('01101'), width: 5);
     final mod = Count(bus);
-    expect(mod.index.value.toInt(), 3);
+    expect(mod.count.value.toInt(), 3);
   });
 
   test('count all 1s when input is all 1s', () {
     final bus = Const(bin('11111'), width: 5);
     final mod = Count(bus);
-    expect(mod.index.value.toInt(), 5);
+    expect(mod.count.value.toInt(), 5);
   });
   test('count all 1s when input is all 0s', () {
     final bus = Const(bin('00000'), width: 5);
     final mod = Count(bus);
-    expect(mod.index.value.toInt(), 0);
+    expect(mod.count.value.toInt(), 0);
   });
 
   test('count all 0s', () {
     final bus = Const(bin('001101'), width: 6);
     final mod = Count(bus, countOne: false);
-    expect(mod.index.value.toInt(), 3);
+    expect(mod.count.value.toInt(), 3);
   });
   test('count all 0s when input is all 1s', () {
     final bus = Const(bin('11111'), width: 5);
     final mod = Count(bus, countOne: false);
-    expect(mod.index.value.toInt(), 0);
+    expect(mod.count.value.toInt(), 0);
   });
   test('count all 0s when input is all 0s', () {
     final bus = Const(bin('00000'), width: 5);
     final mod = Count(bus, countOne: false);
-    expect(mod.index.value.toInt(), 5);
+    expect(mod.count.value.toInt(), 5);
+  });
+
+  test('width of count output is correct', () {
+    expect(Count(Const(0, width: 1)).count.width, 1);
+    expect(Count(Const(0, width: 2)).count.width, 2);
+    expect(Count(Const(0, width: 3)).count.width, 2);
+    expect(Count(Const(0, width: 4)).count.width, 3);
+    expect(Count(Const(0, width: 7)).count.width, 3);
+    expect(Count(Const(0, width: 8)).count.width, 4);
   });
 }

--- a/tool/gh_actions/generate_documentation.sh
+++ b/tool/gh_actions/generate_documentation.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2022-2025 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 # generate_documentation.sh
@@ -17,7 +17,9 @@ set -euo pipefail
 #   https://github.com/dart-lang/dartdoc/issues/2907
 #   https://github.com/dart-lang/dartdoc/issues/1959
 
-# Disabling --validate-links due to https://github.com/dart-lang/dartdoc/issues/3584
+# Disabling --validate-links due to
+#   https://github.com/dart-lang/dartdoc/issues/3584
+#   https://github.com/dart-lang/dartdoc/issues/3939
 # output=$(dart doc --validate-links 2>&1 | tee)
 output=$(dart doc 2>&1 | tee)
 


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

- Adds compatibility with ROHD v0.6.0 and ROHD-VF v0.6.0
- Some minor documentation updates
- Fixed the `Count` module's output API and width calculation

## Related Issue(s)

N/A

## Testing

Existing tests, plus a new one for count

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

Yes!

Minimum ROHD and ROHD-VF versions are now 0.6.0

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
