### PR TITLE
`FloatingPointUtilities` extraction for `swap`/`sort`, and parameterization of some FP components

### DIFF
--- a/lib/src/arithmetic/floating_point/floating_point.dart
+++ b/lib/src/arithmetic/floating_point/floating_point.dart
@@ -8,3 +8,4 @@ export 'floating_point_converter.dart';
 export 'floating_point_multiplier.dart';
 export 'floating_point_multiplier_simple.dart';
 export 'floating_point_rounding.dart';
+export 'floating_point_utilities.dart';

--- a/lib/src/arithmetic/floating_point/floating_point_adder.dart
+++ b/lib/src/arithmetic/floating_point/floating_point_adder.dart
@@ -47,7 +47,8 @@ abstract class FloatingPointAdder<FpType extends FloatingPoint> extends Module {
   late final FpType b;
 
   /// getter for the computed [FloatingPoint] output.
-  late final FpType sum = (a.clone(name: 'sum') as FpType)..gets(output('sum'));
+  late final FloatingPoint sum = (a.clone(name: 'sum') as FpType)
+    ..gets(output('sum'));
 
   /// Add two floating point numbers [a] and [b], returning result in [sum].
   /// - [clk], [reset], [enable] are optional inputs to control a pipestage

--- a/lib/src/arithmetic/floating_point/floating_point_adder_round.dart
+++ b/lib/src/arithmetic/floating_point/floating_point_adder_round.dart
@@ -13,7 +13,8 @@ import 'package:rohd_hcl/rohd_hcl.dart';
 
 /// An adder module for variable FloatingPoint type with rounding.
 // This is a Seidel/Even adder, dual-path implementation.
-class FloatingPointAdderRound extends FloatingPointAdder {
+class FloatingPointAdderRound<FpType extends FloatingPoint>
+    extends FloatingPointAdder<FpType> {
   /// Add two floating point numbers [a] and [b], returning result in [sum].
   /// [subtract] is an optional Logic input to do subtraction
   /// [adderGen] is an adder generator to be used in the primary adder
@@ -55,7 +56,7 @@ class FloatingPointAdderRound extends FloatingPointAdder {
     final delta = exponentSubtractor.sum.named('expDelta');
 
     // Seidel: (sl, el, fl) = larger; (ss, es, fs) = smaller
-    final (larger, smaller) = swap(signDelta, (a, b));
+    final (larger, smaller) = FloatingPointUtilities.swap(signDelta, (a, b));
 
     final fl = mux(
       larger.isNormal,

--- a/lib/src/arithmetic/floating_point/floating_point_adder_simple.dart
+++ b/lib/src/arithmetic/floating_point/floating_point_adder_simple.dart
@@ -37,7 +37,7 @@ class FloatingPointAdderSimple<FpType extends FloatingPoint>
         name: 'sum');
     output('sum') <= outputSum;
 
-    final (larger, smaller) = FloatingPointUtilities.sortFp((super.a, super.b));
+    final (larger, smaller) = FloatingPointUtilities.sort((super.a, super.b));
 
     final isInf = (larger.isAnInfinity | smaller.isAnInfinity).named('isInf');
     final isNaN = (larger.isNaN |

--- a/lib/src/arithmetic/floating_point/floating_point_adder_simple.dart
+++ b/lib/src/arithmetic/floating_point/floating_point_adder_simple.dart
@@ -12,7 +12,8 @@ import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
 
 /// An adder module for FloatingPoint values
-class FloatingPointAdderSimple extends FloatingPointAdder {
+class FloatingPointAdderSimple<FpType extends FloatingPoint>
+    extends FloatingPointAdder<FpType> {
   /// Add two floating point numbers [a] and [b], returning result in [sum].
   /// - [adderGen] is an adder generator to be used in the primary adder
   /// functions.
@@ -36,7 +37,7 @@ class FloatingPointAdderSimple extends FloatingPointAdder {
         name: 'sum');
     output('sum') <= outputSum;
 
-    final (larger, smaller) = sortFp((super.a, super.b));
+    final (larger, smaller) = FloatingPointUtilities.sortFp((super.a, super.b));
 
     final isInf = (larger.isAnInfinity | smaller.isAnInfinity).named('isInf');
     final isNaN = (larger.isNaN |

--- a/lib/src/arithmetic/floating_point/floating_point_multiplier.dart
+++ b/lib/src/arithmetic/floating_point/floating_point_multiplier.dart
@@ -12,7 +12,8 @@ import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
 
 /// An abstract API for floating-point multipliers.
-abstract class FloatingPointMultiplier extends Module {
+abstract class FloatingPointMultiplier<FpInType extends FloatingPoint>
+    extends Module {
   /// Width of the output exponent field.
   late final int exponentWidth;
 
@@ -36,11 +37,11 @@ abstract class FloatingPointMultiplier extends Module {
 
   /// The multiplicand [a].
   @protected
-  late final FloatingPoint a;
+  late final FpInType a;
 
   /// The multiplier [b].
   @protected
-  late final FloatingPoint b;
+  late final FpInType b;
 
   /// The computed [FloatingPoint] product of [a] * [b].
   late final FloatingPoint product =
@@ -60,7 +61,7 @@ abstract class FloatingPointMultiplier extends Module {
   /// (only inserted if [clk] is provided).
   /// - [ppGen] is the type of [ParallelPrefix] used in internal adder
   /// generation.
-  FloatingPointMultiplier(FloatingPoint a, FloatingPoint b,
+  FloatingPointMultiplier(FpInType a, FpInType b,
       {Logic? clk,
       Logic? reset,
       Logic? enable,
@@ -98,8 +99,10 @@ abstract class FloatingPointMultiplier extends Module {
     this.enable = (enable != null) ? addInput('enable', enable) : enable;
     this.reset = (reset != null) ? addInput('clk', reset) : reset;
 
-    this.a = a.clone(name: 'a')..gets(addInput('a', a, width: a.width));
-    this.b = b.clone(name: 'b')..gets(addInput('b', b, width: b.width));
+    this.a = (a.clone(name: 'a') as FpInType)
+      ..gets(addInput('a', a, width: a.width));
+    this.b = (b.clone(name: 'b') as FpInType)
+      ..gets(addInput('b', b, width: b.width));
   }
 
   /// Pipelining helper that uses the context for signals clk/enable/reset

--- a/lib/src/arithmetic/floating_point/floating_point_multiplier_simple.dart
+++ b/lib/src/arithmetic/floating_point/floating_point_multiplier_simple.dart
@@ -11,7 +11,8 @@ import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
 
 /// A multiplier module for FloatingPoint logic.
-class FloatingPointMultiplierSimple extends FloatingPointMultiplier {
+class FloatingPointMultiplierSimple<FpInType extends FloatingPoint>
+    extends FloatingPointMultiplier<FpInType> {
   /// Multiply two FloatingPoint numbers [a] and [b], returning result
   /// in [product] FloatingPoint.
   /// - [multGen] is a multiplier generator to be used in the mantissa

--- a/lib/src/arithmetic/floating_point/floating_point_utilities.dart
+++ b/lib/src/arithmetic/floating_point/floating_point_utilities.dart
@@ -1,0 +1,52 @@
+// Copyright (C) 2024-2025 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// floating_point_utilities.dart
+// Utilities for dealing with floating point.
+//
+// 2024 August 30
+// Author: Desmond A Kirkpatrick <desmond.a.kirkpatrick@intel.com
+
+import 'package:rohd/rohd.dart';
+import 'package:rohd_hcl/rohd_hcl.dart';
+
+/// A utility class for floating point operations.
+abstract class FloatingPointUtilities {
+  /// Swap two [FloatingPoint] structures based on a conditional [swap].
+  static (FpType, FpType) swap<FpType extends FloatingPoint>(
+      Logic swap, (FpType, FpType) toSwap) {
+    final in1 = toSwap.$1.named('swapIn1_${toSwap.$1.name}');
+    final in2 = toSwap.$2.named('swapIn2_${toSwap.$2.name}');
+
+    FpType clone({String? name}) => toSwap.$1.clone(name: name) as FpType;
+
+    final out1 = mux(swap, in2, in1).named('swapOut1');
+    final out2 = mux(swap, in1, in2).named('swapOut2');
+    final first = clone(name: 'swapOut1')..gets(out1);
+    final second = clone(name: 'swapOut2')..gets(out2);
+    return (first, second);
+  }
+
+  /// Sort two [FloatingPoint]s and swap them if necessary so that the larger
+  /// of the two is the first element in the returned tuple.
+  static (FpType larger, FpType smaller) sortFp<FpType extends FloatingPoint>(
+      (FpType, FpType) toSort) {
+    final ae = toSort.$1.exponent;
+    final be = toSort.$2.exponent;
+    final am = toSort.$1.mantissa;
+    final bm = toSort.$2.mantissa;
+    final doSwap = (ae.lt(be) |
+            (ae.eq(be) & am.lt(bm)) |
+            ((ae.eq(be) & am.eq(bm)) & toSort.$1.sign))
+        .named('doSwap');
+
+    final swapped = swap(doSwap, toSort);
+
+    FpType clone({String? name}) => toSort.$1.clone(name: name) as FpType;
+
+    final larger = clone(name: 'larger')..gets(swapped.$1);
+    final smaller = clone(name: 'smaller')..gets(swapped.$2);
+
+    return (larger, smaller);
+  }
+}

--- a/lib/src/arithmetic/floating_point/floating_point_utilities.dart
+++ b/lib/src/arithmetic/floating_point/floating_point_utilities.dart
@@ -29,7 +29,7 @@ abstract class FloatingPointUtilities {
 
   /// Sort two [FloatingPoint]s and swap them if necessary so that the larger
   /// of the two is the first element in the returned tuple.
-  static (FpType larger, FpType smaller) sortFp<FpType extends FloatingPoint>(
+  static (FpType larger, FpType smaller) sort<FpType extends FloatingPoint>(
       (FpType, FpType) toSort) {
     final ae = toSort.$1.exponent;
     final be = toSort.$2.exponent;

--- a/lib/src/arithmetic/signals/floating_point_logics/floating_point_logic.dart
+++ b/lib/src/arithmetic/signals/floating_point_logics/floating_point_logic.dart
@@ -13,7 +13,7 @@ import 'package:meta/meta.dart';
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
 
-/// Flexible floating point logic representation
+/// Flexible floating point logic representation.
 class FloatingPoint extends LogicStructure {
   /// unsigned, biased binary [exponent]
   final Logic exponent;


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

The `swap` and `sort` routines for `FloatingPoint` signals are useful beyond just inside of ROHD-HCL `FloatingPointAdder`s, so this PR extracts them as static functions to a separate `FloatingPointUtilities` class.

Additionally, add some parameterization on inputs for floating point adders and multipliers.  Held off on parameterization of the outputs, since that could cause some backwards incompatible problems when we upgrade so that outputs can be different types than the inputs (as is already the case for multipliers).

## Related Issue(s)

N/A

## Testing

Existing tests should cover, this is not a functional change

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
