### PR TITLE
Fixing bug in CsrTop frontdoor reads

### DIFF
--- a/lib/src/memory/csr/csr_top.dart
+++ b/lib/src/memory/csr/csr_top.dart
@@ -238,7 +238,7 @@ class CsrTop extends Module {
               maskedFrontWrAddr
                   .eq(Const(_blocks[i].baseAddr, width: addrWidth));
       _fdReads[i].en <=
-          _frontWrite.en &
+          _frontRead.en &
               maskedFrontRdAddr
                   .eq(Const(_blocks[i].baseAddr, width: addrWidth));
 


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Bug fix in CsrTop for frontdoor reads where the individual block read enables are tied to the top's frontdoor **write** enable. Obviously this is incorrect but technically is masked if one performs a write and then a read immediately after because the write will also trigger a read which in some cases will allow the read data to persist on the output.

## Related Issue(s)

N/A

## Testing

Slight tweak to the unit tests because they were getting fooled due to performing a write followed by a read or a read to a register that happened to be expecting an output of 0x0 (the default read value given resets).

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No issues with backwards compatibility - the fix is entirely contained within the implementation internals.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No need for doc updates.
