### PR TITLE
reduction with control working

### DIFF
--- a/doc/components/reduction_tree.md
+++ b/doc/components/reduction_tree.md
@@ -5,20 +5,20 @@ The `ReductionTree` component is a general tree generator that allows for arbitr
 The input sequence is provided in the form 'List\<Logic\>'.  The operation must be provided in the form:
 
  ```dart
- Logic Function(List<Logic> operands, {int? fullDepth, Logic? control, String name})
+ Logic Function(List<Logic> operands, {int depth, Logic? control, String name})
  ```
 
  This function should support operand lengths between $[2,radix]$ if the tree is to support an arbitrary length sequence: Note that the `ReductionTree` itself does not require the sequence length to be a power of the radix; it will use shorter operations to balance the tree when the sequence length is not a power of the radix.
 
-The resulting tree can be pipelined by specifying the depth of nodes before a pipestage is added.  Since the input can be of arbitrary length, paths in the tree may not be balanced, and extra pipestages will be added in shorter sections of the tree to align the computation.
+The resulting tree can be pipelined by specifying the depth of nodes before a pipestage is added, a parameter called `depthBetweenFlops`.  Since the input can be of arbitrary length, paths in the tree may not be balanced, and extra pipestages will be added in shorter sections of the tree to align the computation.
 
-An optional `control` Logic can be passed in to provide control at each level of the reduction tree. The optional `fullDepth` input informs this function what the depth of the tree is, which can be used to access the control.
+An optional `control` Logic can be passed in to the operation function to provide control at each level of the reduction tree. The `depth` input informs this function what the depth of the tree is, which can be used to access the control.  The depth is computed from the leaves of the tree.  If the original sequence length is not a power of the radix, then the depth is the maximum depth at each node in the tree to the leaves.
 
 Here is an example radix-4 computation tree using native addition on 79 13-bit inputs, pipelining every 2 operations deep, and producing a single 13-bit result.
 
 ```dart
   Logic addReduce(List<Logic> inputs,
-          {int? fullDepth, Logic? control, String name = ''}) =>
+          {int depth, Logic? control, String name = ''}) =>
       inputs.reduce((v, e) => v + e);
   /// Tree reduction using addReduce
     const width = 13;
@@ -26,13 +26,13 @@ Here is an example radix-4 computation tree using native addition on 79 13-bit i
     final vec = <Logic>[];
 
     final reductionTree = ReductionTree(
-        vec, radix: 4, addReduce, clk: clk, depthToFlop; 2);
+        vec, radix: 4, addReduce, clk: clk, depthBetweenFlops; 2);
   ```
 
 Here is the same example radix-4 computation tree but using prefix adders on 79 13-bit inputs, pipelining every 2 operations deep, and producing a single 21-bit result, due to width-extension of the prefix adder, adding 1 bit for each addition in 7 levels of the tree.
 
   ```dart
-Logic addReduceAdders(List<Logic> inputs, {int? fullDepth, Logic? control, String name = 'prefix'}) {
+Logic addReduceAdders(List<Logic> inputs, {int depth, Logic? control, String name = 'prefix'}) {
   if (inputs.length < 4) {
     return inputs.reduce((v, e) => v + e);
   } else {
@@ -51,7 +51,7 @@ Logic addReduceAdders(List<Logic> inputs, {int? fullDepth, Logic? control, Strin
     final vec = <Logic>[];
 
     final reductionTree = ReductionTree(
-        vec, radix: 4, addReduceWithAdders, clk: clk, depthToFlop; 2, signExtend: true);
+        vec, radix: 4, addReduceWithAdders, clk: clk, depthBetweenFlops; 2, signExtend: true);
   ```
 
 ## ReductionTree with control  
@@ -65,9 +65,9 @@ Logic addReduceAdders(List<Logic> inputs, {int? fullDepth, Logic? control, Strin
     final control = Logic(width: log2Ceil(vec.length)));
 
     Logic muxReduce(List<Logic> inputs,
-        {int? fullDepth, Logic? control, String name = 'mux'}) =>
-      mux(control![fullDepth!], inputs[1], inputs[0]);
+        {int depth, Logic? control, String name = 'mux'}) =>
+      mux(control![depth], inputs[1], inputs[0]);
 
     final muxTree = ReductionTree(vec, muxReduce,
-        clk: clk, depthToFlop: 2, control: control, name: 'mux');
+        clk: clk, depthBetweenFlops: 2, control: control, name: 'mux');
 ```

--- a/doc/components/reduction_tree.md
+++ b/doc/components/reduction_tree.md
@@ -12,13 +12,14 @@ The input sequence is provided in the form 'List\<Logic\>'.  The operation must 
 
 The resulting tree can be pipelined by specifying the depth of nodes before a pipestage is added.  Since the input can be of arbitrary length, paths in the tree may not be balanced, and extra pipestages will be added in shorter sections of the tree to align the computation.
 
+An optional `control` Logic can be passed in to provide control at each level of the reduction tree.
+
 Here is an example radix-4 computation tree using native addition on 79 13-bit inputs, pipelining every 2 operations deep, and producing a single 13-bit result.
 
 ```dart
-  Logic addReduce(List<Logic> inputs, {String name = 'native'}) {
-    final a = inputs.reduce((v, e) => v + e);
-    return a;
-  }
+  Logic addReduce(List<Logic> inputs,
+          {int? trueDepth, Logic? control, String name = ''}) =>
+      inputs.reduce((v, e) => v + e);
   /// Tree reduction using addReduce
     const width = 13;
     const length = 79;
@@ -52,3 +53,21 @@ Logic addReduceAdders(List<Logic> inputs, {String name = 'prefix'}) {
     final reductionTree = ReductionTree(
         vec, radix: 4, addReduceWithAdders, clk: clk, depthToFlop; 2, signExtend: true);
   ```
+
+## ReductionTree with control  
+
+  Here is an example using a radix-2 computation tree with muxes and a selection control signal.
+
+```dart
+    const length = 1024;
+    final width = log2Ceil(length);
+    final vec = <Logic>[];
+    final control = Logic(width: log2Ceil(vec.length)));
+
+    Logic muxReduce(List<Logic> inputs,
+        {int? trueDepth, Logic? control, String name = 'mux'}) =>
+      mux(control![trueDepth!], inputs[1], inputs[0]);
+
+    final muxTree = ReductionTree(vec, muxReduce,
+        clk: clk, depthToFlop: 2, control: control, name: 'mux');
+```

--- a/doc/components/reduction_tree.md
+++ b/doc/components/reduction_tree.md
@@ -5,20 +5,20 @@ The `ReductionTree` component is a general tree generator that allows for arbitr
 The input sequence is provided in the form 'List\<Logic\>'.  The operation must be provided in the form:
 
  ```dart
- Logic Function(List<Logic> operands, {String name})
+ Logic Function(List<Logic> operands, {int? fullDepth, Logic? control, String name})
  ```
 
  This function should support operand lengths between $[2,radix]$ if the tree is to support an arbitrary length sequence: Note that the `ReductionTree` itself does not require the sequence length to be a power of the radix; it will use shorter operations to balance the tree when the sequence length is not a power of the radix.
 
 The resulting tree can be pipelined by specifying the depth of nodes before a pipestage is added.  Since the input can be of arbitrary length, paths in the tree may not be balanced, and extra pipestages will be added in shorter sections of the tree to align the computation.
 
-An optional `control` Logic can be passed in to provide control at each level of the reduction tree.
+An optional `control` Logic can be passed in to provide control at each level of the reduction tree. The optional `fullDepth` input informs this function what the depth of the tree is, which can be used to access the control.
 
 Here is an example radix-4 computation tree using native addition on 79 13-bit inputs, pipelining every 2 operations deep, and producing a single 13-bit result.
 
 ```dart
   Logic addReduce(List<Logic> inputs,
-          {int? trueDepth, Logic? control, String name = ''}) =>
+          {int? fullDepth, Logic? control, String name = ''}) =>
       inputs.reduce((v, e) => v + e);
   /// Tree reduction using addReduce
     const width = 13;
@@ -32,7 +32,7 @@ Here is an example radix-4 computation tree using native addition on 79 13-bit i
 Here is the same example radix-4 computation tree but using prefix adders on 79 13-bit inputs, pipelining every 2 operations deep, and producing a single 21-bit result, due to width-extension of the prefix adder, adding 1 bit for each addition in 7 levels of the tree.
 
   ```dart
-Logic addReduceAdders(List<Logic> inputs, {String name = 'prefix'}) {
+Logic addReduceAdders(List<Logic> inputs, {int? fullDepth, Logic? control, String name = 'prefix'}) {
   if (inputs.length < 4) {
     return inputs.reduce((v, e) => v + e);
   } else {
@@ -65,8 +65,8 @@ Logic addReduceAdders(List<Logic> inputs, {String name = 'prefix'}) {
     final control = Logic(width: log2Ceil(vec.length)));
 
     Logic muxReduce(List<Logic> inputs,
-        {int? trueDepth, Logic? control, String name = 'mux'}) =>
-      mux(control![trueDepth!], inputs[1], inputs[0]);
+        {int? fullDepth, Logic? control, String name = 'mux'}) =>
+      mux(control![fullDepth!], inputs[1], inputs[0]);
 
     final muxTree = ReductionTree(vec, muxReduce,
         clk: clk, depthToFlop: 2, control: control, name: 'mux');

--- a/lib/rohd_hcl.dart
+++ b/lib/rohd_hcl.dart
@@ -21,6 +21,7 @@ export 'src/memory/memories.dart';
 export 'src/models/models.dart';
 export 'src/priority_encoder.dart';
 export 'src/reduction_tree.dart';
+export 'src/reduction_tree_generator.dart';
 export 'src/rotate.dart';
 export 'src/serialization/serialization.dart';
 export 'src/shift_register.dart';

--- a/lib/src/reduction_tree.dart
+++ b/lib/src/reduction_tree.dart
@@ -78,10 +78,10 @@ class ReductionTree extends Module {
   /// segment.
   /// - [sequence] is the input sequence to be reduced using the tree of
   ///   operations.
-  /// - Logic Function(List<Logic> inputs, {String name}) [operation] is the
-  ///   operation to be performed at each node. Note that [operation] can widen
-  ///   the output. The logic function must support the operation for (2 to
-  ///   [radix]) inputs.
+  /// - Logic Function(List<Logic> inputs, {int? trueDepth, String name})
+  ///   [operation] is the operation to be performed at each node. Note that
+  ///   [operation] can widen the output. The logic function must support the
+  ///   operation for (2 to [radix]) inputs.
   /// - [radix] is the width of reduction at each node in the tree (e.g.,
   ///   binary: radix=2).
   /// - [signExtend] if true, use sign-extension to widen Logic values as needed

--- a/lib/src/reduction_tree.dart
+++ b/lib/src/reduction_tree.dart
@@ -28,9 +28,13 @@ class ReductionTree extends Module {
 
   /// Operation to be performed at each node. Note that [operation] can widen
   /// the output. The logic function must support the operation for 2 and up to
-  /// [radix] inputs.
+  /// [radix] inputs. The [depth] input is the depth of the current node in the
+  /// tree to the leaves.  For sequences that are not powers of [radix], the
+  /// depth is the maximum depth to the leaves from this node in the tree.  The
+  /// [depth] can be used to index the control Logic to change behavior at each
+  /// depth of the tree.
   final Logic Function(List<Logic> inputs,
-      {int? depth, Logic? control, String name}) operation;
+      {int depth, Logic? control, String name}) operation;
 
   /// Specified width of input to each reduction node (e.g., binary: radix=2)
   final int radix;
@@ -81,8 +85,7 @@ class ReductionTree extends Module {
   /// segment.
   /// - [sequence] is the input sequence to be reduced using the tree of
   ///   operations.
-  /// - Logic Function(List<Logic> inputs, {int? depth, String name})
-  ///   [operation] is the operation to be performed at each node. Note that
+  /// - [operation] is the operation to be performed at each node. Note that
   ///   [operation] can widen the output. The logic function must support the
   ///   operation for (2 to [radix]) inputs.
   /// - [radix] is the width of reduction at each node in the tree (e.g.,
@@ -109,6 +112,9 @@ class ReductionTree extends Module {
     if (sequence.isEmpty) {
       throw RohdHclException("Don't use ReductionTree "
           'with an empty sequence');
+    }
+    if (radix < 2) {
+      throw RohdHclException('Radix must be at least 2, got $radix');
     }
     _sequence = [
       for (var i = 0; i < sequence.length; i++)

--- a/lib/src/reduction_tree_generator.dart
+++ b/lib/src/reduction_tree_generator.dart
@@ -32,9 +32,13 @@ class ReductionTreeGenerator {
 
   /// Operation to be performed at each node. Note that [operation] can widen
   /// the output. The logic function must support the operation for 2 and up to
-  /// [radix] inputs.
+  /// [radix] inputs. The [depth] input is the depth of the current node in the
+  /// tree to the leaves.  For sequences that are not powers of [radix], the
+  /// depth is the maximum depth to the leaves from this node in the tree.  The
+  /// [depth] can be used to index the control Logic to change behavior at each
+  /// depth of the tree.
   final Logic Function(List<Logic> inputs,
-      {int? depth, Logic? control, String name}) operation;
+      {int depth, Logic? control, String name}) operation;
 
   /// Specified width of input to each reduction node (e.g., binary: radix=2)
   final int radix;
@@ -77,8 +81,7 @@ class ReductionTreeGenerator {
   /// segment.
   /// - [sequence] is the input sequence to be reduced using the tree of
   ///   operations.
-  /// - Logic Function(List<Logic> inputs, {int? depth, String name})
-  ///   [operation] is the operation to be performed at each node. Note that
+  /// - [operation] is the operation to be performed at each node. Note that
   ///   [operation] can widen the output. The logic function must support the
   ///   operation for (2 to [radix]) inputs.
   /// - [radix] is the width of reduction at each node in the tree (e.g.,
@@ -104,6 +107,9 @@ class ReductionTreeGenerator {
     if (sequence.isEmpty) {
       throw RohdHclException("Don't use ReductionTreeGenerator "
           'with an empty sequence');
+    }
+    if (radix < 2) {
+      throw RohdHclException('Radix must be at least 2, got $radix');
     }
     controlOut = control != null ? Logic(width: control!.width) : null;
     _computed = _reductionTreeRecurse(sequence);

--- a/test/reduction_tree_generator_test.dart
+++ b/test/reduction_tree_generator_test.dart
@@ -1,20 +1,18 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
-// reduction_tree_test.dart
+// reduction_tree_generator_test.dart
 // Tests of the ReductionTree generator.
 //
-// 2025 January 8
+// 2025 June 23
 // Author: Desmond A Kirkpatrick <desmond.a.kirkpatrick@intel.com
 
 import 'dart:async';
-import 'dart:io';
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
 import 'package:rohd_vf/rohd_vf.dart';
 import 'package:test/test.dart';
 
-// Only for radix>=4
 Logic addReduceAdders(List<Logic> inputs,
     {int? fullDepth, Logic? control, String name = 'prefix'}) {
   if (inputs.length < 4) {
@@ -24,23 +22,20 @@ Logic addReduceAdders(List<Logic> inputs,
         ParallelPrefixAdder(inputs[0], inputs[1], name: '${name}_add0');
     final add1 =
         ParallelPrefixAdder(inputs[2], inputs[3], name: '${name}_add1');
-    final addf = ParallelPrefixAdder(add0.sum, add1.sum,
-        name: '${name}_addf_${fullDepth ?? 0}');
+    final addf = ParallelPrefixAdder(add0.sum, add1.sum, name: '${name}_addf');
     return addf.sum;
   }
 }
-
-Logic muxReduce(List<Logic> inputs,
-        {int? fullDepth, Logic? control, String name = 'mux'}) =>
-    mux(control![fullDepth!], inputs[1], inputs[0]);
 
 void main() {
   tearDown(() async {
     await Simulator.reset();
   });
   Logic addReduce(List<Logic> inputs,
-          {int? fullDepth, Logic? control, String name = ''}) =>
-      inputs.reduce((v, e) => v + e);
+      {int? fullDepth, Logic? control, String name = ''}) {
+    final a = inputs.reduce((v, e) => v + e);
+    return a;
+  }
 
   test('reduction tree of add operations -- quick test', () async {
     const width = 13;
@@ -54,61 +49,9 @@ void main() {
       count = count + i;
     }
     for (var radix = 2; radix < length; radix++) {
-      final prefixAdd = ReductionTree(vec, radix: radix, addReduce);
+      final prefixAdd = ReductionTreeGenerator(vec, radix: radix, addReduce);
       expect(prefixAdd.out.value.toInt(), equals(count));
     }
-  });
-
-  test('reduction tree of muxes -- large singleton', () async {
-    const length = 16;
-    final width = log2Ceil(length);
-    final vec = <Logic>[];
-
-    // First sum will be length *(length-1) /2
-    var count = 0;
-    for (var i = 0; i < length; i++) {
-      vec.add(Const(i, width: width));
-      count = count + i;
-    }
-    const controlValue = 14;
-    final control = Const(controlValue, width: log2Ceil(vec.length));
-    final muxTree =
-        ReductionTree(vec, muxReduce, control: control, name: 'mux');
-    await muxTree.build();
-    File('mux_tree.sv').writeAsStringSync(muxTree.generateSynth());
-  });
-
-  test('reduction tree of muxes -- large flopped', () async {
-    final clk = SimpleClockGenerator(10).clk;
-
-    const length = 1024;
-    final width = log2Ceil(length);
-    final vec = <Logic>[];
-
-    var count = 0;
-    for (var i = 0; i < length; i++) {
-      vec.add(Const(i, width: width));
-      count = count + i;
-    }
-    final control = Logic(width: log2Ceil(vec.length))..put(0);
-    final muxTree = ReductionTree(vec, muxReduce,
-        clk: clk, depthToFlop: 2, control: control, name: 'mux');
-
-    final positions = [7, 4, 5, 6, 12, 0, 1010, 511, 212, 0, 789];
-
-    await muxTree.build();
-    final latency = muxTree.latency;
-    unawaited(Simulator.run());
-    for (var clkCnt = 0; clkCnt < positions.length + latency; clkCnt++) {
-      await clk.nextNegedge;
-      if (clkCnt < positions.length) {
-        control.put(positions[clkCnt]);
-      }
-      if (clkCnt >= latency) {
-        expect(muxTree.out.value.toInt(), positions[clkCnt - latency]);
-      }
-    }
-    await Simulator.endSimulation();
   });
 
   test('reduction tree of adders -- large', () async {
@@ -125,7 +68,8 @@ void main() {
       count = count + i;
     }
     for (var radix = 2; radix < length; radix++) {
-      final prefixAdd = ReductionTree(vec, radix: radix, addReduce, clk: clk);
+      final prefixAdd =
+          ReductionTreeGenerator(vec, radix: radix, addReduce, clk: clk);
       expect(prefixAdd.out.value.toInt(), equals(count));
     }
   });
@@ -141,15 +85,9 @@ void main() {
       vec.add(Const(i, width: width));
     }
     const radix = 4;
-    final prefixAdd = ReductionTree(
-        vec,
-        radix: radix,
-        addReduce,
-        clk: clk,
-        depthToFlop: 1,
-        name: 'prefix_reduction');
+    final prefixAdd = ReductionTreeGenerator(
+        vec, radix: radix, addReduce, clk: clk, depthToFlop: 1);
 
-    await prefixAdd.build();
     unawaited(Simulator.run());
     var cycles = 0;
     await clk.nextNegedge;
@@ -179,6 +117,42 @@ void main() {
     await Simulator.endSimulation();
   });
 
+  Logic muxReduce(List<Logic> inputs,
+          {int? fullDepth, Logic? control, String name = 'mux'}) =>
+      mux(control![fullDepth!], inputs[1], inputs[0]);
+
+  test('reduction tree of muxes -- large flopped', () async {
+    final clk = SimpleClockGenerator(10).clk;
+
+    const length = 1024;
+    final width = log2Ceil(length);
+    final vec = <Logic>[];
+
+    var count = 0;
+    for (var i = 0; i < length; i++) {
+      vec.add(Const(i, width: width));
+      count = count + i;
+    }
+    final control = Logic(width: log2Ceil(vec.length))..put(0);
+    final muxTree = ReductionTreeGenerator(vec, muxReduce,
+        clk: clk, depthToFlop: 2, control: control);
+
+    final positions = [7, 4, 5, 6, 12, 0, 1010, 511, 212, 0, 789];
+
+    final latency = muxTree.latency;
+    unawaited(Simulator.run());
+    for (var clkCnt = 0; clkCnt < positions.length + latency; clkCnt++) {
+      await clk.nextNegedge;
+      if (clkCnt < positions.length) {
+        control.put(positions[clkCnt]);
+      }
+      if (clkCnt >= latency) {
+        expect(muxTree.out.value.toInt(), positions[clkCnt - latency]);
+      }
+    }
+    await Simulator.endSimulation();
+  });
+
   test('reduction tree of prefix adders -- large, pipelined, radix 4',
       () async {
     final clk = SimpleClockGenerator(10).clk;
@@ -191,10 +165,9 @@ void main() {
       vec.add(Const(i, width: width));
     }
     const reduce = 4;
-    final prefixAdd = ReductionTree(
+    final prefixAdd = ReductionTreeGenerator(
         vec, radix: reduce, addReduceAdders, clk: clk, depthToFlop: 1);
 
-    await prefixAdd.build();
     unawaited(Simulator.run());
     var cycles = 0;
     await clk.nextNegedge;

--- a/test/reduction_tree_generator_test.dart
+++ b/test/reduction_tree_generator_test.dart
@@ -14,7 +14,7 @@ import 'package:rohd_vf/rohd_vf.dart';
 import 'package:test/test.dart';
 
 Logic addReduceAdders(List<Logic> inputs,
-    {int? fullDepth, Logic? control, String name = 'prefix'}) {
+    {int? depth, Logic? control, String name = 'prefix'}) {
   if (inputs.length < 4) {
     return inputs.reduce((v, e) => v + e);
   } else {
@@ -32,7 +32,7 @@ void main() {
     await Simulator.reset();
   });
   Logic addReduce(List<Logic> inputs,
-      {int? fullDepth, Logic? control, String name = ''}) {
+      {int? depth, Logic? control, String name = ''}) {
     final a = inputs.reduce((v, e) => v + e);
     return a;
   }
@@ -86,7 +86,7 @@ void main() {
     }
     const radix = 4;
     final prefixAdd = ReductionTreeGenerator(
-        vec, radix: radix, addReduce, clk: clk, depthToFlop: 1);
+        vec, radix: radix, addReduce, clk: clk, depthBetweenFlops: 1);
 
     unawaited(Simulator.run());
     var cycles = 0;
@@ -118,8 +118,8 @@ void main() {
   });
 
   Logic muxReduce(List<Logic> inputs,
-          {int? fullDepth, Logic? control, String name = 'mux'}) =>
-      mux(control![fullDepth!], inputs[1], inputs[0]);
+          {int? depth, Logic? control, String name = 'mux'}) =>
+      mux(control![depth!], inputs[1], inputs[0]);
 
   test('reduction tree of muxes -- large flopped', () async {
     final clk = SimpleClockGenerator(10).clk;
@@ -135,7 +135,7 @@ void main() {
     }
     final control = Logic(width: log2Ceil(vec.length))..put(0);
     final muxTree = ReductionTreeGenerator(vec, muxReduce,
-        clk: clk, depthToFlop: 2, control: control);
+        clk: clk, depthBetweenFlops: 2, control: control);
 
     final positions = [7, 4, 5, 6, 12, 0, 1010, 511, 212, 0, 789];
 
@@ -166,7 +166,7 @@ void main() {
     }
     const reduce = 4;
     final prefixAdd = ReductionTreeGenerator(
-        vec, radix: reduce, addReduceAdders, clk: clk, depthToFlop: 1);
+        vec, radix: reduce, addReduceAdders, clk: clk, depthBetweenFlops: 1);
 
     unawaited(Simulator.run());
     var cycles = 0;

--- a/test/reduction_tree_test.dart
+++ b/test/reduction_tree_test.dart
@@ -76,7 +76,6 @@ void main() {
         ReductionTree(vec, muxReduce, control: control, name: 'mux');
     await muxTree.build();
     File('mux_tree.sv').writeAsStringSync(muxTree.generateSynth());
-    print(muxTree.out.value.toInt());
   });
 
   test('reduction tree of muxes -- large flopped', () async {

--- a/test/reduction_tree_test.dart
+++ b/test/reduction_tree_test.dart
@@ -98,7 +98,6 @@ void main() {
 
     await muxTree.build();
     final latency = muxTree.latency;
-    WaveDumper(muxTree);
     unawaited(Simulator.run());
     for (var clkCnt = 0; clkCnt < positions.length + latency; clkCnt++) {
       await clk.nextNegedge;

--- a/test/reduction_tree_test.dart
+++ b/test/reduction_tree_test.dart
@@ -8,12 +8,15 @@
 // Author: Desmond A Kirkpatrick <desmond.a.kirkpatrick@intel.com
 
 import 'dart:async';
+import 'dart:io';
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
 import 'package:rohd_vf/rohd_vf.dart';
 import 'package:test/test.dart';
 
-Logic addReduceAdders(List<Logic> inputs, {String name = 'prefix'}) {
+// Only for radix>=4
+Logic addReduceAdders(List<Logic> inputs,
+    {int? trueDepth, Logic? control, String name = 'prefix'}) {
   if (inputs.length < 4) {
     return inputs.reduce((v, e) => v + e);
   } else {
@@ -21,19 +24,23 @@ Logic addReduceAdders(List<Logic> inputs, {String name = 'prefix'}) {
         ParallelPrefixAdder(inputs[0], inputs[1], name: '${name}_add0');
     final add1 =
         ParallelPrefixAdder(inputs[2], inputs[3], name: '${name}_add1');
-    final addf = ParallelPrefixAdder(add0.sum, add1.sum, name: '${name}_addf');
+    final addf = ParallelPrefixAdder(add0.sum, add1.sum,
+        name: '${name}_addf_${trueDepth ?? 0}');
     return addf.sum;
   }
 }
+
+Logic muxReduce(List<Logic> inputs,
+        {int? trueDepth, Logic? control, String name = 'mux'}) =>
+    mux(control![trueDepth!], inputs[1], inputs[0]);
 
 void main() {
   tearDown(() async {
     await Simulator.reset();
   });
-  Logic addReduce(List<Logic> inputs, {String name = ''}) {
-    final a = inputs.reduce((v, e) => v + e);
-    return a;
-  }
+  Logic addReduce(List<Logic> inputs,
+          {int? trueDepth, Logic? control, String name = ''}) =>
+      inputs.reduce((v, e) => v + e);
 
   test('reduction tree of add operations -- quick test', () async {
     const width = 13;
@@ -50,6 +57,60 @@ void main() {
       final prefixAdd = ReductionTree(vec, radix: radix, addReduce);
       expect(prefixAdd.out.value.toInt(), equals(count));
     }
+  });
+
+  test('reduction tree of muxes -- large singleton', () async {
+    const length = 16;
+    final width = log2Ceil(length);
+    final vec = <Logic>[];
+
+    // First sum will be length *(length-1) /2
+    var count = 0;
+    for (var i = 0; i < length; i++) {
+      vec.add(Const(i, width: width));
+      count = count + i;
+    }
+    const controlValue = 14;
+    final control = Const(controlValue, width: log2Ceil(vec.length));
+    final muxTree =
+        ReductionTree(vec, muxReduce, control: control, name: 'mux');
+    await muxTree.build();
+    File('mux_tree.sv').writeAsStringSync(muxTree.generateSynth());
+    print(muxTree.out.value.toInt());
+  });
+
+  test('reduction tree of muxes -- large flopped', () async {
+    final clk = SimpleClockGenerator(10).clk;
+
+    const length = 1024;
+    final width = log2Ceil(length);
+    final vec = <Logic>[];
+
+    var count = 0;
+    for (var i = 0; i < length; i++) {
+      vec.add(Const(i, width: width));
+      count = count + i;
+    }
+    final control = Logic(width: log2Ceil(vec.length))..put(0);
+    final muxTree = ReductionTree(vec, muxReduce,
+        clk: clk, depthToFlop: 2, control: control, name: 'mux');
+
+    final positions = [7, 4, 5, 6, 12, 0, 1010, 511, 212, 0, 789];
+
+    await muxTree.build();
+    final latency = muxTree.latency;
+    WaveDumper(muxTree);
+    unawaited(Simulator.run());
+    for (var clkCnt = 0; clkCnt < positions.length + latency; clkCnt++) {
+      await clk.nextNegedge;
+      if (clkCnt < positions.length) {
+        control.put(positions[clkCnt]);
+      }
+      if (clkCnt >= latency) {
+        expect(muxTree.out.value.toInt(), positions[clkCnt - latency]);
+      }
+    }
+    await Simulator.endSimulation();
   });
 
   test('reduction tree of adders -- large', () async {

--- a/test/reduction_tree_test.dart
+++ b/test/reduction_tree_test.dart
@@ -16,7 +16,7 @@ import 'package:test/test.dart';
 
 // Only for radix>=4
 Logic addReduceAdders(List<Logic> inputs,
-    {int? fullDepth, Logic? control, String name = 'prefix'}) {
+    {int? depth, Logic? control, String name = 'prefix'}) {
   if (inputs.length < 4) {
     return inputs.reduce((v, e) => v + e);
   } else {
@@ -25,21 +25,21 @@ Logic addReduceAdders(List<Logic> inputs,
     final add1 =
         ParallelPrefixAdder(inputs[2], inputs[3], name: '${name}_add1');
     final addf = ParallelPrefixAdder(add0.sum, add1.sum,
-        name: '${name}_addf_${fullDepth ?? 0}');
+        name: '${name}_addf_${depth ?? 0}');
     return addf.sum;
   }
 }
 
 Logic muxReduce(List<Logic> inputs,
-        {int? fullDepth, Logic? control, String name = 'mux'}) =>
-    mux(control![fullDepth!], inputs[1], inputs[0]);
+        {int? depth, Logic? control, String name = 'mux'}) =>
+    mux(control![depth!], inputs[1], inputs[0]);
 
 void main() {
   tearDown(() async {
     await Simulator.reset();
   });
   Logic addReduce(List<Logic> inputs,
-          {int? fullDepth, Logic? control, String name = ''}) =>
+          {int? depth, Logic? control, String name = ''}) =>
       inputs.reduce((v, e) => v + e);
 
   test('reduction tree of add operations -- quick test', () async {
@@ -92,7 +92,7 @@ void main() {
     }
     final control = Logic(width: log2Ceil(vec.length))..put(0);
     final muxTree = ReductionTree(vec, muxReduce,
-        clk: clk, depthToFlop: 2, control: control, name: 'mux');
+        clk: clk, depthBetweenFlops: 2, control: control, name: 'mux');
 
     final positions = [7, 4, 5, 6, 12, 0, 1010, 511, 212, 0, 789];
 
@@ -146,7 +146,7 @@ void main() {
         radix: radix,
         addReduce,
         clk: clk,
-        depthToFlop: 1,
+        depthBetweenFlops: 1,
         name: 'prefix_reduction');
 
     await prefixAdd.build();
@@ -192,7 +192,7 @@ void main() {
     }
     const reduce = 4;
     final prefixAdd = ReductionTree(
-        vec, radix: reduce, addReduceAdders, clk: clk, depthToFlop: 1);
+        vec, radix: reduce, addReduceAdders, clk: clk, depthBetweenFlops: 1);
 
     await prefixAdd.build();
     unawaited(Simulator.run());


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

There are situations where we need control at each level of reduction.

## Related Issue(s)

None.

## Testing

We provide a muxing example that tests that mux input selects come out on the correct cycle.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

None.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Yes.  The markdown is updated as is the API documentation for using the new control input.
