### PR TITLE
Fix bug in `SparseMemoryStorage` where reloading the same data corrupted the first byte

### DIFF
--- a/lib/src/models/sparse_memory_storage.dart
+++ b/lib/src/models/sparse_memory_storage.dart
@@ -181,12 +181,14 @@ abstract class MemoryStorage {
           // must reconstruct the bytes array ending at the provided address
           final endOff = lineAddr % addrIncrPerLine;
           final origData = getData(lineAddrLv);
-          chunks
-            ..clear()
-            ..add(origData!
+          chunks.clear();
+
+          if (endOff != 0) {
+            chunks.add(origData!
                 .getRange(0, endOff * bitsPerAddress)
                 .toInt()
                 .toRadixString(radix));
+          }
         }
 
         address = lineAddrLv.toInt();

--- a/test/sparse_memory_storage_test.dart
+++ b/test/sparse_memory_storage_test.dart
@@ -42,6 +42,67 @@ void main() {
           equals(0x1ff50513));
     });
 
+    test('double load', () {
+      const hex = '''
+@1000
+12 34 56 78
+''';
+      final storage = SparseMemoryStorage(addrWidth: 32, dataWidth: 32)
+        ..loadMemString(hex)
+        ..loadMemString(hex);
+
+      const expected = 0x78563412;
+
+      final addr = LogicValue.ofInt(0x1000, 32);
+      final expectedData = LogicValue.ofInt(expected, 32);
+
+      expect(storage.getData(addr)!.toInt(), equals(expectedData.toInt()),
+          reason: 'Data at address $addr '
+              'should be $expectedData but was '
+              '${storage.getData(addr)!}');
+    });
+
+    test('example simple memory load with double load', () {
+      const hex = '''
+@80000000
+6F 00 80 04 73 2F 20 34 25 0F 80 00 63 08 AB 03
+25 0F 90 00 63 04 AB 03 25 0F B0 00 63 00 AB 03
+13 0F 00 00 63 04 0F 00 67 00 0F 00 73 2F 20 34
+63 54 0F 00 6F 00 40 00 25 E1 91 53 17 1F 00 00
+''';
+
+      final storage = SparseMemoryStorage(addrWidth: 32, dataWidth: 32)
+        ..loadMemString(hex)
+        ..loadMemString(hex);
+
+      final expected = [
+        0x0480006f,
+        0x34202f73,
+        0x00800f25,
+        0x03ab0863,
+        0x00900f25,
+        0x03ab0463,
+        0x00b00f25,
+        0x03ab0063,
+        0x00000f13,
+        0x000f0463,
+        0x000f0067,
+        0x34202f73,
+        0x000f5463,
+        0x0040006f,
+        0x5391e125,
+      ];
+
+      for (var i = 0; i < expected.length; i++) {
+        final addr = LogicValue.ofInt(0x80000000 + i * 4, 32);
+        final expectedData = LogicValue.ofInt(expected[i], 32);
+        expect(storage.getData(addr)!.toInt(), equals(expectedData.toInt()),
+            reason: 'Data at address $addr '
+                'should be $expectedData but was '
+                '${storage.getData(addr)!}');
+      }
+    });
+
     test('store 32-bit 1-per-addr data', () {
       final storage = SparseMemoryStorage(addrWidth: 8, dataWidth: 32);
       for (var i = 0; i < 10; i++) {


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

There was a bug in the `SparseMemoryStorage` where data in the first word would get shifted over by one byte (and some other stuff) if you load memory with `loadMemString` twice on overlapping or the same data ranges.  This PR fixes the bug and includes tests to cover the problem.

## Related Issue(s)

N/A

## Testing

Added new tests

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

N/A
