### PR TITLE
Add error generation to `TreeOneHotToBinary`

### DIFF
--- a/lib/src/encodings/one_hot_to_binary.dart
+++ b/lib/src/encodings/one_hot_to_binary.dart
@@ -32,14 +32,11 @@ abstract class OneHotToBinary extends Module {
       {bool generateError = false, String name = 'one_hot_to_binary'}) {
     final isSmall = onehot.width <= 8;
 
-    if (!isSmall && generateError) {
-      throw RohdHclException(
-          'Tree implementation does not generate error signal.');
-    }
-
-    return isSmall
-        ? CaseOneHotToBinary(onehot, generateError: generateError, name: name)
-        : TreeOneHotToBinary(onehot, name: name);
+    return (isSmall ? CaseOneHotToBinary.new : TreeOneHotToBinary.new)(
+      onehot,
+      generateError: generateError,
+      name: name,
+    );
   }
 
   /// The [input] of this instance.
@@ -50,6 +47,7 @@ abstract class OneHotToBinary extends Module {
 
   /// Constructs a [Module] which decodes a one-hot number [onehot] into a 2s
   /// complement number [binary] by encoding the position of the '1'.
+  @protected
   OneHotToBinary.base(Logic onehot,
       {this.generateError = false,
       super.name = 'one_hot_to_binary',

--- a/lib/src/encodings/tree_one_hot_to_binary.dart
+++ b/lib/src/encodings/tree_one_hot_to_binary.dart
@@ -13,9 +13,15 @@ import 'package:rohd_hcl/rohd_hcl.dart';
 /// Module for binary-tree recursion for decoding one-hot.
 class TreeOneHotToBinary extends OneHotToBinary {
   /// Top level module for computing binary to one-hot using recursion
-  TreeOneHotToBinary(super.onehot, {super.name = 'tree_one_hot_to_binary'})
+  TreeOneHotToBinary(super.onehot,
+      {super.generateError, super.name = 'tree_one_hot_to_binary'})
       : super.base() {
-    binary <= _NodeOneHotToBinary(onehot).binary;
+    final node = _NodeOneHotToBinary(onehot, generateMultiple: generateError);
+    binary <= node.binary;
+
+    if (generateError) {
+      error! <= ~onehot.or() | node.multiple!;
+    }
   }
 }
 
@@ -24,22 +30,40 @@ class _NodeOneHotToBinary extends Module {
   /// The [binary] decoded result.
   Logic get binary => output('binary');
 
+  /// If `true`, then the [multiple] output will be generated.
+  final bool generateMultiple;
+
+  /// Indicates that multiple bits (>1) were asserted.
+  Logic? get multiple => tryOutput('multiple');
+
   /// Build a shorter-input module for recursion
   /// (borrowed from Chisel OHToUInt)
-  _NodeOneHotToBinary(Logic onehot)
+  _NodeOneHotToBinary(Logic onehot, {this.generateMultiple = false})
       : super(
             name: 'node_one_hot_to_binary',
             definitionName: 'NodeOneHotToBinary_W${onehot.width}') {
     final wid = onehot.width;
     onehot = addInput('onehot', onehot, width: wid);
 
+    if (generateMultiple) {
+      addOutput('multiple');
+    }
+
     if (wid <= 2) {
       addOutput('binary');
       //Log2 of 2-bit quantity
       if (wid == 2) {
         binary <= onehot[1];
+
+        if (generateMultiple) {
+          multiple! <= onehot.and();
+        }
       } else {
-        binary <= Const(0, width: 1);
+        binary <= Const(0);
+
+        if (generateMultiple) {
+          multiple! <= Const(0);
+        }
       }
     } else {
       final mid = 1 << (log2Ceil(wid) - 1);
@@ -47,8 +71,16 @@ class _NodeOneHotToBinary extends Module {
       final hi = onehot.getRange(mid).zeroExtend(mid).named('hi');
       final lo = onehot.getRange(0, mid).zeroExtend(mid).named('lo');
       final recurse = lo | hi;
-      final response = _NodeOneHotToBinary(recurse).binary;
-      binary <= [hi.or(), response].swizzle();
+      final anyHi = hi.or().named('any_hi');
+      final subNode =
+          _NodeOneHotToBinary(recurse, generateMultiple: generateMultiple);
+      final response = subNode.binary;
+      binary <= [anyHi, response].swizzle();
+
+      if (generateMultiple) {
+        final anyLo = lo.or().named('any_lo');
+        multiple! <= (anyHi & anyLo) | subNode.multiple!;
+      }
     }
   }
 }

--- a/lib/src/error_checking/ecc.dart
+++ b/lib/src/error_checking/ecc.dart
@@ -44,9 +44,6 @@ enum HammingType {
   int get _extraParityBits => hasExtraParityBit ? 1 : 0;
 }
 
-/// Returns whether [n] is a power of two.
-bool _isPowerOfTwo(int n) => n != 0 && (n & (n - 1) == 0);
-
 /// A transmitter for data which generates a Hamming code for error detection
 /// and possibly correction.
 class HammingEccTransmitter extends ErrorCheckingTransmitter {
@@ -87,7 +84,7 @@ class HammingEccTransmitter extends ErrorCheckingTransmitter {
     for (var i = 1;
         i <= transmission.width - hammingType._extraParityBits;
         i++) {
-      if (!_isPowerOfTwo(i)) {
+      if (!isPowerOfTwo(i)) {
         final ilv = LogicValue.ofInt(i, hammingCodeWidth);
 
         for (var p = 0; p < hammingCodeWidth; p++) {
@@ -214,7 +211,7 @@ class HammingEccReceiver extends ErrorCheckingReceiver {
     final mapping = <int, int>{};
     var dataIdx = 0;
     for (var encodedIdx = 1; encodedIdx <= transmission.width; encodedIdx++) {
-      if (!_isPowerOfTwo(encodedIdx)) {
+      if (!isPowerOfTwo(encodedIdx)) {
         mapping[encodedIdx] = dataIdx++;
       }
     }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -10,6 +10,9 @@ import 'package:rohd/rohd.dart';
 /// Computes the bit width needed to store [w] addresses.
 int log2Ceil(int w) => (log(w) / log(2)).ceil();
 
+/// Returns whether [n] is a power of two.
+bool isPowerOfTwo(int n) => n != 0 && (n & (n - 1) == 0);
+
 /// This extension will eventually move to ROHD once it is proven useful
 extension LogicValueBitString on LogicValue {
   /// Simplest version of bit string representation as shorthand

--- a/test/one_hot_test.dart
+++ b/test/one_hot_test.dart
@@ -45,6 +45,19 @@ void main() {
       expect(err.value.toBool(), isTrue);
     });
 
+    test('tree error on decode', () {
+      final onehot = Logic(width: 13);
+      final bin = TreeOneHotToBinary(onehot, generateError: true);
+      onehot.put(3);
+      expect(bin.error!.value.toBool(), isTrue);
+
+      onehot.put(0);
+      expect(bin.error!.value.toBool(), isTrue);
+
+      onehot.put(2);
+      expect(bin.error!.value.toBool(), isFalse);
+    });
+
     final ohToBTypes = [
       (name: 'case', constructor: CaseOneHotToBinary.new, max: 8),
       (name: 'tree', constructor: TreeOneHotToBinary.new, max: 100),
@@ -59,6 +72,22 @@ void main() {
               ohToBType.constructor(Const(val, width: pos + 1)).binary;
           final expected = LogicValue.ofInt(pos, computed.width);
           expect(computed.value, equals(expected));
+        }
+      });
+
+      test('error detection ${ohToBType.name}', () {
+        for (final width in [7, 8, 9, 10]) {
+          final onehot = Logic(width: width);
+          final dut = ohToBType.constructor(onehot, generateError: true);
+
+          for (var i = 0; i < 1 << width; i++) {
+            onehot.put(i);
+            if (i == 0 || !isPowerOfTwo(i)) {
+              expect(dut.error!.value.toBool(), isTrue, reason: '$i');
+            } else {
+              expect(dut.error!.value.toBool(), isFalse, reason: '$i');
+            }
+          }
         }
       });
     }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

The `TreeOneHotToBinary` had a limitation where it could not generate an error signal, which was annoying.  This PR adds it.

## Related Issue(s)

N/A

## Testing

Added new tests

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
