### PR TITLE
`FiniteStateMachine` upgrade with "updates"

### DIFF
--- a/lib/rohd_hcl.dart
+++ b/lib/rohd_hcl.dart
@@ -15,6 +15,7 @@ export 'src/extrema.dart';
 export 'src/fifo.dart';
 export 'src/find.dart';
 export 'src/find_pattern.dart';
+export 'src/finite_state_machine_with_updates.dart';
 export 'src/gaskets/spi/spi_gaskets.dart';
 export 'src/interfaces/interfaces.dart';
 export 'src/memory/memories.dart';

--- a/lib/src/finite_state_machine_with_updates.dart
+++ b/lib/src/finite_state_machine_with_updates.dart
@@ -1,0 +1,57 @@
+import 'package:rohd/rohd.dart';
+
+class StateWithUpdates<StateIdentifier> extends State<StateIdentifier> {
+  List<Conditional> updates;
+  StateWithUpdates(super.identifier,
+      {required super.events, required super.actions, this.updates = const []});
+}
+
+class FiniteStateMachineWithUpdates<StateIdentifier>
+    extends FiniteStateMachine<StateIdentifier> {
+  final Map<Logic, dynamic> updateResetValues;
+
+  FiniteStateMachineWithUpdates(
+    Logic clk,
+    Logic reset,
+    StateIdentifier resetState,
+    List<State<StateIdentifier>> states, {
+    bool asyncReset = false,
+    List<Conditional> setupActions = const [],
+    Map<Logic, dynamic> updateResetValues = const {},
+  }) : this.multi([clk], reset, resetState, states,
+            asyncReset: asyncReset,
+            setupActions: setupActions,
+            updateResetValues: updateResetValues);
+
+  FiniteStateMachineWithUpdates.multi(List<Logic> clks, Logic reset,
+      StateIdentifier resetState, List<State<StateIdentifier>> states,
+      {super.asyncReset, super.setupActions, this.updateResetValues = const {}})
+      : super.multi(
+          clks,
+          reset,
+          resetState,
+          states,
+        ) {
+    Sequential.multi(
+      clks,
+      reset: reset,
+      asyncReset: asyncReset,
+      resetValues: updateResetValues,
+      [
+        Case(
+            currentState,
+            states
+                .whereType<StateWithUpdates<StateIdentifier>>()
+                .map(
+                  (state) => CaseItem(
+                    label: state.identifier.toString(),
+                    Const(stateIndexLookup[state.identifier], width: stateWidth)
+                        .named(state.identifier.toString()),
+                    state.updates,
+                  ),
+                )
+                .toList(growable: false))
+      ],
+    );
+  }
+}

--- a/test/fsm_with_updates_test.dart
+++ b/test/fsm_with_updates_test.dart
@@ -1,0 +1,42 @@
+import 'package:rohd/rohd.dart';
+import 'package:rohd_hcl/src/finite_state_machine_with_updates.dart';
+import 'package:test/test.dart';
+
+enum ExStates {
+  state1,
+  state2,
+}
+
+class ExMod extends Module {
+  ExMod(Logic clk) {
+    clk = addInput('clk', clk);
+
+    FiniteStateMachineWithUpdates<ExStates>(
+      clk,
+      Logic(),
+      ExStates.state1,
+      [
+        StateWithUpdates<ExStates>(
+          ExStates.state1,
+          events: {},
+          actions: [],
+          updates: [Logic() < 1],
+        ),
+        StateWithUpdates<ExStates>(
+          ExStates.state2,
+          events: {},
+          actions: [],
+        ),
+      ],
+    );
+  }
+}
+
+void main() {
+  test('basic', () async {
+    final dut = ExMod(Logic());
+    await dut.build();
+
+    print(dut.generateSynth());
+  });
+}


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Adds a `FiniteStateMachineWithUpdates` that enables sequential updates in addition to the usual FSM capabilities.

## Related Issue(s)

<!-- If there are any issues related to this PR, please link to the issues here. -->

## Testing

<!-- Please describe how you tested your changes. -->

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

<!-- Answer here. -->

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

<!-- Answer here. -->
