### PR TITLE
Add Find N'th Pattern component

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -24,7 +24,7 @@ Some in-development items will have opened issues, as well. Feel free to create 
 - [Find](./components/find.md)
   - [Find N'th bit (0 or 1) from the start/end](./components/find.md#find-nth)
   - [Extrema](./components/extrema.md)
-  - Find N'th pattern from the start/end
+  - [Find N'th pattern from the start/end](./components/find.md#find-nth-pattern)
 - Count
   - [Count bit occurrence](./components/count.md)
   - Count pattern occurrence

--- a/doc/README.md
+++ b/doc/README.md
@@ -24,9 +24,9 @@ Some in-development items will have opened issues, as well. Feel free to create 
 - [Find](./components/find.md)
   - [Find N'th bit (0 or 1) from the start/end](./components/find.md#find-nth)
   - [Extrema](./components/extrema.md)
-- [Find Pattern](./components/find_pattern.md)
-  - [Find Pattern from Start/End](./components/find_pattern.md#find-pattern-from-startend)
-  - [Find N'th Pattern from Start/End](./components/find_pattern.md#find-nth-pattern-from-startend)
+  - [Find Pattern](./components/find_pattern.md)
+    - [Find Pattern from Start/End](./components/find_pattern.md#find-pattern-from-startend)
+    - [Find N'th Pattern from Start/End](./components/find_pattern.md#find-nth-pattern-from-startend)
 - Count
   - [Count bit occurrence](./components/count.md)
   - Count pattern occurrence

--- a/doc/README.md
+++ b/doc/README.md
@@ -24,7 +24,9 @@ Some in-development items will have opened issues, as well. Feel free to create 
 - [Find](./components/find.md)
   - [Find N'th bit (0 or 1) from the start/end](./components/find.md#find-nth)
   - [Extrema](./components/extrema.md)
-  - [Find N'th pattern from the start/end](./components/find.md#find-nth-pattern)
+- [Find Pattern](./components/find_pattern.md)
+  - [Find Pattern from Start/End](./components/find_pattern.md#find-pattern-from-startend)
+  - [Find N'th Pattern from Start/End](./components/find_pattern.md#find-nth-pattern-from-startend)
 - Count
   - [Count bit occurrence](./components/count.md)
   - Count pattern occurrence

--- a/doc/components/find.md
+++ b/doc/components/find.md
@@ -36,3 +36,14 @@ To find the nth occurrence just pass in `bus` along with Logic value `n` passed 
 ### Find Nth Zero
 
 To find the nth occurrence just pass in `bus` along with Logic value `n` passed in as an argument. In addition to finding occurrence of Zero (`0`), set the argument `countOne` to `false`.
+
+## Find Nth Pattern
+To find the nth pattern occurrence just pass in `bus` along with Logic pattern `n` passed in as an argument. Note that the pattern needs to be smaller than bus.
+
+### Find Nth Pattern from start
+To find the nth pattern occurrence just pass in `bus` along with Logic pattern `n` passed in as an argument. Note that the pattern needs to be smaller than bus.
+In addition to finding occurrence of pattern `n`, set the argument `start` as true.
+
+### Find Nth Pattern from end
+To find the nth pattern occurrence just pass in `bus` along with Logic pattern `n` passed in as an argument. Note that the pattern needs to be smaller than bus.
+In addition to finding occurrence of pattern `n`, set the argument `start` as false.

--- a/doc/components/find.md
+++ b/doc/components/find.md
@@ -38,12 +38,12 @@ To find the nth occurrence just pass in `bus` along with Logic value `n` passed 
 To find the nth occurrence just pass in `bus` along with Logic value `n` passed in as an argument. In addition to finding occurrence of Zero (`0`), set the argument `countOne` to `false`.
 
 ## Find Nth Pattern
-To find the nth pattern occurrence just pass in `bus` along with Logic pattern `n` passed in as an argument. Note that the pattern needs to be smaller than bus.
+To find the nth pattern occurrence just pass in `bus` along with Logic pattern `pattern` passed in as an argument. Note that the `pattern` needs to be smaller than `bus`.
 
 ### Find Nth Pattern from start
-To find the nth pattern occurrence just pass in `bus` along with Logic pattern `n` passed in as an argument. Note that the pattern needs to be smaller than bus.
-In addition to finding occurrence of pattern `n`, set the argument `start` as true.
+To find the nth pattern occurrence just pass in `bus` along with Logic pattern `pattern` passed in as an argument. Note that the `pattern` needs to be smaller than `bus`.
+In addition to finding occurrence of `pattern`, set the argument `start` as true.
 
 ### Find Nth Pattern from end
-To find the nth pattern occurrence just pass in `bus` along with Logic pattern `n` passed in as an argument. Note that the pattern needs to be smaller than bus.
-In addition to finding occurrence of pattern `n`, set the argument `start` as false.
+To find the nth pattern occurrence just pass in `bus` along with Logic pattern `pattern` passed in as an argument. Note that the `pattern` needs to be smaller than `bus`.
+In addition to finding occurrence of `pattern`, set the argument `start` as false.

--- a/doc/components/find.md
+++ b/doc/components/find.md
@@ -36,14 +36,3 @@ To find the nth occurrence just pass in `bus` along with Logic value `n` passed 
 ### Find Nth Zero
 
 To find the nth occurrence just pass in `bus` along with Logic value `n` passed in as an argument. In addition to finding occurrence of Zero (`0`), set the argument `countOne` to `false`.
-
-## Find Nth Pattern
-To find the nth pattern occurrence just pass in `bus` along with Logic pattern `pattern` passed in as an argument. Note that the `pattern` needs to be smaller than `bus`.
-
-### Find Nth Pattern from start
-To find the nth pattern occurrence just pass in `bus` along with Logic pattern `pattern` passed in as an argument. Note that the `pattern` needs to be smaller than `bus`.
-In addition to finding occurrence of `pattern`, set the argument `start` as true.
-
-### Find Nth Pattern from end
-To find the nth pattern occurrence just pass in `bus` along with Logic pattern `pattern` passed in as an argument. Note that the `pattern` needs to be smaller than `bus`.
-In addition to finding occurrence of `pattern`, set the argument `start` as false.

--- a/doc/components/find_pattern.md
+++ b/doc/components/find_pattern.md
@@ -15,7 +15,7 @@ To find the index of a fixed-width `pattern` in a `bus`. By default, it will fin
 
 `index` and `n` is zero-based index, where first index and first occurrence is defined `0`.
 
-If `pattern` is not found in the `bus`, output `index` will be undefined, and if `generateError` is `true`, output `error` will be generated and is equal to `1`.
+If `pattern` is not found in the `bus`, output `index` will be `0`, and if `generateError` is `true`, output `error` will be generated and is equal to `1`.
 
 ## Find Pattern from Start/End
 
@@ -81,4 +81,4 @@ expect(findPattern.index.value.toInt(), equals(6));
 
 ### Pattern not Found in Bus
 
-If `pattern` is not found in the Logic `bus`, output `index` will be `undefined` (i.e., `b'zzzz`). To generate the output pin `error`, set the `generateError` boolean to `true`. By default, `generateError` is `false`. If pattern is not found, `error` will be `1`.
+If `pattern` is not found in the Logic `bus`, output `index` will be `0`. To generate the output pin `error`, set the `generateError` boolean to `true`. By default, `generateError` is `false`. If pattern is not found, `error` will be `1`.

--- a/doc/components/find_pattern.md
+++ b/doc/components/find_pattern.md
@@ -5,7 +5,7 @@ ROHD-HCL comes with a FindPattern.  The detailed API docs are available [here](h
 A FindPattern will search for first/nth occurrence of a fixed-width `pattern` within a given Logic `bus`.
 
 It takes a Binary Logic `bus` and finds the position of the desired `pattern` within the `bus`. A FindPattern function without any constructor arguments will find the first pattern from the start of the bus.
-That is to say, By default a FindPattern will go for finding the first occurrence when no `n` is passed. In addition, with `fromStart` which is set as `true` by default to search for the pattern from the start of the `bus`. Both boolean `fromStart` and Logic `n` are optional. Logic `bus` and Logic `pattern` are mandatory argument.
+That is to say, by default a FindPattern will go for finding the first occurrence when no `n` is passed. In addition, with `fromStart` which is set as `true` by default to search for the pattern from the start of the `bus`. Both boolean `fromStart` and Logic `n` are optional. Logic `bus` and Logic `pattern` are mandatory argument.
 
 FindPattern has an output pin named as `index`, for the index position on the occurrence searched taken from the LSB (Least Significant Bit) or MSB (Most Significant Bit) depending on the search direction defined with boolean `fromStart`.
 
@@ -38,7 +38,7 @@ expect(findPattern.index.value.toInt(), equals(4));
 
 To get the `index` location of the pattern from end of the bus (MSB), pass the Logic `bus`, Logic `pattern` and set the `fromStart` to `false`. Ensure that the `pattern` width is smaller than the `bus` width. By default, it will find the first occurrence of the `pattern` from end of the `bus`.
 
-For example, if `bus` is `11101010` and `pattern` is `11101`, the output `index` will return `40` as the first occurrence of the pattern is found at the 0th-bit of the bus from the MSB.
+For example, if `bus` is `11101010` and `pattern` is `11101`, the output `index` will return `0` as the first occurrence of the pattern is found at the 0th-bit of the bus from the MSB.
 
 ```dart
 final bus = Const(bin('11101010'), width: 8);
@@ -79,6 +79,13 @@ final findPattern = FindPattern(bus, pattern, fromStart: false, n: n);
 expect(findPattern.index.value.toInt(), equals(6));
 ```
 
-### Pattern not Found in Bus
+## Pattern not Found in Bus
 
 If `pattern` is not found in the Logic `bus`, output `index` will be `0`. To generate the output pin `error`, set the `generateError` boolean to `true`. By default, `generateError` is `false`. If pattern is not found, `error` will be `1`.
+
+```dart
+final bus = Const(bin('00000000'), width: 8);
+final pattern = Const(bin('111'), width: 3);
+final findPattern = FindPattern(bus, pattern, generateError: true);
+expect(findPattern.error!.value.toInt(), equals(1));
+```

--- a/doc/components/find_pattern.md
+++ b/doc/components/find_pattern.md
@@ -1,0 +1,84 @@
+# Find Pattern
+
+ROHD-HCL comes with a FindPattern.  The detailed API docs are available [here](https://intel.github.io/rohd-hcl/rohd_hcl/rohd_hcl-library.html).
+
+A FindPattern will search for first/nth occurrence of a fixed-width `pattern` within a given Logic `bus`.
+
+It takes a Binary Logic `bus` and finds the position of the desired `pattern` within the `bus`. A FindPattern function without any constructor arguments will find the first pattern from the start of the bus.
+That is to say, By default a FindPattern will go for finding the first occurrence when no `n` is passed. In addition, with `fromStart` which is set as `true` by default to search for the pattern from the start of the `bus`. Both boolean `fromStart` and Logic `n` are optional. Logic `bus` and Logic `pattern` are mandatory argument.
+
+FindPattern has an output pin named as `index`, for the index position on the occurrence searched taken from the LSB (Least Significant Bit) or MSB (Most Significant Bit) depending on the search direction defined with boolean `fromStart`.
+
+## Implementation
+
+To find the index of a fixed-width `pattern` in a `bus`. By default, it will find the first occurrence of the pattern from the start of the bus. The search direction is defined by `fromStart` argument. To find `index` of the second or third occurrence, define the `n` value to the desired number of occurrences.
+
+`index` and `n` is zero-based index, where first index and first occurrence is defined `0`.
+
+If `pattern` is not found in the `bus`, output `index` will be undefined, and if `generateError` is `true`, output `error` will be generated and is equal to `1`.
+
+## Find Pattern from Start/End
+
+To find the `index` of the first occurrence of specific `pattern` in a `bus` from start/end.
+
+### Find Pattern from Start
+
+To get the `index` location of the pattern from start of the bus, simply pass the Logic `bus` and `pattern`. Ensure that the `pattern` width is smaller than the `bus` width. By default, it will find the first occurrence of the `pattern` from start of the `bus`.
+
+For example, if `bus` is `10100001` and `pattern` is `1010`, the output `index` will return `4` as the first occurrence of the pattern is found at the 5th-bit of the bus from the LSB.
+
+```dart
+final bus = Const(bin('10100001'), width: 8);
+final pattern = Const(bin('1010'), width: 4);
+final findPattern = FindPattern(bus, pattern);
+expect(findPattern.index.value.toInt(), equals(4));
+```
+
+### Find Pattern from End
+
+To get the `index` location of the pattern from end of the bus (MSB), pass the Logic `bus`, Logic `pattern` and set the `fromStart` to `false`. Ensure that the `pattern` width is smaller than the `bus` width. By default, it will find the first occurrence of the `pattern` from end of the `bus`.
+
+For example, if `bus` is `11101010` and `pattern` is `11101`, the output `index` will return `40` as the first occurrence of the pattern is found at the 0th-bit of the bus from the MSB.
+
+```dart
+final bus = Const(bin('11101010'), width: 8);
+final pattern = Const(bin('11101'), width: 5);
+final findPattern = FindPattern(bus, pattern, fromStart: false);
+expect(findPattern.index.value.toInt(), equals(0));
+```
+
+## Find Nth Pattern from Start/End
+
+To find the `index` of `n`th occurrence of specific `pattern` in a `bus` from start/end.
+
+### Find Nth Pattern from Start
+
+To get the `index` location of the `n`th occurrence of `pattern` in the `bus`, simply pass the Logic `bus` and `pattern` and additional input Logic of `n`. By default `n` is `null` and will be set to `0` if it is not defined. `n` is zero-based indexing, so if you want to find the 2nd occurrence of the pattern, `n` should be set to `1`.
+
+For example, if `bus` is `10101001` and you want to find the 3rd occurrence of `pattern` of `01`, pass input `n` as `2`. The output `index` will return `5` as the 3rd occurrence of the pattern is found at the 5th-bit of the bus from the LSB.
+
+```dart
+final bus = Const(bin('10101001'), width: 8);
+final pattern = Const(bin('01'), width: 2);
+final n = Const(2, width: log2Ceil(bus.width) + 1);
+final findPattern = FindPattern(bus, pattern, n: n);
+expect(findPattern.index.value.toInt(), equals(5));
+```
+
+### Find Nth Pattern from End
+
+To get the `index` location of the `n`th occurrence of `pattern` from end of the `bus` (MSB), pass the Logic `bus`, Logic `pattern`, set `fromStart` to `false` with additional input Logic of `n`. By default `n` is `null` and will be set to `0` if it is not defined. `n` is zero-based indexing, so if you want to find the 2nd occurrence of the pattern, `n` should be set to `1`.
+
+For example, if `bus` is `10101001` and you want to find the 3rd occurrence of `pattern` of `01`, pass input `n` as `2`. The output `index` will return `6` as the 3rd occurrence of the pattern is found at the 6th-bit of the bus from the MSB.
+
+```dart
+final bus = Const(bin('10101001'), width: 8);
+final pattern = Const(bin('01'), width: 2);
+final n = Const(2, width: log2Ceil(bus.width) + 1);
+final findPattern = FindPattern(bus, pattern, fromStart: false, n: n);
+expect(findPattern.index.value.toInt(), equals(6));
+```
+
+### Pattern not Found in Bus
+
+If `pattern` is not found in the Logic `bus`, output `index` will be `undefined` (i.e., `b'zzzz`). To generate the output pin `error`, set the `generateError` boolean to `true`. By default, `generateError` is `false`. If pattern is not found, `error` will be `1`.

--- a/lib/rohd_hcl.dart
+++ b/lib/rohd_hcl.dart
@@ -14,6 +14,7 @@ export 'src/exceptions.dart';
 export 'src/extrema.dart';
 export 'src/fifo.dart';
 export 'src/find.dart';
+export 'src/find_pattern.dart';
 export 'src/gaskets/spi/spi_gaskets.dart';
 export 'src/interfaces/interfaces.dart';
 export 'src/memory/memories.dart';

--- a/lib/src/find_pattern.dart
+++ b/lib/src/find_pattern.dart
@@ -19,7 +19,7 @@ class FindPattern extends Module {
   /// [index] is a getter for output of FindPattern.
   /// It contains the position of the pattern in the bus depending on the
   /// search direction defined.
-  /// [index] starts from `0` based and is `undefined` if pattern is not found.
+  /// [index] starts from `0` based and is `0` if pattern is not found.
   Logic get index => output('index');
 
   /// [error] is a getter for error in FindPattern and is generated when
@@ -50,7 +50,7 @@ class FindPattern extends Module {
   /// `false`, the [index] will be `6` as the pattern is found at the
   /// 6th position from end of the bus.
   ///
-  /// [index] will be `undefined` (i.e., b'zzz) when pattern is not found.
+  /// [index] will be `0` when pattern is not found.
   FindPattern(Logic bus, Logic pattern,
       {bool fromStart = true, Logic? n, this.generateError = false})
       : super(definitionName: 'FindPattern_W${bus.width}_P${pattern.width}') {
@@ -88,7 +88,6 @@ class FindPattern extends Module {
       // Append result to the index list
       indexList.add(valCheck & nVal.eq(count));
     }
-
     final indexBinary = OneHotToBinary(indexList.rswizzle());
     final bin = indexBinary.binary;
     addOutput('index', width: bin.width);

--- a/lib/src/find_pattern.dart
+++ b/lib/src/find_pattern.dart
@@ -11,27 +11,29 @@ class FindPattern extends Module {
 
   /// Find a fixed-width pattern
   ///
-  /// Takes in search pattern [pattern] and a boolean [start] to determine the search direction.
+  /// Takes in search pattern [pattern] and a boolean [start] to determine the
+  ///  search direction.
   /// If [start] is `true`, the search starts from the beginning of the bus.
   /// If [start] is `false`, the search starts from the end of the bus.
   ///
-  /// By default, [FindPattern] will look for the first occurrence of the pattern.
-  /// If [n] is given, [FindPattern] will find the N'th occurrence of the pattern.
-  /// [n] starts from `0` as the first occurrence.
+  /// By default, [FindPattern] will look for the first occurrence
+  /// of the pattern.
+  /// If [n] is given, [FindPattern] will find the N'th occurrence
+  /// of the pattern.
+  /// [n] starts from `1` as the first occurrence.
   ///
   /// Outputs pin `index` contains the position. Position starts from `0` based.
-  FindPattern(Logic bus, Logic pattern, {bool start=true, Logic? n})
+  FindPattern(Logic bus, Logic pattern, {bool start = true, int n = 1})
       : super(definitionName: 'FindPattern_W${bus.width}_P${pattern.width}') {
     bus = addInput('bus', bus, width: bus.width);
     pattern = addInput('pattern', pattern, width: pattern.width);
     addOutput('index', width: bus.width);
 
-    if (n ?= null) {
-      n = addInput('n', n, width: n.width);
-    }
-
     print('bus: ${bus.value.toInt()}');
     print('pattern: ${pattern.value.toInt()}');
+
+    // Initialize countPatternOccurence to 0
+    int count = 0;
 
     print('=======================');
 
@@ -43,17 +45,28 @@ class FindPattern extends Module {
         final valCheck = bus.getRange(i, i + pattern.width).eq(pattern);
         print('i: $i, busVal: ${busVal.value}, valCheck: ${valCheck.value}');
 
-        // Check if pattern matches, break if found
+        // Check if pattern matches, count if found
         if (valCheck.value.toInt() == 1) {
-          // If pattern is found, set index to current position
-          index <= Const(i, width: bus.width);
-          break;
+          count = count + 1;
+          print('count: $count');
+          // If pattern is found and n is equal to 1, set index to
+          //current position
+          if (n == 1) {
+            index <= Const(i, width: bus.width);
+            break;
+          }
+          // If pattern is found and count == n, set index to
+          //current position
+          else if (n == count) {
+            print('n == count');
+            index <= Const(i, width: bus.width);
+            break;
+          }
         }
-
+        print('count: $count');
         print('=======================');
       }
-      print('index: ${index.value.toInt()}');
-
+      print('index: ${index.value}');
     } else {
       print('check from end');
       for (var i = bus.width; i >= bus.width - pattern.width; i = i - 1) {
@@ -61,12 +74,25 @@ class FindPattern extends Module {
         final busVal = bus.getRange(i - pattern.width, i);
         final valCheck = bus.getRange(i - pattern.width, i).eq(pattern);
         print('i: $i, busVal: ${busVal.value}, valCheck: ${valCheck.value}');
+        print('count: $count');
 
-        // Check if pattern matches, break if found
+        // Check if pattern matches, count if found
         if (valCheck.value.toInt() == 1) {
-          // If pattern is found, set index to current position - 1
-          index <= Const(i-1, width: bus.width);
-          break;
+          count = count + 1;
+          print('count: $count');
+          // If pattern is found and n is equal to 1, set index to
+          //current position
+          if (n == 1) {
+            index <= Const(i - 1, width: bus.width);
+            break;
+          }
+          // If pattern is found and count == n, set index to
+          //current position
+          else if (n == count) {
+            print('n == count');
+            index <= Const(i - 1, width: bus.width);
+            break;
+          }
         }
         print('=======================');
       }

--- a/lib/src/find_pattern.dart
+++ b/lib/src/find_pattern.dart
@@ -68,10 +68,9 @@ class FindPattern extends Module {
     Logic count = Const(0, width: log2Ceil(bus.width + 1));
     final nVal = ((n ?? Const(0)) + 1).zeroExtend(count.width);
 
-    int minBit;
-    int maxBit;
-
     for (var i = 0; i <= bus.width - pattern.width; i = i + 1) {
+      int minBit;
+      int maxBit;
       if (fromStart) {
         // Read from start of bus
         minBit = i;

--- a/lib/src/find_pattern.dart
+++ b/lib/src/find_pattern.dart
@@ -1,5 +1,6 @@
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
+import 'package:rohd_vf/rohd_vf.dart';
 
 /// FindPattern functionality
 ///
@@ -9,7 +10,14 @@ class FindPattern extends Module {
   /// [index] is a getter for output of FindPattern
   Logic get index => output('index');
 
-  /// Find a fixed-width pattern
+  /// [error] is a getter for error in FindPattern
+  /// When your pattern is not found it will result in error `1`
+  Logic? get error => tryOutput('error');
+
+  /// If `true`, then the [error] output will be generated.
+  final bool generateError;
+
+  /// Find a position for a fixed-width pattern
   ///
   /// Takes in search pattern [pattern] and a boolean [start] to determine the
   ///  search direction.
@@ -23,7 +31,8 @@ class FindPattern extends Module {
   /// [n] starts from `1` as the first occurrence.
   ///
   /// Outputs pin `index` contains the position. Position starts from `0` based.
-  FindPattern(Logic bus, Logic pattern, {bool start = true, int n = 1})
+  FindPattern(Logic bus, Logic pattern,
+      {bool start = true, int n = 1, this.generateError = false})
       : super(definitionName: 'FindPattern_W${bus.width}_P${pattern.width}') {
     bus = addInput('bus', bus, width: bus.width);
     pattern = addInput('pattern', pattern, width: pattern.width);
@@ -32,70 +41,73 @@ class FindPattern extends Module {
     print('bus: ${bus.value.toInt()}');
     print('pattern: ${pattern.value.toInt()}');
 
-    // Initialize countPatternOccurence to 0
-    int count = 0;
+    // Initialize counter pattern occurrence to 0
+    var count = 0;
 
     print('=======================');
 
     if (start) {
       print('check from start');
       for (var i = 0; i <= bus.width - pattern.width; i = i + 1) {
-        // determines if it is what we are looking for?
-        final busVal = bus.getRange(i, i + pattern.width);
-        final valCheck = bus.getRange(i, i + pattern.width).eq(pattern);
+        // Read from start of bus
+        final minBit = i;
+        final maxBit = i + pattern.width;
+        print('minBit: $minBit, maxBit: $maxBit');
+        final busVal = bus.getRange(minBit, maxBit);
+        // Check if pattern matches
+        final valCheck = busVal.eq(pattern);
         print('i: $i, busVal: ${busVal.value}, valCheck: ${valCheck.value}');
 
         // Check if pattern matches, count if found
-        if (valCheck.value.toInt() == 1) {
-          count = count + 1;
-          print('count: $count');
-          // If pattern is found and n is equal to 1, set index to
-          //current position
-          if (n == 1) {
-            index <= Const(i, width: bus.width);
-            break;
-          }
-          // If pattern is found and count == n, set index to
-          //current position
-          else if (n == count) {
-            print('n == count');
-            index <= Const(i, width: bus.width);
-            break;
-          }
-        }
+        count += (valCheck.value.toInt() == 1) ? 1 : 0;
         print('count: $count');
+
+        // If count matches n, break and return index
+        if (n == count) {
+          print('n == count');
+          index <= Const(i, width: bus.width);
+          print('index: ${index.value}');
+          break;
+        }
         print('=======================');
       }
-      print('index: ${index.value}');
     } else {
       print('check from end');
-      for (var i = bus.width; i >= bus.width - pattern.width; i = i - 1) {
-        // determines if it is what we are looking for?
-        final busVal = bus.getRange(i - pattern.width, i);
-        final valCheck = bus.getRange(i - pattern.width, i).eq(pattern);
+      for (var i = 0; i <= bus.width - pattern.width; i = i + 1) {
+        // Read from end of bus
+        final minBit = bus.width - i - pattern.width;
+        final maxBit = bus.width - i;
+        print('minBit: $minBit, maxBit: $maxBit');
+        final busVal = bus.getRange(minBit, maxBit);
+        print('busVal: ${busVal.value}');
+        // Check if pattern matches
+        final valCheck = busVal.eq(pattern);
         print('i: $i, busVal: ${busVal.value}, valCheck: ${valCheck.value}');
         print('count: $count');
 
         // Check if pattern matches, count if found
-        if (valCheck.value.toInt() == 1) {
-          count = count + 1;
-          print('count: $count');
-          // If pattern is found and n is equal to 1, set index to
-          //current position
-          if (n == 1) {
-            index <= Const(i - 1, width: bus.width);
-            break;
-          }
-          // If pattern is found and count == n, set index to
-          //current position
-          else if (n == count) {
-            print('n == count');
-            index <= Const(i - 1, width: bus.width);
-            break;
-          }
+        count += (valCheck.value.toInt() == 1) ? 1 : 0;
+        print('count: $count');
+
+        // If count matches n, break and return index
+        if (n == count) {
+          print('n == count');
+          index <= Const(i, width: bus.width);
+          print('index: ${index.value}');
+          break;
         }
         print('=======================');
       }
+    }
+
+    if (generateError) {
+      // If pattern is not found, return error
+      var isError = (count < n || count == 0) ? 1 : 0;
+      addOutput('error');
+      error! <= Const(isError, width: 1);
+      print('error: ${error!.value}');
+      // If error is generated, return index as 255
+      index <= Const(255, width: bus.width);
       print('index: ${index.value}');
     }
   }

--- a/lib/src/find_pattern.dart
+++ b/lib/src/find_pattern.dart
@@ -1,4 +1,3 @@
-import 'dart:math';
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
 import 'package:rohd_vf/rohd_vf.dart';

--- a/lib/src/find_pattern.dart
+++ b/lib/src/find_pattern.dart
@@ -44,7 +44,6 @@ class FindPattern extends Module {
       : super(definitionName: 'FindPattern_W${bus.width}_P${pattern.width}') {
     bus = addInput('bus', bus, width: bus.width);
     pattern = addInput('pattern', pattern, width: pattern.width);
-    addOutput('index', width: bus.width);
 
     if (n != null) {
       n = addInput('n', n, width: n.width);
@@ -77,6 +76,7 @@ class FindPattern extends Module {
 
       // If count matches n, break and return index
       if (nVal.value.toInt() == count.value.toInt()) {
+        addOutput('index', width: bus.width);
         index <= Const(i, width: bus.width);
         break;
       }
@@ -90,8 +90,6 @@ class FindPattern extends Module {
               : 0;
       addOutput('error');
       error! <= Const(isError, width: 1);
-      // If error is generated, return index as 255
-      index <= Const(255, width: bus.width);
     }
   }
 }

--- a/lib/src/find_pattern.dart
+++ b/lib/src/find_pattern.dart
@@ -9,8 +9,6 @@
 //
 
 import 'package:rohd/rohd.dart';
-import 'package:rohd_hcl/rohd_hcl.dart';
-import 'package:rohd_vf/rohd_vf.dart';
 
 /// [FindPattern] functionality
 ///

--- a/lib/src/find_pattern.dart
+++ b/lib/src/find_pattern.dart
@@ -1,3 +1,13 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// find_pattern.dart
+// Implementation of Find Pattern Functionality.
+//
+// 2025 March 07
+// Author: Ramli, Nurul Izziany <nurul.izziany.ramli@intel.com>
+//
+
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
 import 'package:rohd_vf/rohd_vf.dart';

--- a/lib/src/find_pattern.dart
+++ b/lib/src/find_pattern.dart
@@ -1,0 +1,76 @@
+import 'package:rohd/rohd.dart';
+import 'package:rohd_hcl/rohd_hcl.dart';
+
+/// FindPattern functionality
+///
+/// Takes in a [Logic] to find location of a fixed-width pattern.
+/// Outputs pin `index` contains position.
+class FindPattern extends Module {
+  /// [index] is a getter for output of FindPattern
+  Logic get index => output('index');
+
+  /// Find a fixed-width pattern
+  ///
+  /// Takes in search pattern [pattern] and a boolean [start] to determine the search direction.
+  /// If [start] is `true`, the search starts from the beginning of the bus.
+  /// If [start] is `false`, the search starts from the end of the bus.
+  ///
+  /// By default, [FindPattern] will look for the first occurrence of the pattern.
+  /// If [n] is given, [FindPattern] will find the N'th occurrence of the pattern.
+  /// [n] starts from `0` as the first occurrence.
+  ///
+  /// Outputs pin `index` contains the position. Position starts from `0` based.
+  FindPattern(Logic bus, Logic pattern, {bool start=true, Logic? n})
+      : super(definitionName: 'FindPattern_W${bus.width}_P${pattern.width}') {
+    bus = addInput('bus', bus, width: bus.width);
+    pattern = addInput('pattern', pattern, width: pattern.width);
+    addOutput('index', width: bus.width);
+
+    if (n ?= null) {
+      n = addInput('n', n, width: n.width);
+    }
+
+    print('bus: ${bus.value.toInt()}');
+    print('pattern: ${pattern.value.toInt()}');
+
+    print('=======================');
+
+    if (start) {
+      print('check from start');
+      for (var i = 0; i <= bus.width - pattern.width; i = i + 1) {
+        // determines if it is what we are looking for?
+        final busVal = bus.getRange(i, i + pattern.width);
+        final valCheck = bus.getRange(i, i + pattern.width).eq(pattern);
+        print('i: $i, busVal: ${busVal.value}, valCheck: ${valCheck.value}');
+
+        // Check if pattern matches, break if found
+        if (valCheck.value.toInt() == 1) {
+          // If pattern is found, set index to current position
+          index <= Const(i, width: bus.width);
+          break;
+        }
+
+        print('=======================');
+      }
+      print('index: ${index.value.toInt()}');
+
+    } else {
+      print('check from end');
+      for (var i = bus.width; i >= bus.width - pattern.width; i = i - 1) {
+        // determines if it is what we are looking for?
+        final busVal = bus.getRange(i - pattern.width, i);
+        final valCheck = bus.getRange(i - pattern.width, i).eq(pattern);
+        print('i: $i, busVal: ${busVal.value}, valCheck: ${valCheck.value}');
+
+        // Check if pattern matches, break if found
+        if (valCheck.value.toInt() == 1) {
+          // If pattern is found, set index to current position - 1
+          index <= Const(i-1, width: bus.width);
+          break;
+        }
+        print('=======================');
+      }
+      print('index: ${index.value}');
+    }
+  }
+}

--- a/lib/src/find_pattern.dart
+++ b/lib/src/find_pattern.dart
@@ -19,7 +19,7 @@ class FindPattern extends Module {
   /// [index] is a getter for output of FindPattern.
   /// It contains the position of the pattern in the bus depending on the
   /// search direction defined.
-  /// [index] starts from `0` based.
+  /// [index] starts from `0` based and is `undefined` if pattern is not found.
   Logic get index => output('index');
 
   /// [error] is a getter for error in FindPattern and is generated when

--- a/test/find_pattern_test.dart
+++ b/test/find_pattern_test.dart
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // find_pattern_test.dart
-// Tests for FindPattern
+// Tests for Find Pattern
 //
-// 2025 June 3
+// 2025 March 6
 // Author: Louiz Ang Zhi Lin <louiz.zhi.lin.ang@intel.com>
 //
 

--- a/test/find_pattern_test.dart
+++ b/test/find_pattern_test.dart
@@ -32,12 +32,12 @@ void main() {
       final findPattern = FindPattern(bus, pattern);
       expect(findPattern.index.value.toInt(), equals(3));
     });
-    // test('when pattern not present', () async {
-    //   final bus = Const(bin('00000000'), width: 8);
-    //   final pattern = Const(bin('111'), width: 3);
-    //   final findPattern = FindPattern(bus, pattern, generateError: true);
-    //   expect(findPattern.error!.value.toInt(), equals(1));
-    // });
+    test('when pattern not present', () async {
+      final bus = Const(bin('00000000'), width: 8);
+      final pattern = Const(bin('111'), width: 3);
+      final findPattern = FindPattern(bus, pattern, generateError: true);
+      expect(findPattern.error!.value.toInt(), equals(1));
+    });
   });
 
   group('From end, find first pattern with n as null', () {
@@ -57,37 +57,38 @@ void main() {
       final bus = Const(bin('10000001'), width: 8);
       final pattern = Const(bin('01'), width: 2);
       final findPattern = FindPattern(bus, pattern, start: false);
-      expect(findPattern.index.value.toInt(), equals(7));
+      expect(findPattern.index.value.toInt(), equals(6));
     });
-    // test('Pattern not present', () async {
-    //   final bus = Const(bin('00000000'), width: 8);
-    //   final pattern = Const(bin('111'), width: 3);
-    //   final findPattern = FindPattern(bus, pattern, start:false, generateError: true);
-    //   expect(findPattern.error!.value.toInt(), equals(1));
-    // });
+    test('Pattern not present', () async {
+      final bus = Const(bin('00000000'), width: 8);
+      final pattern = Const(bin('111'), width: 3);
+      final findPattern =
+          FindPattern(bus, pattern, start: false, generateError: true);
+      expect(findPattern.error!.value.toInt(), equals(1));
+    });
   });
 
   group('From start, find nth pattern', () {
     test('where n is 0', () async {
       final bus = Const(bin('10101001'), width: 8);
       final pattern = Const(bin('01'), width: 2);
-      final n = 0;
-      final findPattern = FindPattern(bus, pattern, start: true, n: n);
-      expect(findPattern.index.value.toInt(), equals(1));
+      final n = Const(0, width: log2Ceil(8) + 1);
+      final findPattern = FindPattern(bus, pattern, n: n);
+      expect(findPattern.index.value.toInt(), equals(0));
     });
-    test('where n is 2', () async {
+    test('where n is 2 (find the 3rd occurrence, n is zero-index)', () async {
       final bus = Const(bin('10101001'), width: 8);
       final pattern = Const(bin('01'), width: 2);
-      final n = 2;
-      final findPattern = FindPattern(bus, pattern, start: true, n: n);
-      expect(findPattern.index.value.toInt(), equals(6));
+      final n = Const(2, width: log2Ceil(8) + 1);
+      final findPattern = FindPattern(bus, pattern, n: n);
+      expect(findPattern.index.value.toInt(), equals(5));
     });
     test('where n is outside bound', () async {
       final bus = Const(bin('10101001'), width: 8);
       final pattern = Const(bin('01'), width: 2);
-      final n = 5;
-      final findPattern = FindPattern(bus, pattern, start: true, n: n);
-      expect(findPattern.index.value.toInt(), equals(2));
+      final n = Const(5, width: log2Ceil(8) + 1);
+      final findPattern = FindPattern(bus, pattern, n: n, generateError: true);
+      expect(findPattern.error!.value.toInt(), equals(1));
     });
   });
 
@@ -95,23 +96,24 @@ void main() {
     test('where n is 0', () async {
       final bus = Const(bin('01010110'), width: 8);
       final pattern = Const(bin('01'), width: 2);
-      final n = 0;
+      final n = Const(0, width: log2Ceil(8) + 1);
       final findPattern = FindPattern(bus, pattern, start: false, n: n);
-      expect(findPattern.index.value.toInt(), equals(1));
+      expect(findPattern.index.value.toInt(), equals(0));
     });
-    test('where n is 2', () async {
+    test('where n is 2 (find the 3rd occurrence, n is zero-index)', () async {
       final bus = Const(bin('10101001'), width: 8);
       final pattern = Const(bin('01'), width: 2);
-      final n = 2;
+      final n = Const(2, width: log2Ceil(8) + 1);
       final findPattern = FindPattern(bus, pattern, start: false, n: n);
-      expect(findPattern.index.value.toInt(), equals(7));
+      expect(findPattern.index.value.toInt(), equals(6));
     });
     test('where n is outside bound', () async {
       final bus = Const(bin('10101001'), width: 8);
       final pattern = Const(bin('01'), width: 2);
-      final n = 5;
-      final findPattern = FindPattern(bus, pattern, start: false, n: n);
-      expect(findPattern.index.value.toInt(), equals(2));
+      final n = Const(5, width: log2Ceil(8) + 1);
+      final findPattern =
+          FindPattern(bus, pattern, start: false, n: n, generateError: true);
+      expect(findPattern.error!.value.toInt(), equals(1));
     });
   });
 }

--- a/test/find_pattern_test.dart
+++ b/test/find_pattern_test.dart
@@ -6,6 +6,7 @@
 //
 // 2025 March 6
 // Author: Louiz Ang Zhi Lin <louiz.zhi.lin.ang@intel.com>
+// Co-author: Ramli, Nurul Izziany <nurul.izziany.ramli@intel.com>
 //
 
 import 'package:rohd/rohd.dart';
@@ -113,6 +114,98 @@ void main() {
       final n = Const(5, width: log2Ceil(8) + 1);
       final findPattern = FindPattern(bus, pattern,
           fromStart: false, n: n, generateError: true);
+      expect(findPattern.error!.value.toInt(), equals(1));
+    });
+  });
+
+  group('Dynamic input', () {
+    test('where n is null, from start', () async {
+      final bus = Logic(width: 8);
+      final pattern = Logic(width: 2);
+      final findPattern = FindPattern(bus, pattern, generateError: true);
+
+      bus.put(bin('10000001'));
+      pattern.put(bin('01'));
+      expect(findPattern.index.value.toInt(), equals(0));
+      expect(findPattern.error!.value.toInt(), equals(0));
+
+      bus.put(bin('11011111'));
+      pattern.put(bin('10'));
+      expect(findPattern.index.value.toInt(), equals(5));
+      expect(findPattern.error!.value.toInt(), equals(0));
+
+      bus.put(bin('11110111'));
+      pattern.put(bin('00'));
+      expect(findPattern.error!.value.toInt(), equals(1));
+    });
+
+    test('where n is defined, from start', () async {
+      final bus = Logic(width: 8);
+      final pattern = Logic(width: 2);
+      final n = Logic(width: log2Ceil(8) + 1);
+      final findPattern = FindPattern(bus, pattern, n: n, generateError: true);
+
+      bus.put(bin('10110101'));
+      pattern.put(bin('01'));
+      n.put(1);
+      expect(findPattern.index.value.toInt(), equals(2));
+      expect(findPattern.error!.value.toInt(), equals(0));
+
+      bus.put(bin('10010101'));
+      pattern.put(bin('10'));
+      n.put(2);
+      expect(findPattern.index.value.toInt(), equals(6));
+      expect(findPattern.error!.value.toInt(), equals(0));
+
+      bus.put(bin('11100100'));
+      pattern.put(bin('00'));
+      n.put(3);
+      expect(findPattern.error!.value.toInt(), equals(1));
+    });
+
+    test('where n is null, from end', () async {
+      final bus = Logic(width: 8);
+      final pattern = Logic(width: 2);
+      final findPattern =
+          FindPattern(bus, pattern, fromStart: false, generateError: true);
+
+      bus.put(bin('10000001'));
+      pattern.put(bin('01'));
+      expect(findPattern.index.value.toInt(), equals(6));
+      expect(findPattern.error!.value.toInt(), equals(0));
+
+      bus.put(bin('11011111'));
+      pattern.put(bin('10'));
+      expect(findPattern.index.value.toInt(), equals(1));
+      expect(findPattern.error!.value.toInt(), equals(0));
+
+      bus.put(bin('11110111'));
+      pattern.put(bin('00'));
+      expect(findPattern.error!.value.toInt(), equals(1));
+    });
+
+    test('where n is defined, from end', () async {
+      final bus = Logic(width: 8);
+      final pattern = Logic(width: 2);
+      final n = Logic(width: log2Ceil(8) + 1);
+      final findPattern = FindPattern(bus, pattern,
+          fromStart: false, n: n, generateError: true);
+
+      bus.put(bin('10110101'));
+      pattern.put(bin('01'));
+      n.put(1);
+      expect(findPattern.index.value.toInt(), equals(4));
+      expect(findPattern.error!.value.toInt(), equals(0));
+
+      bus.put(bin('10010101'));
+      pattern.put(bin('10'));
+      n.put(2);
+      expect(findPattern.index.value.toInt(), equals(5));
+      expect(findPattern.error!.value.toInt(), equals(0));
+
+      bus.put(bin('11100100'));
+      pattern.put(bin('11'));
+      n.put(3);
       expect(findPattern.error!.value.toInt(), equals(1));
     });
   });

--- a/test/find_pattern_test.dart
+++ b/test/find_pattern_test.dart
@@ -44,26 +44,26 @@ void main() {
     test('at 0th position', () async {
       final bus = Const(bin('11101010'), width: 8);
       final pattern = Const(bin('11101'), width: 5);
-      final findPattern = FindPattern(bus, pattern, start: false);
+      final findPattern = FindPattern(bus, pattern, fromStart: false);
       expect(findPattern.index.value.toInt(), equals(0));
     });
     test('at random position', () async {
       final bus = Const(bin('11011111'), width: 8);
       final pattern = Const(bin('101'), width: 3);
-      final findPattern = FindPattern(bus, pattern, start: false);
+      final findPattern = FindPattern(bus, pattern, fromStart: false);
       expect(findPattern.index.value.toInt(), equals(1));
     });
     test('at last position', () async {
       final bus = Const(bin('10000001'), width: 8);
       final pattern = Const(bin('01'), width: 2);
-      final findPattern = FindPattern(bus, pattern, start: false);
+      final findPattern = FindPattern(bus, pattern, fromStart: false);
       expect(findPattern.index.value.toInt(), equals(6));
     });
     test('Pattern not present', () async {
       final bus = Const(bin('00000000'), width: 8);
       final pattern = Const(bin('111'), width: 3);
       final findPattern =
-          FindPattern(bus, pattern, start: false, generateError: true);
+          FindPattern(bus, pattern, fromStart: false, generateError: true);
       expect(findPattern.error!.value.toInt(), equals(1));
     });
   });
@@ -97,22 +97,22 @@ void main() {
       final bus = Const(bin('01010110'), width: 8);
       final pattern = Const(bin('01'), width: 2);
       final n = Const(0, width: log2Ceil(8) + 1);
-      final findPattern = FindPattern(bus, pattern, start: false, n: n);
+      final findPattern = FindPattern(bus, pattern, fromStart: false, n: n);
       expect(findPattern.index.value.toInt(), equals(0));
     });
     test('where n is 2 (find the 3rd occurrence, n is zero-index)', () async {
       final bus = Const(bin('10101001'), width: 8);
       final pattern = Const(bin('01'), width: 2);
       final n = Const(2, width: log2Ceil(8) + 1);
-      final findPattern = FindPattern(bus, pattern, start: false, n: n);
+      final findPattern = FindPattern(bus, pattern, fromStart: false, n: n);
       expect(findPattern.index.value.toInt(), equals(6));
     });
     test('where n is outside bound', () async {
       final bus = Const(bin('10101001'), width: 8);
       final pattern = Const(bin('01'), width: 2);
       final n = Const(5, width: log2Ceil(8) + 1);
-      final findPattern =
-          FindPattern(bus, pattern, start: false, n: n, generateError: true);
+      final findPattern = FindPattern(bus, pattern,
+          fromStart: false, n: n, generateError: true);
       expect(findPattern.error!.value.toInt(), equals(1));
     });
   });

--- a/test/find_pattern_test.dart
+++ b/test/find_pattern_test.dart
@@ -1,22 +1,117 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// find_pattern_test.dart
+// Tests for FindPattern
+//
+// 2025 June 3
+// Author: Louiz Ang Zhi Lin <louiz.zhi.lin.ang@intel.com>
+//
+
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
 import 'package:test/test.dart';
-import 'package:rohd_hcl/src/find_pattern.dart';
 
 void main() {
-  group('FindPattern', () {
-    test('Find pattern from start', () async {
-      final bus = Const(bin('10101010'), width: 8);
+  group('From start, find first pattern with n as null', () {
+    test('at 0th position', () async {
+      final bus = Const(bin('10000001'), width: 8);
+      final pattern = Const(bin('01'), width: 2);
+      final findPattern = FindPattern(bus, pattern);
+      expect(findPattern.index.value.toInt(), equals(0));
+    });
+    test('at random position', () async {
+      final bus = Const(bin('11011111'), width: 8);
       final pattern = Const(bin('101'), width: 3);
       final findPattern = FindPattern(bus, pattern);
+      expect(findPattern.index.value.toInt(), equals(4));
+    });
+    test('at last position', () async {
+      final bus = Const(bin('11101010'), width: 8);
+      final pattern = Const(bin('11101'), width: 5);
+      final findPattern = FindPattern(bus, pattern);
+      expect(findPattern.index.value.toInt(), equals(3));
+    });
+    // test('when pattern not present', () async {
+    //   final bus = Const(bin('00000000'), width: 8);
+    //   final pattern = Const(bin('111'), width: 3);
+    //   final findPattern = FindPattern(bus, pattern, generateError: true);
+    //   expect(findPattern.error!.value.toInt(), equals(1));
+    // });
+  });
+
+  group('From end, find first pattern with n as null', () {
+    test('at 0th position', () async {
+      final bus = Const(bin('11101010'), width: 8);
+      final pattern = Const(bin('11101'), width: 5);
+      final findPattern = FindPattern(bus, pattern, start: false);
+      expect(findPattern.index.value.toInt(), equals(0));
+    });
+    test('at random position', () async {
+      final bus = Const(bin('11011111'), width: 8);
+      final pattern = Const(bin('101'), width: 3);
+      final findPattern = FindPattern(bus, pattern, start: false);
       expect(findPattern.index.value.toInt(), equals(1));
     });
+    test('at last position', () async {
+      final bus = Const(bin('10000001'), width: 8);
+      final pattern = Const(bin('01'), width: 2);
+      final findPattern = FindPattern(bus, pattern, start: false);
+      expect(findPattern.index.value.toInt(), equals(6));
+    });
+    // test('Pattern not present', () async {
+    //   final bus = Const(bin('00000000'), width: 8);
+    //   final pattern = Const(bin('111'), width: 3);
+    //   final findPattern = FindPattern(bus, pattern, start:false, generateError: true);
+    //   expect(findPattern.error!.value.toInt(), equals(1));
+    // });
+  });
 
-    test('Find pattern from end', () async {
-      final bus = Const(bin('10101010'), width: 8);
-      final pattern = Const(bin('101'), width: 3);
-      final findPattern = FindPattern(bus, pattern, start:false);
-      expect(findPattern.index.value.toInt(), equals(7));
+  group('From start, find nth pattern', () {
+    test('where n is 0', () async {
+      final bus = Const(bin('10101001'), width: 8);
+      final pattern = Const(bin('01'), width: 2);
+      final n = Const(0);
+      final findPattern = FindPattern(bus, pattern, start: true, n);
+      expect(findPattern.index.value.toInt(), equals(0));
+    });
+    test('where n is 2', () async {
+      final bus = Const(bin('10101001'), width: 8);
+      final pattern = Const(bin('01'), width: 2);
+      final n = Const(2);
+      final findPattern = FindPattern(bus, pattern, start: true, n);
+      expect(findPattern.index.value.toInt(), equals(5));
+    });
+    test('where n is outside bound', () async {
+      final bus = Const(bin('10101001'), width: 8);
+      final pattern = Const(bin('01'), width: 2);
+      final n = Const(5);
+      final findPattern = FindPattern(bus, pattern, start: true, n);
+      expect(findPattern.index.value.toInt(), equals(1));
+    });
+  });
+
+  group('From end, find nth pattern', () {
+    test('where n is 0', () async {
+      final bus = Const(bin('01010110'), width: 8);
+      final pattern = Const(bin('01'), width: 2);
+      final n = Const(0);
+      final findPattern = FindPattern(bus, pattern, start: false, n);
+      expect(findPattern.index.value.toInt(), equals(0));
+    });
+    test('where n is 2', () async {
+      final bus = Const(bin('10101001'), width: 8);
+      final pattern = Const(bin('01'), width: 2);
+      final n = Const(2);
+      final findPattern = FindPattern(bus, pattern, start: false, n);
+      expect(findPattern.index.value.toInt(), equals(6));
+    });
+    test('where n is outside bound', () async {
+      final bus = Const(bin('10101001'), width: 8);
+      final pattern = Const(bin('01'), width: 2);
+      final n = Const(5);
+      final findPattern = FindPattern(bus, pattern, start: false, n);
+      expect(findPattern.index.value.toInt(), equals(1));
     });
   });
 }

--- a/test/find_pattern_test.dart
+++ b/test/find_pattern_test.dart
@@ -57,7 +57,7 @@ void main() {
       final bus = Const(bin('10000001'), width: 8);
       final pattern = Const(bin('01'), width: 2);
       final findPattern = FindPattern(bus, pattern, start: false);
-      expect(findPattern.index.value.toInt(), equals(6));
+      expect(findPattern.index.value.toInt(), equals(7));
     });
     // test('Pattern not present', () async {
     //   final bus = Const(bin('00000000'), width: 8);
@@ -71,23 +71,23 @@ void main() {
     test('where n is 0', () async {
       final bus = Const(bin('10101001'), width: 8);
       final pattern = Const(bin('01'), width: 2);
-      final n = Const(0);
-      final findPattern = FindPattern(bus, pattern, start: true, n);
-      expect(findPattern.index.value.toInt(), equals(0));
+      final n = 0;
+      final findPattern = FindPattern(bus, pattern, start: true, n: n);
+      expect(findPattern.index.value.toInt(), equals(1));
     });
     test('where n is 2', () async {
       final bus = Const(bin('10101001'), width: 8);
       final pattern = Const(bin('01'), width: 2);
-      final n = Const(2);
-      final findPattern = FindPattern(bus, pattern, start: true, n);
-      expect(findPattern.index.value.toInt(), equals(5));
+      final n = 2;
+      final findPattern = FindPattern(bus, pattern, start: true, n: n);
+      expect(findPattern.index.value.toInt(), equals(6));
     });
     test('where n is outside bound', () async {
       final bus = Const(bin('10101001'), width: 8);
       final pattern = Const(bin('01'), width: 2);
-      final n = Const(5);
-      final findPattern = FindPattern(bus, pattern, start: true, n);
-      expect(findPattern.index.value.toInt(), equals(1));
+      final n = 5;
+      final findPattern = FindPattern(bus, pattern, start: true, n: n);
+      expect(findPattern.index.value.toInt(), equals(2));
     });
   });
 
@@ -95,23 +95,23 @@ void main() {
     test('where n is 0', () async {
       final bus = Const(bin('01010110'), width: 8);
       final pattern = Const(bin('01'), width: 2);
-      final n = Const(0);
-      final findPattern = FindPattern(bus, pattern, start: false, n);
-      expect(findPattern.index.value.toInt(), equals(0));
+      final n = 0;
+      final findPattern = FindPattern(bus, pattern, start: false, n: n);
+      expect(findPattern.index.value.toInt(), equals(1));
     });
     test('where n is 2', () async {
       final bus = Const(bin('10101001'), width: 8);
       final pattern = Const(bin('01'), width: 2);
-      final n = Const(2);
-      final findPattern = FindPattern(bus, pattern, start: false, n);
-      expect(findPattern.index.value.toInt(), equals(6));
+      final n = 2;
+      final findPattern = FindPattern(bus, pattern, start: false, n: n);
+      expect(findPattern.index.value.toInt(), equals(7));
     });
     test('where n is outside bound', () async {
       final bus = Const(bin('10101001'), width: 8);
       final pattern = Const(bin('01'), width: 2);
-      final n = Const(5);
-      final findPattern = FindPattern(bus, pattern, start: false, n);
-      expect(findPattern.index.value.toInt(), equals(1));
+      final n = 5;
+      final findPattern = FindPattern(bus, pattern, start: false, n: n);
+      expect(findPattern.index.value.toInt(), equals(2));
     });
   });
 }

--- a/test/find_pattern_test.dart
+++ b/test/find_pattern_test.dart
@@ -1,0 +1,22 @@
+import 'package:rohd/rohd.dart';
+import 'package:rohd_hcl/rohd_hcl.dart';
+import 'package:test/test.dart';
+import 'package:rohd_hcl/src/find_pattern.dart';
+
+void main() {
+  group('FindPattern', () {
+    test('Find pattern from start', () async {
+      final bus = Const(bin('10101010'), width: 8);
+      final pattern = Const(bin('101'), width: 3);
+      final findPattern = FindPattern(bus, pattern);
+      expect(findPattern.index.value.toInt(), equals(1));
+    });
+
+    test('Find pattern from end', () async {
+      final bus = Const(bin('10101010'), width: 8);
+      final pattern = Const(bin('101'), width: 3);
+      final findPattern = FindPattern(bus, pattern, start:false);
+      expect(findPattern.index.value.toInt(), equals(7));
+    });
+  });
+}


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation
<!-- Description of changes, and motivation for adding them. -->
Similar to Find N'th bit from start/end, but FindPattern find an entire multi-bit pattern from start/end and returns it index

## Related Issue(s)

<!-- If there are any issues related to this PR, please link to the issues here. -->
https://github.com/intel/rohd-hcl/issues/169 

## Testing

<!-- Please describe how you tested your changes. -->
Test is included in test/find_pattern_test.dart 

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

<!-- Answer here. -->
No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

<!-- Answer here. -->
Documentation added in doc/components/find.md