### PR TITLE
Denormal as Zero / Flush to Zero feature added to floating-point adders

### DIFF
--- a/lib/src/arithmetic/floating_point/floating_point_adder.dart
+++ b/lib/src/arithmetic/floating_point/floating_point_adder.dart
@@ -52,6 +52,7 @@ abstract class FloatingPointAdder<FpTypeIn extends FloatingPoint,
   late final FpTypeOut internalSum;
 
   /// The rounding mode to use for the adder.
+  @protected
   late final FloatingPointRoundingMode roundingMode;
 
   /// Add two floating point numbers [a] and [b], returning result in [sum].

--- a/lib/src/arithmetic/floating_point/floating_point_adder_dualpath.dart
+++ b/lib/src/arithmetic/floating_point/floating_point_adder_dualpath.dart
@@ -30,6 +30,7 @@ class FloatingPointAdderDualPath<FpTypeIn extends FloatingPoint,
       super.clk,
       super.reset,
       super.enable,
+      super.outSum,
       super.roundingMode = FloatingPointRoundingMode.roundNearestEven,
       Adder Function(Logic a, Logic b, {Logic? carryIn, String name}) adderGen =
           NativeAdder.new,

--- a/lib/src/arithmetic/floating_point/floating_point_adder_singlepath.dart
+++ b/lib/src/arithmetic/floating_point/floating_point_adder_singlepath.dart
@@ -62,9 +62,16 @@ class FloatingPointAdderSinglePath<FpTypeIn extends FloatingPoint,
           'roundNearestEven (default) and truncate).');
     }
 
+    final fa = a.subNormalAsZero
+        ? (a.clone()..gets(mux(a.isNormal, a, Const(0, width: a.width))))
+        : a;
+    final fb = b.subNormalAsZero
+        ? (b.clone()..gets(mux(b.isNormal, b, Const(0, width: b.width))))
+        : b;
+
     final aExplicit = Const(a.explicitJBit);
     final bExplicit = Const(b.explicitJBit);
-    final swapper = FloatingPointSortByExp(a, b,
+    final swapper = FloatingPointSortByExp(fa, fb,
         metaA: aExplicit, metaB: bExplicit, name: 'sorter_${a.name}_${b.name}');
     final larger = swapper.outA;
     final smaller = swapper.outB;
@@ -353,6 +360,11 @@ class FloatingPointAdderSinglePath<FpTypeIn extends FloatingPoint,
       }
       exponentRound = exponent;
     }
+    // Handle Flush to Zero subnormal case
+    mantissaRound = (internalSum.subNormalAsZero
+        ? mux(lead1Dominates | ~exponentRound.or(),
+            Const(0, width: mantissaRound.width), mantissaRound)
+        : mantissaRound);
 
     final realIsInf =
         (isInfFlopped | exponentRound.eq(infExponent)).named('realIsInf');

--- a/lib/src/arithmetic/signals/floating_point_logics/floating_point_logic.dart
+++ b/lib/src/arithmetic/signals/floating_point_logics/floating_point_logic.dart
@@ -39,6 +39,7 @@ class FloatingPoint extends LogicStructure {
       {required int exponentWidth,
       required int mantissaWidth,
       bool explicitJBit = false,
+      bool subNormalAsZero = false,
       String? name})
       : this._(
             Logic(name: _nameJoin(name, 'sign'), naming: Naming.mergeable),
@@ -51,10 +52,12 @@ class FloatingPoint extends LogicStructure {
                 name: _nameJoin(name, 'mantissa'),
                 naming: Naming.mergeable),
             explicitJBit,
+            subNormalAsZero,
             name: name);
 
   /// [FloatingPoint] internal constructor.
   FloatingPoint._(this.sign, this.exponent, this.mantissa, this._explicitJBit,
+      this._subNormalAsZero,
       {super.name})
       : super([mantissa, exponent, sign]);
 
@@ -64,6 +67,7 @@ class FloatingPoint extends LogicStructure {
         exponentWidth: exponent.width,
         mantissaWidth: mantissa.width,
         explicitJBit: explicitJBit,
+        subNormalAsZero: subNormalAsZero,
         name: name,
       );
 
@@ -73,12 +77,16 @@ class FloatingPoint extends LogicStructure {
   FloatingPointValuePopulator valuePopulator() => FloatingPointValue.populator(
       exponentWidth: exponent.width,
       mantissaWidth: mantissa.width,
-      explicitJBit: explicitJBit);
+      explicitJBit: explicitJBit,
+      subNormalAsZero: subNormalAsZero);
 
   /// Return true if the J-bit is explicitly represented in the mantissa.
   bool get explicitJBit => _explicitJBit;
-
   late final bool _explicitJBit;
+
+  /// Return true if subnormal numbers are represented as zero.
+  bool get subNormalAsZero => _subNormalAsZero;
+  late final bool _subNormalAsZero;
 
   /// Return the [FloatingPointValue] of the current [value].
   FloatingPointValue get floatingPointValue =>
@@ -159,6 +167,10 @@ class FloatingPoint extends LogicStructure {
       if (val.explicitJBit != explicitJBit) {
         throw RohdHclException('FloatingPoint explicit jbit does not match');
       }
+      if (val.subNormalAsZero != subNormalAsZero) {
+        throw RohdHclException(
+            'FloatingPoint subnormal as zero does not match');
+      }
       put(val.value);
     } else {
       super.put(val, fill: fill);
@@ -171,21 +183,25 @@ class FloatingPoint extends LogicStructure {
       required int mantissaWidth,
       Logic? sign,
       bool negative = false,
-      bool explicitJBit = false}) {
+      bool explicitJBit = false,
+      bool subNormalAsZero = false}) {
     final signLogic = Logic()..gets(sign ?? Const(negative));
     final exponent = Const(1, width: exponentWidth, fill: true);
     final mantissa = Const(0, width: mantissaWidth, fill: true);
-    return FloatingPoint._(signLogic, exponent, mantissa, explicitJBit);
+    return FloatingPoint._(
+        signLogic, exponent, mantissa, explicitJBit, subNormalAsZero);
   }
 
   /// Construct a FloatingPoint that represents NaN.
   factory FloatingPoint.nan(
       {required int exponentWidth,
       required int mantissaWidth,
-      bool explicitJBit = false}) {
+      bool explicitJBit = false,
+      bool subNormalAsZero = false}) {
     final signLogic = Const(0);
     final exponent = Const(1, width: exponentWidth, fill: true);
     final mantissa = Const(1, width: mantissaWidth);
-    return FloatingPoint._(signLogic, exponent, mantissa, explicitJBit);
+    return FloatingPoint._(
+        signLogic, exponent, mantissa, explicitJBit, subNormalAsZero);
   }
 }

--- a/lib/src/arithmetic/values/floating_point_values/floating_point_8_e4m3_value.dart
+++ b/lib/src/arithmetic/values/floating_point_values/floating_point_8_e4m3_value.dart
@@ -69,8 +69,9 @@ class FloatingPoint8E4M3Value extends FloatingPointValue {
 
   @override
   @protected
-  ({LogicValue sign, LogicValue exponent, LogicValue mantissa})
-      getConstantComponents(FloatingPointConstants constantFloatingPoint) {
+  ({LogicValue sign, LogicValue exponent, LogicValue mantissa})?
+      getSpecialConstantComponents(
+          FloatingPointConstants constantFloatingPoint) {
     final (
       String signStr,
       String exponentStr,
@@ -90,7 +91,7 @@ class FloatingPoint8E4M3Value extends FloatingPointValue {
         throw InfinityNotSupportedException(
             'Infinity is not representable in E4M3 format');
       case _:
-        return super.getConstantComponents(constantFloatingPoint);
+        return null;
     }
 
     return (

--- a/lib/src/arithmetic/values/floating_point_values/floating_point_value.dart
+++ b/lib/src/arithmetic/values/floating_point_values/floating_point_value.dart
@@ -447,6 +447,9 @@ class FloatingPointValue implements Comparable<FloatingPointValue> {
 
   /// Addition operation for [FloatingPointValue].
   FloatingPointValue operator +(FloatingPointValue addend) {
+    if (isNaN | addend.isNaN) {
+      return clonePopulator().nan;
+    }
     if (isAnInfinity) {
       if (addend.isAnInfinity) {
         if (sign != addend.sign) {

--- a/lib/src/arithmetic/values/floating_point_values/floating_point_value.dart
+++ b/lib/src/arithmetic/values/floating_point_values/floating_point_value.dart
@@ -112,29 +112,6 @@ class FloatingPointValue implements Comparable<FloatingPointValue> {
         .._exponentWidth = exponentWidth
         .._mantissaWidth = mantissaWidth);
 
-  /// A wrapper around [FloatingPointValuePopulator.ofString] that computes the
-  /// widths of the exponent and mantissa from the input string.
-  factory FloatingPointValue.ofBinaryStrings(
-          String sign, String exponent, String mantissa,
-          {bool explicitJBit = false}) =>
-      populator(
-              exponentWidth: exponent.length,
-              mantissaWidth: mantissa.length,
-              explicitJBit: explicitJBit)
-          .ofBinaryStrings(sign, exponent, mantissa);
-
-  /// A wrapper around [FloatingPointValuePopulator.ofSpacedBinaryString] that
-  /// computes the widths of the exponent and mantissa from the input string.
-  factory FloatingPointValue.ofSpacedBinaryString(String fp,
-      {bool explicitJBit = false}) {
-    final split = fp.split(' ');
-    return populator(
-            exponentWidth: split[1].length,
-            mantissaWidth: split[2].length,
-            explicitJBit: explicitJBit)
-        .ofSpacedBinaryString(fp);
-  }
-
   /// Validate the [FloatingPointValue] to ensure widths and other
   /// characteristics are legal.
   @protected

--- a/lib/src/arithmetic/values/floating_point_values/floating_point_value.dart
+++ b/lib/src/arithmetic/values/floating_point_values/floating_point_value.dart
@@ -153,88 +153,16 @@ class FloatingPointValue implements Comparable<FloatingPointValue> {
     }
   }
 
-  // TODO(desmonddak): toRadixString() would be useful, not limited to binary
-
-  /// Return the set of [LogicValue]s for a given [FloatingPointConstants] at a
-  /// given [exponentWidth] and [mantissaWidth].
-  ///
-  /// This is a good function to override if constants behave specially in
-  /// subclases.
+  /// Returns a tuple of [LogicValue]s for the sign, exponent, and mantissa
+  /// components of a special constant, or `null` if the constant does not have
+  /// special components.This is useful for constants like NaN, Infinity, etc in
+  /// certain types of floating point representations.
   @protected
-  ({LogicValue sign, LogicValue exponent, LogicValue mantissa})
-      getConstantComponents(FloatingPointConstants constantFloatingPoint) {
-    final (
-      String signStr,
-      String exponentStr,
-      String mantissaStr
-    ) stringComponents;
-
-    switch (constantFloatingPoint) {
-      // smallest possible number
-      case FloatingPointConstants.negativeInfinity:
-        stringComponents = ('1', '1' * exponentWidth, '0' * mantissaWidth);
-
-      // -0.0
-      case FloatingPointConstants.negativeZero:
-        stringComponents = ('1', '0' * exponentWidth, '0' * mantissaWidth);
-
-      // 0.0
-      case FloatingPointConstants.positiveZero:
-        stringComponents = ('0', '0' * exponentWidth, '0' * mantissaWidth);
-
-      // Smallest possible number, most exponent negative, LSB set in mantissa
-      case FloatingPointConstants.smallestPositiveSubnormal:
-        stringComponents =
-            ('0', '0' * exponentWidth, '${'0' * (mantissaWidth - 1)}1');
-
-      // Largest possible subnormal, most negative exponent, mantissa all 1s
-      case FloatingPointConstants.largestPositiveSubnormal:
-        stringComponents = ('0', '0' * exponentWidth, '1' * mantissaWidth);
-
-      // Smallest possible positive number, most negative exponent, mantissa 0
-      case FloatingPointConstants.smallestPositiveNormal:
-        stringComponents =
-            ('0', '${'0' * (exponentWidth - 1)}1', '0' * mantissaWidth);
-
-      // Largest number smaller than one
-      case FloatingPointConstants.largestLessThanOne:
-        stringComponents =
-            ('0', '0${'1' * (exponentWidth - 2)}0', '1' * mantissaWidth);
-
-      // The number '1.0'
-      case FloatingPointConstants.one:
-        stringComponents =
-            ('0', '0${'1' * (exponentWidth - 1)}', '0' * mantissaWidth);
-
-      // Smallest number greater than one
-      case FloatingPointConstants.smallestLargerThanOne:
-        stringComponents = (
-          '0',
-          '0${'1' * (exponentWidth - 2)}0',
-          '${'0' * (mantissaWidth - 1)}1'
-        );
-
-      // Largest positive number, most positive exponent, full mantissa
-      case FloatingPointConstants.largestNormal:
-        stringComponents =
-            ('0', '${'1' * (exponentWidth - 1)}0', '1' * mantissaWidth);
-
-      // Largest possible number
-      case FloatingPointConstants.positiveInfinity:
-        stringComponents = ('0', '1' * exponentWidth, '0' * mantissaWidth);
-
-      // Not a Number (NaN)
-      case FloatingPointConstants.nan:
-        stringComponents =
-            ('0', '1' * exponentWidth, '${'0' * (mantissaWidth - 1)}1');
-    }
-
-    return (
-      sign: LogicValue.of(stringComponents.$1),
-      exponent: LogicValue.of(stringComponents.$2),
-      mantissa: LogicValue.of(stringComponents.$3)
-    );
-  }
+  @visibleForOverriding
+  ({LogicValue sign, LogicValue exponent, LogicValue mantissa})?
+      getSpecialConstantComponents(
+              FloatingPointConstants constantFloatingPoint) =>
+          null;
 
   @override
   int get hashCode => sign.hashCode ^ exponent.hashCode ^ mantissa.hashCode;

--- a/test/arithmetic/floating_point/floating_point_adder_dualpath_test.dart
+++ b/test/arithmetic/floating_point/floating_point_adder_dualpath_test.dart
@@ -212,14 +212,12 @@ void main() {
       final expectedNoRound =
           fpvPopulator().ofDoubleUnrounded(fv1.toDouble() + fv2.toDouble());
 
-      final FloatingPointValue expected;
       final expectedRound = fv1 + fv2;
-      if (((fv1.exponent.toInt() - fv2.exponent.toInt()).abs() < 2) &
-          (fv1.sign.toInt() != fv2.sign.toInt())) {
-        expected = expectedNoRound;
-      } else {
-        expected = expectedRound;
-      }
+      final expected =
+          (((fv1.exponent.toInt() - fv2.exponent.toInt()).abs() < 2) &
+                  (fv1.sign.toInt() != fv2.sign.toInt()))
+              ? expectedNoRound
+              : expectedRound;
       final adder = FloatingPointAdderDualPath(fp1, fp2);
 
       final computed = adder.sum.floatingPointValue;
@@ -244,14 +242,12 @@ void main() {
       final expectedNoRound =
           fpvPopulator().ofDoubleUnrounded(fv1.toDouble() + fv2.toDouble());
 
-      final FloatingPointValue expected;
       final expectedRound = fv1 + fv2;
-      if (((fv1.exponent.toInt() - fv2.exponent.toInt()).abs() < 2) &
-          (fv1.sign.toInt() != fv2.sign.toInt())) {
-        expected = expectedNoRound;
-      } else {
-        expected = expectedRound;
-      }
+      final expected =
+          (((fv1.exponent.toInt() - fv2.exponent.toInt()).abs() < 2) &
+                  (fv1.sign.toInt() != fv2.sign.toInt()))
+              ? expectedNoRound
+              : expectedRound;
       final adder = FloatingPointAdderDualPath(clk: clk, fp1, fp2);
       await adder.build();
       unawaited(Simulator.run());
@@ -287,13 +283,11 @@ void main() {
                 final computed = adder.sum.floatingPointValue;
                 final dbl = fv1.toDouble() + fv2.toDouble();
 
-                final FloatingPointValue expected;
-                if ((subtract == 1) &
-                    ((fv1.exponent.toInt() - fv2.exponent.toInt()).abs() < 2)) {
-                  expected = fpvPopulator().ofDoubleUnrounded(dbl);
-                } else {
-                  expected = fpvPopulator().ofDouble(dbl);
-                }
+                final expected =
+                    (((fv1.exponent.toInt() - fv2.exponent.toInt()).abs() < 2) &
+                            (fv1.sign.toInt() != fv2.sign.toInt()))
+                        ? fpvPopulator().ofDoubleUnrounded(dbl)
+                        : fv1 + fv2;
 
                 expect(computed, equals(expected), reason: '''
       $fv1 (${fv1.toDouble()})\t+
@@ -361,15 +355,13 @@ void main() {
     final expectedNoRound = FloatingPointValue.populator(
             exponentWidth: eWidth, mantissaWidth: mWidth)
         .ofDoubleUnrounded(fv1.toDouble() + fv2.toDouble());
-
-    final FloatingPointValue expected;
     final expectedRound = fv1 + fv2;
-    if (((fv1.exponent.toInt() - fv2.exponent.toInt()).abs() < 2) &
-        (fv1.sign.toInt() != fv2.sign.toInt())) {
-      expected = expectedNoRound;
-    } else {
-      expected = expectedRound;
-    }
+
+    final expected =
+        (((fv1.exponent.toInt() - fv2.exponent.toInt()).abs() < 2) &
+                (fv1.sign.toInt() != fv2.sign.toInt()))
+            ? expectedNoRound
+            : expectedRound;
     final adder = FloatingPointAdderDualPath(
         clk: clk, fa, fb, adderGen: ParallelPrefixAdder.new);
     await adder.build();

--- a/test/arithmetic/floating_point/floating_point_adder_dualpath_test.dart
+++ b/test/arithmetic/floating_point/floating_point_adder_dualpath_test.dart
@@ -17,164 +17,284 @@ void main() {
   tearDown(() async {
     await Simulator.reset();
   });
-  test('FP: rounding adder singleton N path', () async {
-    const exponentWidth = 4;
-    const mantissaWidth = 5;
-    final fp1 = FloatingPoint(
-        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    final fp2 = FloatingPoint(
-        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
 
-    final fv1 = FloatingPointValue.populator(
-            exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-        .ofInts(0, 0);
-    final fv2 = FloatingPointValue.populator(
-            exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-        .ofInts(0, 1, sign: true);
-
-    fp1.put(fv1);
-    fp2.put(fv2);
-
-    final expectedNoRound = FloatingPointValue.populator(
-            exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-        .ofDoubleUnrounded(fv1.toDouble() + fv2.toDouble());
-    final expected = expectedNoRound;
-
-    final adder = FloatingPointAdderDualPath(fp1, fp2);
-
-    unawaited(Simulator.run());
-
-    final computed = adder.sum.floatingPointValue;
-    expect(computed, equals(expected));
-    await Simulator.endSimulation();
-  });
-
-  // isR is Addition or exponent delta >= 2
-  // N path is Subtraction & exponent delta < 2
-
-  test('FP: rounding adder N path, subtraction, delta < 2', () async {
+  group('FP: dual-path adder N path tests', () {
     const exponentWidth = 3;
     const mantissaWidth = 5;
-
-    final one = FloatingPointValue.populator(
-            exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-        .ofConstant(FloatingPointConstants.one);
-    final fp1 = FloatingPoint(
+    FloatingPoint fpConstructor() => FloatingPoint(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    final fp2 = FloatingPoint(
+    final fp1 = fpConstructor();
+    final fp2 = fpConstructor();
+
+    FloatingPointValuePopulator fpvPopulator() => FloatingPointValue.populator(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    fp1.put(one);
-    fp2.put(one);
-    final adder = FloatingPointAdderDualPath(fp1, fp2);
-    await adder.build();
-    unawaited(Simulator.run());
+    test('FP: dual-path adder N path singleton', () async {
+      final fv1 = fpvPopulator().ofInts(0, 0);
+      final fv2 = fpvPopulator().ofInts(0, 1, sign: true);
 
-    final pop = FloatingPointValue.populator(
-        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    final largestExponent = pop.bias + pop.maxExponent;
+      fp1.put(fv1);
+      fp2.put(fv2);
 
-    final largestMantissa = pow(2, mantissaWidth).toInt() - 1;
-    for (var e1 = 0; e1 <= largestExponent; e1++) {
-      for (var e2 = 0; e2 <= largestExponent; e2++) {
-        if ((e1 - e2).abs() < 2) {
-          for (var m1 = 0; m1 <= largestMantissa; m1++) {
-            final fv1 = FloatingPointValue.populator(
-                    exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-                .ofInts(e1, m1);
-            for (var m2 = 0; m2 <= largestMantissa; m2++) {
-              final fv2 = FloatingPointValue.populator(
-                      exponentWidth: exponentWidth,
-                      mantissaWidth: mantissaWidth)
-                  .ofInts(e2, m2, sign: true);
+      final expectedNoRound =
+          fpvPopulator().ofDoubleUnrounded(fv1.toDouble() + fv2.toDouble());
+      final expected = expectedNoRound;
 
-              fp1.put(fv1);
-              fp2.put(fv2);
-              // No rounding
-              final expected = FloatingPointValue.populator(
-                      exponentWidth: exponentWidth,
-                      mantissaWidth: mantissaWidth)
-                  .ofDoubleUnrounded(fv1.toDouble() + fv2.toDouble());
+      final adder = FloatingPointAdderDualPath(fp1, fp2);
 
-              final computed = adder.sum.floatingPointValue;
-              expect(computed, equals(expected));
+      final computed = adder.sum.floatingPointValue;
+      expect(computed, equals(expected));
+    });
+
+    // isR is Addition or exponent delta >= 2
+    // N path is Subtraction & exponent delta < 2
+
+    test('FP: dual-path adder N path, subtraction, delta < 2', () async {
+      final one = fpvPopulator().ofConstant(FloatingPointConstants.one);
+      fp1.put(one);
+      fp2.put(one);
+      final adder = FloatingPointAdderDualPath(fp1, fp2);
+
+      final largestExponent = fpvPopulator().bias + fpvPopulator().maxExponent;
+
+      final largestMantissa = pow(2, mantissaWidth).toInt() - 1;
+      for (var e1 = 0; e1 <= largestExponent; e1++) {
+        for (var e2 = 0; e2 <= largestExponent; e2++) {
+          if ((e1 - e2).abs() < 2) {
+            for (var m1 = 0; m1 <= largestMantissa; m1++) {
+              final fv1 = fpvPopulator().ofInts(e1, m1);
+              for (var m2 = 0; m2 <= largestMantissa; m2++) {
+                final fv2 = fpvPopulator().ofInts(e2, m2, sign: true);
+
+                fp1.put(fv1);
+                fp2.put(fv2);
+                // No rounding
+                final expected = fpvPopulator()
+                    .ofDoubleUnrounded(fv1.toDouble() + fv2.toDouble());
+
+                final computed = adder.sum.floatingPointValue;
+                expect(computed, equals(expected));
+              }
             }
           }
         }
       }
-    }
-    await Simulator.endSimulation();
+    });
   });
 
-  test('FP: rounding adder singleton R path', () async {
-    final clk = SimpleClockGenerator(10).clk;
+  group('FP: dual-path adder R path tests', () {
+    const exponentWidth = 3;
+    const mantissaWidth = 4;
+    final expLimit = pow(2, exponentWidth).toInt();
+    final mantLimit = pow(2, mantissaWidth).toInt();
 
-    const exponentWidth = 4;
-    const mantissaWidth = 5;
-    final fp1 = FloatingPoint(
+    FloatingPoint fpConstructor() => FloatingPoint(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    final fp2 = FloatingPoint(
+    final fp1 = fpConstructor();
+    final fp2 = fpConstructor();
+
+    FloatingPointValuePopulator fpvPopulator() => FloatingPointValue.populator(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    fp1.put(0);
-    fp2.put(0);
+    test('FP: dual-path adder singleton R path', () async {
+      final clk = SimpleClockGenerator(10).clk;
 
-    final fv1 = FloatingPointValue.populator(
-            exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-        .ofInts(3, 11);
-    final fv2 = FloatingPointValue.populator(
-            exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-        .ofInts(11, 25, sign: true);
+      fp1.put(0);
+      fp2.put(0);
 
-    fp1.put(fv1);
-    fp2.put(fv2);
+      final fv1 = fpvPopulator().ofInts(3, 5);
+      final fv2 = fpvPopulator().ofInts(5, 2, sign: true);
 
-    final expected = fv1 + fv2;
-    final adder = FloatingPointAdderDualPath(clk: clk, fp1, fp2);
-    await adder.build();
-    unawaited(Simulator.run());
-    await clk.nextNegedge;
-    fp1.put(0);
-    fp2.put(0);
+      fp1.put(fv1);
+      fp2.put(fv2);
 
-    final computed = adder.sum.floatingPointValue;
-    expect(computed.isNaN, equals(expected.isNaN));
-    expect(computed, equals(expected));
-    await Simulator.endSimulation();
+      final expected = fv1 + fv2;
+      final adder = FloatingPointAdderDualPath(clk: clk, fp1, fp2);
+      await adder.build();
+      unawaited(Simulator.run());
+      await clk.nextNegedge;
+      fp1.put(0);
+      fp2.put(0);
+
+      final computed = adder.sum.floatingPointValue;
+      expect(computed.isNaN, equals(expected.isNaN));
+      expect(computed, equals(expected));
+      await Simulator.endSimulation();
+    });
+
+    test('FP: dual-path adder R path exhaustive', () async {
+      fp1.put(0);
+      fp2.put(0);
+      final adder = FloatingPointAdderDualPath(fp1, fp2);
+
+      for (final sign in [false, true]) {
+        for (var e1 = 0; e1 < expLimit; e1++) {
+          for (var e2 = 0; e2 < expLimit; e2++) {
+            if (!sign || (e1 - e2).abs() >= 2) {
+              for (var m1 = 0; m1 < mantLimit; m1++) {
+                final fv1 = fpvPopulator().ofInts(e1, m1);
+                for (var m2 = 0; m2 < mantLimit; m2++) {
+                  final fv2 = fpvPopulator().ofInts(e2, m2, sign: sign);
+
+                  fp1.put(fv1);
+                  fp2.put(fv2);
+                  final expected = fv1 + fv2;
+                  final computed = adder.sum.floatingPointValue;
+                  expect(computed, equals(expected), reason: '''
+      $fv1 (${fv1.toDouble()})\t+
+      $fv2 (${fv2.toDouble()})\t=
+      $computed (${computed.toDouble()})\tcomputed
+      $expected (${expected.toDouble()})\texpected
+''');
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+
+    test('FP: dual-path adder R path, full random', () async {
+      final clk = SimpleClockGenerator(10).clk;
+
+      fp1.put(0);
+      fp2.put(0);
+      final adder = FloatingPointAdderDualPath(clk: clk, fp1, fp2);
+      await adder.build();
+      unawaited(Simulator.run());
+      final rand = Random(47);
+
+      var cnt = 200;
+      while (cnt > 0) {
+        final fv1 = fpvPopulator().random(rand);
+        final fv2 = fpvPopulator().random(rand);
+        fp1.put(fv1);
+        fp2.put(fv2);
+        if ((fv1.exponent.toInt() - fv2.exponent.toInt()).abs() >= 2) {
+          cnt--;
+          final expected = fv1 + fv2;
+          await clk.nextNegedge;
+          fp1.put(0);
+          fp2.put(0);
+          final computed = adder.sum.floatingPointValue;
+          expect(computed, equals(expected), reason: '''
+      $fv1 (${fv1.toDouble()})\t+
+      $fv2 (${fv2.toDouble()})\t=
+      $computed (${computed.toDouble()})\tcomputed
+      $expected (${expected.toDouble()})\texpected
+''');
+        }
+      }
+      await Simulator.endSimulation();
+    });
   });
 
-  test('FP: rounding adder R path, strict subnormal', () async {
-    const exponentWidth = 4;
-    const mantissaWidth = 5;
+  group('FP: dual-path adder both paths tests', () {
+    const exponentWidth = 3;
+    const mantissaWidth = 4;
+    final expLimit = pow(2, exponentWidth).toInt();
+    final mantLimit = pow(2, mantissaWidth).toInt();
 
-    final fp1 = FloatingPoint(
+    FloatingPoint fpConstructor() => FloatingPoint(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    final fp2 = FloatingPoint(
+    final fp1 = fpConstructor();
+    final fp2 = fpConstructor();
+
+    FloatingPointValuePopulator fpvPopulator() => FloatingPointValue.populator(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    fp1.put(0);
-    fp2.put(0);
-    final adder = FloatingPointAdderDualPath(fp1, fp2);
-    await adder.build();
-    unawaited(Simulator.run());
 
-    final largestMantissa = pow(2, mantissaWidth).toInt() - 1;
-    for (final sign in [false, true]) {
-      for (var e1 = 0; e1 <= 1; e1++) {
-        for (var e2 = 0; e2 <= 1; e2++) {
-          if (!sign || (e1 - e2).abs() >= 2) {
-            for (var m1 = 0; m1 <= largestMantissa; m1++) {
-              final fv1 = FloatingPointValue.populator(
-                      exponentWidth: exponentWidth,
-                      mantissaWidth: mantissaWidth)
-                  .ofInts(e1, m1);
-              for (var m2 = 0; m2 <= largestMantissa; m2++) {
-                final fv2 = FloatingPointValue.populator(
-                        exponentWidth: exponentWidth,
-                        mantissaWidth: mantissaWidth)
-                    .ofInts(e2, m2, sign: sign);
+    test('FP: dual-path adder singleton merged path', () async {
+      fp1.put(0);
+      fp2.put(0);
+      final fv1 = fpvPopulator().ofInts(4, 7);
+      final fv2 = fpvPopulator().ofInts(3, 4, sign: true);
+      fp1.put(fv1);
+      fp2.put(fv2);
 
-                fp1.put(fv1);
-                fp2.put(fv2);
-                final expected = fv1 + fv2;
+      final expectedNoRound =
+          fpvPopulator().ofDoubleUnrounded(fv1.toDouble() + fv2.toDouble());
+
+      final FloatingPointValue expected;
+      final expectedRound = fv1 + fv2;
+      if (((fv1.exponent.toInt() - fv2.exponent.toInt()).abs() < 2) &
+          (fv1.sign.toInt() != fv2.sign.toInt())) {
+        expected = expectedNoRound;
+      } else {
+        expected = expectedRound;
+      }
+      final adder = FloatingPointAdderDualPath(fp1, fp2);
+
+      final computed = adder.sum.floatingPointValue;
+      expect(computed, equals(expected), reason: '''
+      $fv1 (${fv1.toDouble()})\t+
+      $fv2 (${fv2.toDouble()})\t=
+      $computed (${computed.toDouble()})\tcomputed
+      $expected (${expected.toDouble()})\texpected
+''');
+    });
+
+    test('FP: dual-path adder singleton merged pipelined path', () async {
+      final clk = SimpleClockGenerator(10).clk;
+
+      fp1.put(0);
+      fp2.put(0);
+      final fv1 = fpvPopulator().ofInts(4, 5);
+      final fv2 = fpvPopulator().ofInts(3, 7, sign: true);
+      fp1.put(fv1);
+      fp2.put(fv2);
+
+      final expectedNoRound =
+          fpvPopulator().ofDoubleUnrounded(fv1.toDouble() + fv2.toDouble());
+
+      final FloatingPointValue expected;
+      final expectedRound = fv1 + fv2;
+      if (((fv1.exponent.toInt() - fv2.exponent.toInt()).abs() < 2) &
+          (fv1.sign.toInt() != fv2.sign.toInt())) {
+        expected = expectedNoRound;
+      } else {
+        expected = expectedRound;
+      }
+      final adder = FloatingPointAdderDualPath(clk: clk, fp1, fp2);
+      await adder.build();
+      unawaited(Simulator.run());
+      await clk.nextNegedge;
+      fp1.put(0);
+      fp2.put(0);
+
+      final computed = adder.sum.floatingPointValue;
+      expect(computed, equals(expected), reason: '''
+      $fv1 (${fv1.toDouble()})\t+
+      $fv2 (${fv2.toDouble()})\t=
+      $computed (${computed.toDouble()})\tcomputed
+      $expected (${expected.toDouble()})\texpected
+''');
+      await Simulator.endSimulation();
+    });
+
+    test('FP: dual-path adder exhaustive', () {
+      fp1.put(0);
+      fp2.put(0);
+      final adder = FloatingPointAdderDualPath(fp1, fp2);
+
+      for (final subtract in [0, 1]) {
+        for (var e1 = 0; e1 < expLimit; e1++) {
+          for (var m1 = 0; m1 < mantLimit; m1++) {
+            final fv1 = fpvPopulator().ofInts(e1, m1);
+            for (var e2 = 0; e2 < expLimit; e2++) {
+              for (var m2 = 0; m2 < mantLimit; m2++) {
+                final fv2 = fpvPopulator().ofInts(e2, m2, sign: subtract == 1);
+
+                fp1.put(fv1.value);
+                fp2.put(fv2.value);
                 final computed = adder.sum.floatingPointValue;
+                final dbl = fv1.toDouble() + fv2.toDouble();
+
+                final FloatingPointValue expected;
+                if ((subtract == 1) &
+                    ((fv1.exponent.toInt() - fv2.exponent.toInt()).abs() < 2)) {
+                  expected = fpvPopulator().ofDoubleUnrounded(dbl);
+                } else {
+                  expected = fpvPopulator().ofDouble(dbl);
+                }
+
                 expect(computed, equals(expected), reason: '''
       $fv1 (${fv1.toDouble()})\t+
       $fv2 (${fv2.toDouble()})\t=
@@ -186,127 +306,28 @@ void main() {
           }
         }
       }
-    }
-    await Simulator.endSimulation();
+    });
   });
 
-  test('FP: rounding adder R path, full random', () async {
-    final clk = SimpleClockGenerator(10).clk;
-
-    const exponentWidth = 3;
-    const mantissaWidth = 5;
-
-    final fp1 = FloatingPoint(
-        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    final fp2 = FloatingPoint(
-        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    fp1.put(0);
-    fp2.put(0);
-    final adder = FloatingPointAdderDualPath(clk: clk, fp1, fp2);
-    await adder.build();
-    unawaited(Simulator.run());
-    final rand = Random(47);
-
-    var cnt = 200;
-    while (cnt > 0) {
-      final fv1 = FloatingPointValue.populator(
-              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-          .random(rand);
-      final fv2 = FloatingPointValue.populator(
-              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-          .random(rand);
-      fp1.put(fv1);
-      fp2.put(fv2);
-      if ((fv1.exponent.toInt() - fv2.exponent.toInt()).abs() >= 2) {
-        cnt--;
-        final expected = fv1 + fv2;
-        await clk.nextNegedge;
-        fp1.put(0);
-        fp2.put(0);
-        final computed = adder.sum.floatingPointValue;
-        expect(computed, equals(expected), reason: '''
-      $fv1 (${fv1.toDouble()})\t+
-      $fv2 (${fv2.toDouble()})\t=
-      $computed (${computed.toDouble()})\tcomputed
-      $expected (${expected.toDouble()})\texpected
-''');
-      }
-    }
-    await Simulator.endSimulation();
-  });
-
-  test('FP: rounding adder singleton merged pipelined path', () async {
-    final clk = SimpleClockGenerator(10).clk;
-
-    const exponentWidth = 3;
-    const mantissaWidth = 5;
-    final fp1 = FloatingPoint(
-        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    final fp2 = FloatingPoint(
-        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    fp1.put(0);
-    fp2.put(0);
-    final fv1 = FloatingPointValue.populator(
-            exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-        .ofInts(14, 31);
-    final fv2 = FloatingPointValue.populator(
-            exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-        .ofInts(13, 7, sign: true);
-    fp1.put(fv1);
-    fp2.put(fv2);
-
-    final expectedNoRound = FloatingPointValue.populator(
-            exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-        .ofDoubleUnrounded(fv1.toDouble() + fv2.toDouble());
-
-    final FloatingPointValue expected;
-    final expectedRound = fv1 + fv2;
-    if (((fv1.exponent.toInt() - fv2.exponent.toInt()).abs() < 2) &
-        (fv1.sign.toInt() != fv2.sign.toInt())) {
-      expected = expectedNoRound;
-    } else {
-      expected = expectedRound;
-    }
-    final adder = FloatingPointAdderDualPath(clk: clk, fp1, fp2);
-    await adder.build();
-    unawaited(Simulator.run());
-    await clk.nextNegedge;
-    fp1.put(0);
-    fp2.put(0);
-
-    final computed = adder.sum.floatingPointValue;
-    expect(computed, equals(expected), reason: '''
-      $fv1 (${fv1.toDouble()})\t+
-      $fv2 (${fv2.toDouble()})\t=
-      $computed (${computed.toDouble()})\tcomputed
-      $expected (${expected.toDouble()})\texpected
-''');
-    await Simulator.endSimulation();
-  });
-
-  test('FP: rounding adder full random wide', () async {
+  test('FP: dual-path adder full random wide', () async {
     const exponentWidth = 11;
     const mantissaWidth = 52;
 
-    final fp1 = FloatingPoint(
+    FloatingPoint fpConstructor() => FloatingPoint(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    final fp2 = FloatingPoint(
+    FloatingPointValuePopulator fpvPopulator() => FloatingPointValue.populator(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
+    final fp1 = fpConstructor();
+    final fp2 = fpConstructor();
     fp1.put(0);
     fp2.put(0);
     final adder = FloatingPointAdderDualPath(fp1, fp2);
-    await adder.build();
-    unawaited(Simulator.run());
     final rand = Random(51);
 
     var cnt = 100;
     while (cnt > 0) {
-      final fv1 = FloatingPointValue.populator(
-              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-          .random(rand);
-      final fv2 = FloatingPointValue.populator(
-              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-          .random(rand);
+      final fv1 = fpvPopulator().random(rand);
+      final fv2 = fpvPopulator().random(rand);
       fp1.put(fv1);
       fp2.put(fv2);
       final expected = fv1 + fv2;
@@ -320,188 +341,20 @@ void main() {
 ''');
       cnt--;
     }
-    await Simulator.endSimulation();
   });
 
-  test('FP: rounding adder singleton merged path', () async {
-    const exponentWidth = 3;
-    const mantissaWidth = 5;
-    final fp1 = FloatingPoint(
-        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    final fp2 = FloatingPoint(
-        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    fp1.put(0);
-    fp2.put(0);
-    final fv1 = FloatingPointValue.populator(
-            exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-        .ofInts(14, 31);
-    final fv2 = FloatingPointValue.populator(
-            exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-        .ofInts(13, 7, sign: true);
-    fp1.put(fv1);
-    fp2.put(fv2);
-
-    final expectedNoRound = FloatingPointValue.populator(
-            exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-        .ofDoubleUnrounded(fv1.toDouble() + fv2.toDouble());
-
-    final FloatingPointValue expected;
-    final expectedRound = fv1 + fv2;
-    if (((fv1.exponent.toInt() - fv2.exponent.toInt()).abs() < 2) &
-        (fv1.sign.toInt() != fv2.sign.toInt())) {
-      expected = expectedNoRound;
-    } else {
-      expected = expectedRound;
-    }
-    final adder = FloatingPointAdderDualPath(fp1, fp2);
-
-    final computed = adder.sum.floatingPointValue;
-    expect(computed, equals(expected), reason: '''
-      $fv1 (${fv1.toDouble()})\t+
-      $fv2 (${fv2.toDouble()})\t=
-      $computed (${computed.toDouble()})\tcomputed
-      $expected (${expected.toDouble()})\texpected
-''');
-  });
-
-  test('FP: rounding adder singleton', () async {
-    const exponentWidth = 4;
-    const mantissaWidth = 5;
-    final fp1 = FloatingPoint(
-        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    final fp2 = FloatingPoint(
-        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    fp1.put(0);
-    fp2.put(0);
-    // rounding error
-    final fv1 = FloatingPointValue.ofBinaryStrings('1', '0110', '00101');
-    final fv2 = FloatingPointValue.ofBinaryStrings('0', '0111', '11110');
-
-    fp1.put(fv1);
-    fp2.put(fv2);
-
-    final expectedNoRound = FloatingPointValue.populator(
-            exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-        .ofDoubleUnrounded(fv1.toDouble() + fv2.toDouble());
-
-    final FloatingPointValue expected;
-    final expectedRound = fv1 + fv2;
-    if (((fv1.exponent.toInt() - fv2.exponent.toInt()).abs() < 2) &
-        (fv1.sign.toInt() != fv2.sign.toInt())) {
-      expected = expectedNoRound;
-    } else {
-      expected = expectedRound;
-    }
-    final adder = FloatingPointAdderDualPath(fp1, fp2);
-
-    final computed = adder.sum.floatingPointValue;
-    expect(computed, equals(expected), reason: '''
-      $fv1 (${fv1.toDouble()})\t+
-      $fv2 (${fv2.toDouble()})\t=
-      $computed (${computed.toDouble()})\tcomputed
-      $expected (${expected.toDouble()})\texpected
-''');
-  });
-
-  test('FP: rounding adder exhaustive', () {
-    const exponentWidth = 4;
-    const mantissaWidth = 4;
-
-    final fp1 = FloatingPoint(
-        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    final fp2 = FloatingPoint(
-        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    fp1.put(0);
-    fp2.put(0);
-    final adder = FloatingPointAdderDualPath(fp1, fp2);
-
-    final expLimit = pow(2, exponentWidth);
-    final mantLimit = pow(2, mantissaWidth);
-    for (final subtract in [0, 1]) {
-      for (var e1 = 0; e1 < expLimit; e1++) {
-        for (var m1 = 0; m1 < mantLimit; m1++) {
-          final fv1 = FloatingPointValue.populator(
-                  exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-              .ofInts(e1, m1);
-          for (var e2 = 0; e2 < expLimit; e2++) {
-            for (var m2 = 0; m2 < mantLimit; m2++) {
-              final fv2 = FloatingPointValue.populator(
-                      exponentWidth: exponentWidth,
-                      mantissaWidth: mantissaWidth)
-                  .ofInts(e2, m2, sign: subtract == 1);
-
-              fp1.put(fv1.value);
-              fp2.put(fv2.value);
-              final computed = adder.sum.floatingPointValue;
-              final expectedDouble = fv1.toDouble() + fv2.toDouble();
-
-              final FloatingPointValue expected;
-              if ((subtract == 1) &
-                  ((fv1.exponent.toInt() - fv2.exponent.toInt()).abs() < 2)) {
-                expected = FloatingPointValue.populator(
-                        exponentWidth: exponentWidth,
-                        mantissaWidth: mantissaWidth)
-                    .ofDoubleUnrounded(expectedDouble);
-              } else {
-                expected = FloatingPointValue.populator(
-                        exponentWidth: exponentWidth,
-                        mantissaWidth: mantissaWidth)
-                    .ofDouble(expectedDouble);
-              }
-
-              expect(computed, equals(expected), reason: '''
-      $fv1 (${fv1.toDouble()})\t+
-      $fv2 (${fv2.toDouble()})\t=
-      $computed (${computed.toDouble()})\tcomputed
-      $expected (${expected.toDouble()})\texpected
-''');
-            }
-          }
-        }
-      }
-    }
-  });
-  test('FP: rounding adder general singleton test', () {
-    FloatingPointValue ofString(String s) =>
-        FloatingPointValue.ofSpacedBinaryString(s);
-
-    final fv1 = ofString('0 001 111111');
-    final fv2 = ofString('1 010 000000');
-
-    final fp1 = FloatingPoint(
-        exponentWidth: fv1.exponent.width, mantissaWidth: fv1.mantissa.width);
-    final fp2 = FloatingPoint(
-        exponentWidth: fv2.exponent.width, mantissaWidth: fv2.mantissa.width);
-    fp1.put(fv1);
-    fp2.put(fv2);
-    final adder = FloatingPointAdderDualPath(fp1, fp2);
-    final exponentWidth = adder.sum.exponent.width;
-    final mantissaWidth = adder.sum.mantissa.width;
-
-    final expectedDouble =
-        fp1.floatingPointValue.toDouble() + fp2.floatingPointValue.toDouble();
-
-    final expectedNoRound = FloatingPointValue.populator(
-            exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-        .ofDoubleUnrounded(expectedDouble);
-    expect(adder.sum.floatingPointValue, equals(expectedNoRound));
-  });
-
-  test('FP: rounding with prefix adder', () async {
-    final clk = SimpleClockGenerator(10).clk;
-
+  test('FP: dual-path with prefix adder pipelined', () async {
     const eWidth = 3;
     const mWidth = 5;
+    FloatingPointValuePopulator fpvPopulator() => FloatingPointValue.populator(
+        exponentWidth: eWidth, mantissaWidth: mWidth);
     final fa = FloatingPoint(exponentWidth: eWidth, mantissaWidth: mWidth);
     final fb = FloatingPoint(exponentWidth: eWidth, mantissaWidth: mWidth);
+    final clk = SimpleClockGenerator(10).clk;
     fa.put(0);
     fb.put(0);
-    final fv1 = FloatingPointValue.populator(
-            exponentWidth: eWidth, mantissaWidth: mWidth)
-        .ofInts(14, 31);
-    final fv2 = FloatingPointValue.populator(
-            exponentWidth: eWidth, mantissaWidth: mWidth)
-        .ofInts(13, 7, sign: true);
+    final fv1 = fpvPopulator().ofInts(14, 31);
+    final fv2 = fpvPopulator().ofInts(13, 7, sign: true);
     fa.put(fv1);
     fb.put(fv2);
 

--- a/test/arithmetic/floating_point/floating_point_adder_singlepath_test.dart
+++ b/test/arithmetic/floating_point/floating_point_adder_singlepath_test.dart
@@ -553,8 +553,9 @@ void main() {
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
     FloatingPointValue ofString(String s) =>
         FloatingPointValue.ofSpacedBinaryString(s);
-    FloatingPointValuePopulator fpvPopulator() => FloatingPointValue.populator(
-        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
+    FloatingPointValuePopulator fpvOutPopulator() =>
+        FloatingPointValue.populator(
+            exponentWidth: exponentWidth, mantissaWidth: outMantissaWidth);
 
     final fp1 = fpConstructor();
     final fp2 = fpConstructor();
@@ -563,6 +564,7 @@ void main() {
 
     final fpout = FloatingPoint(
         exponentWidth: exponentWidth, mantissaWidth: outMantissaWidth);
+
     fp1.put(fv1);
     fp2.put(fv2);
     final adder = FloatingPointAdderSinglePath(fp1, fp2, outSum: fpout);
@@ -570,8 +572,8 @@ void main() {
 
     final expectedDouble = fv1.toDouble() + fv2.toDouble();
 
-    final expectedRound = fpvPopulator().ofDouble(expectedDouble);
-    final expectedNoRound = fpvPopulator().ofDoubleUnrounded(expectedDouble);
+    final expectedRound = fpvOutPopulator().ofDouble(expectedDouble);
+    final expectedNoRound = fpvOutPopulator().ofDoubleUnrounded(expectedDouble);
 
     expect(computed, equals(expectedRound), reason: '''
       $fv1 (${fv1.toDouble()})\t+
@@ -595,6 +597,9 @@ void main() {
     for (final outMantissaWidth in [6, 7, 8, 9, 15]) {
       final fpout = FloatingPoint(
           exponentWidth: exponentWidth, mantissaWidth: outMantissaWidth);
+      FloatingPointValuePopulator fpvOutPopulator() =>
+          FloatingPointValue.populator(
+              exponentWidth: exponentWidth, mantissaWidth: outMantissaWidth);
       fp1.put(0);
       fp2.put(0);
       final adder = FloatingPointAdderSinglePath(fp1, fp2, outSum: fpout);
@@ -613,8 +618,9 @@ void main() {
 
                 final computed = adder.sum.floatingPointValue;
                 final dbl = fv1.toDouble() + fv2.toDouble();
-                final expectedNoRound = fpvPopulator().ofDoubleUnrounded(dbl);
-                final expectedRound = fpvPopulator().ofDouble(dbl);
+                final expectedNoRound =
+                    fpvOutPopulator().ofDoubleUnrounded(dbl);
+                final expectedRound = fpvOutPopulator().ofDouble(dbl);
                 expect(computed, equals(expectedRound), reason: '''
       $fv1 (${fv1.toDouble()})\t+
       $fv2 (${fv2.toDouble()})\t=

--- a/test/arithmetic/floating_point/floating_point_adder_singlepath_test.dart
+++ b/test/arithmetic/floating_point/floating_point_adder_singlepath_test.dart
@@ -25,10 +25,10 @@ void main() {
     const mantissaWidth = 18;
     FloatingPoint fpConstructor() => FloatingPoint(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    FloatingPointValue ofString(String s) =>
-        FloatingPointValue.ofSpacedBinaryString(s);
     FloatingPointValuePopulator fpvPopulator() => FloatingPointValue.populator(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
+    FloatingPointValue ofString(String s) =>
+        fpvPopulator().ofSpacedBinaryString(s);
 
     final fv1 = ofString('0 0000 101011100101000000');
     final fv2 = ofString('1 0001 100100101111011100');
@@ -151,8 +151,8 @@ void main() {
 
     FloatingPointValuePopulator fpvPopulator() => FloatingPointValue.populator(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    final fv1 = FloatingPointValue.ofSpacedBinaryString('0 0000 0001');
-    final fv2 = FloatingPointValue.ofSpacedBinaryString('1 0000 0000');
+    final fv1 = fpvPopulator().ofSpacedBinaryString('0 0000 0001');
+    final fv2 = fpvPopulator().ofSpacedBinaryString('1 0000 0000');
 
     fp1.put(fv1);
     fp2.put(fv2);
@@ -272,10 +272,10 @@ void main() {
     final fp1 = fpConstructor();
     final fp2 = fpConstructor();
 
-    FloatingPointValue ofString(String s) =>
-        FloatingPointValue.ofSpacedBinaryString(s);
     FloatingPointValuePopulator fpvPopulator() => FloatingPointValue.populator(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
+    FloatingPointValue ofString(String s) =>
+        fpvPopulator().ofSpacedBinaryString(s);
 
     fp1.put(0);
     fp2.put(0);
@@ -551,8 +551,10 @@ void main() {
     const outMantissaWidth = 20;
     FloatingPoint fpConstructor() => FloatingPoint(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
+    FloatingPointValuePopulator fpvPopulator() => FloatingPointValue.populator(
+        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
     FloatingPointValue ofString(String s) =>
-        FloatingPointValue.ofSpacedBinaryString(s);
+        fpvPopulator().ofSpacedBinaryString(s);
     FloatingPointValuePopulator fpvOutPopulator() =>
         FloatingPointValue.populator(
             exponentWidth: exponentWidth, mantissaWidth: outMantissaWidth);
@@ -645,13 +647,12 @@ void main() {
             exponentWidth: exponentWidth,
             mantissaWidth: mantissaWidth,
             explicitJBit: explicitJBit);
+    FloatingPointValue ofString(String s, {bool explicitJBit = false}) =>
+        fpvPopulator(explicitJBit: explicitJBit).ofSpacedBinaryString(s);
     FloatingPoint fpConstructor({required bool explicitJBit}) => FloatingPoint(
         exponentWidth: exponentWidth,
         mantissaWidth: mantissaWidth,
         explicitJBit: explicitJBit);
-
-    FloatingPointValue ofString(String s, {bool explicitJBit = false}) =>
-        FloatingPointValue.ofSpacedBinaryString(s, explicitJBit: explicitJBit);
 
     test('FP: simple adder mixed explicit/implicit j-bit IO singleton', () {
       const input1ExplicitJBit = false;

--- a/test/arithmetic/floating_point/floating_point_adder_singlepath_test.dart
+++ b/test/arithmetic/floating_point/floating_point_adder_singlepath_test.dart
@@ -141,6 +141,127 @@ void main() {
     }
   });
 
+  group('FP: single-path adder DAZ/FTZ tests', () {
+    const exponentWidth = 3;
+    const mantissaWidth = 3;
+    final expLimit = pow(2, exponentWidth).toInt();
+    final mantLimit = pow(2, mantissaWidth).toInt();
+    FloatingPoint fpConstructor({bool subNormalAsZero = false}) =>
+        FloatingPoint(
+            exponentWidth: exponentWidth,
+            mantissaWidth: mantissaWidth,
+            subNormalAsZero: subNormalAsZero);
+    FloatingPointValuePopulator fpvPopulator({bool subNormalAsZero = false}) =>
+        FloatingPointValue.populator(
+            exponentWidth: exponentWidth,
+            mantissaWidth: mantissaWidth,
+            subNormalAsZero: subNormalAsZero);
+
+    test('FP: dual-path adder DAZ/FTZ test singleton', () {
+      for (final subtract in [0, 1]) {
+        for (final daz1 in [false, true]) {
+          for (final daz2 in [false, true]) {
+            for (final ftz in [false, true]) {
+              final fp1 = fpConstructor(subNormalAsZero: daz1);
+              final fp2 = fpConstructor(subNormalAsZero: daz2);
+              final fpOut = fpConstructor(subNormalAsZero: ftz);
+
+              fp1.put(0);
+              fp2.put(0);
+              final adder =
+                  FloatingPointAdderSinglePath(fp1, fp2, outSum: fpOut);
+              const e1 = 0;
+              const m1 = 6;
+              const e2 = 0;
+              const m2 = 7;
+
+              final fv1 = fpvPopulator(subNormalAsZero: daz1).ofInts(e1, m1);
+              final fv2 = fpvPopulator(subNormalAsZero: daz2)
+                  .ofInts(e2, m2, sign: subtract == 1);
+
+              fp1.put(fv1.value);
+              fp2.put(fv2.value);
+              // This will interpret the adder.sum value as
+              // a FloatingPointValue without the sumNormalAsZero
+              // property set, so we can validate it is indeed zero.
+              final computed = fpvPopulator()
+                  .ofFloatingPointValue(adder.sum.floatingPointValue);
+
+              final dbl = fv1.toDouble() + fv2.toDouble();
+
+              final expectedRound =
+                  fpvPopulator(subNormalAsZero: ftz).ofDouble(dbl);
+
+              final expected = expectedRound;
+              expect(computed.isNaN, equals(expected.isNaN));
+              expect(computed, equals(expected), reason: '''
+      daz1: $daz1, daz2: $daz2    ftz: $ftz
+      $fv1 (${fv1.toDouble()})\t+
+      $fv2 (${fv2.toDouble()})\t=
+      $computed (${computed.toDouble()})\tcomputed
+      $expected (${expected.toDouble()})\texpected
+''');
+            }
+          }
+        }
+      }
+    });
+
+    test('FP: single-path adder DAZ/FTZ test exhaustive', () {
+      for (final subtract in [0, 1]) {
+        for (final daz1 in [false, true]) {
+          for (final daz2 in [false, true]) {
+            for (final ftz in [false, true]) {
+              final fp1 = fpConstructor(subNormalAsZero: daz1);
+              final fp2 = fpConstructor(subNormalAsZero: daz2);
+              final fpOut = fpConstructor(subNormalAsZero: ftz);
+
+              fp1.put(0);
+              fp2.put(0);
+              final adder =
+                  FloatingPointAdderSinglePath(fp1, fp2, outSum: fpOut);
+              for (var e1 = 0; e1 < expLimit; e1++) {
+                for (var m1 = 0; m1 < mantLimit; m1++) {
+                  final fv1 =
+                      fpvPopulator(subNormalAsZero: daz1).ofInts(e1, m1);
+                  for (var e2 = 0; e2 < expLimit; e2++) {
+                    for (var m2 = 0; m2 < mantLimit; m2++) {
+                      final fv2 = fpvPopulator(subNormalAsZero: daz2)
+                          .ofInts(e2, m2, sign: subtract == 1);
+
+                      fp1.put(fv1.value);
+                      fp2.put(fv2.value);
+                      // This will interpret the adder.sum value as
+                      // a FloatingPointValue without the sumNormalAsZero
+                      // property set, so we can validate it is indeed zero.
+                      final computed = fpvPopulator()
+                          .ofFloatingPointValue(adder.sum.floatingPointValue);
+
+                      final dbl = fv1.toDouble() + fv2.toDouble();
+
+                      final expectedRound =
+                          fpvPopulator(subNormalAsZero: ftz).ofDouble(dbl);
+
+                      final expected = expectedRound;
+                      expect(computed.isNaN, equals(expected.isNaN));
+                      expect(computed, equals(expected), reason: '''
+      daz1: $daz1, daz2: $daz2, ftz: $ftz
+      $fv1 (${fv1.toDouble()})\t+
+      $fv2 (${fv2.toDouble()})\t=
+      $computed (${computed.toDouble()})\tcomputed
+      $expected (${expected.toDouble()})\texpected
+''');
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+  });
+
   test('FP: simple new singleton test', () {
     const exponentWidth = 4;
     const mantissaWidth = 4;

--- a/test/arithmetic/floating_point/floating_point_adder_singlepath_test.dart
+++ b/test/arithmetic/floating_point/floating_point_adder_singlepath_test.dart
@@ -23,15 +23,18 @@ void main() {
   test('FP: simple wide singleton test', () async {
     const exponentWidth = 4;
     const mantissaWidth = 18;
+    FloatingPoint fpConstructor() => FloatingPoint(
+        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
     FloatingPointValue ofString(String s) =>
         FloatingPointValue.ofSpacedBinaryString(s);
+    FloatingPointValuePopulator fpvPopulator() => FloatingPointValue.populator(
+        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
 
     final fv1 = ofString('0 0000 101011100101000000');
     final fv2 = ofString('1 0001 100100101111011100');
-    final fp1 = FloatingPoint(
-        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    final fp2 = FloatingPoint(
-        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
+    final fp1 = fpConstructor();
+    final fp2 = fpConstructor();
+
     fp1.put(fv1);
     fp2.put(fv2);
     final adder = FloatingPointAdderSinglePath(fp1, fp2);
@@ -40,12 +43,8 @@ void main() {
 
     final expectedDouble = fv1.toDouble() + fv2.toDouble();
 
-    final expectedRound = FloatingPointValue.populator(
-            exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-        .ofDouble(expectedDouble);
-    final expectedNoRound = FloatingPointValue.populator(
-            exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-        .ofDoubleUnrounded(expectedDouble);
+    final expectedRound = fpvPopulator().ofDouble(expectedDouble);
+    final expectedNoRound = fpvPopulator().ofDoubleUnrounded(expectedDouble);
 
     expect(computed, equals(expectedRound), reason: '''
       $fv1 (${fv1.toDouble()})\t+
@@ -59,10 +58,12 @@ void main() {
   test('FP: simple adder truncating random', () {
     const exponentWidth = 9;
     const mantissaWidth = 15;
-
-    final fp1 = FloatingPoint(
+    FloatingPoint fpConstructor() => FloatingPoint(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    final fp2 = FloatingPoint(
+    final fp1 = fpConstructor();
+    final fp2 = fpConstructor();
+
+    FloatingPointValuePopulator fpvPopulator() => FloatingPointValue.populator(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
     fp1.put(0);
     fp2.put(0);
@@ -70,12 +71,8 @@ void main() {
         roundingMode: FloatingPointRoundingMode.truncate);
     final rand = Random(513);
     for (var i = 0; i < 5000; i++) {
-      final fv1 = FloatingPointValue.populator(
-              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-          .random(rand);
-      final fv2 = FloatingPointValue.populator(
-              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-          .random(rand);
+      final fv1 = fpvPopulator().random(rand);
+      final fv2 = fpvPopulator().random(rand);
       if ((fv1.exponent.toInt() - fv2.exponent.toInt()).abs() >
           51 - mantissaWidth) {
         // Native double math cannot verify unrounded result
@@ -89,12 +86,8 @@ void main() {
       final expectedDouble =
           fp1.floatingPointValue.toDouble() + fp2.floatingPointValue.toDouble();
 
-      final expectedNoRound = FloatingPointValue.populator(
-              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-          .ofDoubleUnrounded(expectedDouble);
-      final expectedRound = FloatingPointValue.populator(
-              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-          .ofDouble(expectedDouble);
+      final expectedNoRound = fpvPopulator().ofDoubleUnrounded(expectedDouble);
+      final expectedRound = fpvPopulator().ofDouble(expectedDouble);
       expect(computed, equals(expectedNoRound), reason: '''
       $fv1 (${fv1.toDouble()})\t+
       $fv2 (${fv2.toDouble()})\t=
@@ -109,21 +102,20 @@ void main() {
     const exponentWidth = 9;
     const mantissaWidth = 15;
 
-    final fp1 = FloatingPoint(
+    FloatingPoint fpConstructor() => FloatingPoint(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    final fp2 = FloatingPoint(
+    final fp1 = fpConstructor();
+    final fp2 = fpConstructor();
+
+    FloatingPointValuePopulator fpvPopulator() => FloatingPointValue.populator(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
     fp1.put(0);
     fp2.put(0);
     final adder = FloatingPointAdderSinglePath(fp1, fp2);
     final rand = Random(513);
     for (var i = 0; i < 5000; i++) {
-      final fv1 = FloatingPointValue.populator(
-              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-          .random(rand);
-      final fv2 = FloatingPointValue.populator(
-              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-          .random(rand);
+      final fv1 = fpvPopulator().random(rand);
+      final fv2 = fpvPopulator().random(rand);
       if ((fv1.exponent.toInt() - fv2.exponent.toInt()).abs() >
           51 - mantissaWidth) {
         // Native double math cannot verify unrounded result
@@ -137,12 +129,8 @@ void main() {
       final expectedDouble =
           fp1.floatingPointValue.toDouble() + fp2.floatingPointValue.toDouble();
 
-      final expectedNoRound = FloatingPointValue.populator(
-              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-          .ofDoubleUnrounded(expectedDouble);
-      final expectedRound = FloatingPointValue.populator(
-              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-          .ofDouble(expectedDouble);
+      final expectedNoRound = fpvPopulator().ofDoubleUnrounded(expectedDouble);
+      final expectedRound = fpvPopulator().ofDouble(expectedDouble);
       expect(computed, equals(expectedRound), reason: '''
       $fv1 (${fv1.toDouble()})\t+
       $fv2 (${fv2.toDouble()})\t=
@@ -156,15 +144,16 @@ void main() {
   test('FP: simple new singleton test', () {
     const exponentWidth = 4;
     const mantissaWidth = 4;
-    FloatingPointValue ofString(String s) =>
-        FloatingPointValue.ofSpacedBinaryString(s);
-    final fv1 = ofString('0 0000 0001');
-    final fv2 = ofString('1 0000 0000');
+    FloatingPoint fpConstructor() => FloatingPoint(
+        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
+    final fp1 = fpConstructor();
+    final fp2 = fpConstructor();
 
-    final fp1 = FloatingPoint(
+    FloatingPointValuePopulator fpvPopulator() => FloatingPointValue.populator(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    final fp2 = FloatingPoint(
-        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
+    final fv1 = FloatingPointValue.ofSpacedBinaryString('0 0000 0001');
+    final fv2 = FloatingPointValue.ofSpacedBinaryString('1 0000 0000');
+
     fp1.put(fv1);
     fp2.put(fv2);
     final adder = FloatingPointAdderSinglePath(fp1, fp2);
@@ -172,12 +161,8 @@ void main() {
 
     final expectedDouble = fv1.toDouble() + fv2.toDouble();
 
-    final expectedRound = FloatingPointValue.populator(
-            exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-        .ofDouble(expectedDouble);
-    final expectedNoRound = FloatingPointValue.populator(
-            exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-        .ofDoubleUnrounded(expectedDouble);
+    final expectedRound = fpvPopulator().ofDouble(expectedDouble);
+    final expectedNoRound = fpvPopulator().ofDoubleUnrounded(expectedDouble);
 
     expect(computed, equals(expectedRound), reason: '''
       $fv1 (${fv1.toDouble()})\t+
@@ -191,9 +176,12 @@ void main() {
   test('FP: simple adder truncating exhaustive', () {
     const exponentWidth = 4;
     const mantissaWidth = 4;
-    final fp1 = FloatingPoint(
+    FloatingPoint fpConstructor() => FloatingPoint(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    final fp2 = FloatingPoint(
+    final fp1 = fpConstructor();
+    final fp2 = fpConstructor();
+
+    FloatingPointValuePopulator fpvPopulator() => FloatingPointValue.populator(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
     fp1.put(0);
     fp2.put(0);
@@ -205,28 +193,17 @@ void main() {
       final mantLimit = pow(2, mantissaWidth);
       for (var e1 = 0; e1 < expLimit; e1++) {
         for (var m1 = 0; m1 < mantLimit; m1++) {
-          final fv1 = FloatingPointValue.populator(
-                  exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-              .ofInts(e1, m1);
+          final fv1 = fpvPopulator().ofInts(e1, m1);
           for (var e2 = 0; e2 < expLimit; e2++) {
             for (var m2 = 0; m2 < mantLimit; m2++) {
-              final fv2 = FloatingPointValue.populator(
-                      exponentWidth: exponentWidth,
-                      mantissaWidth: mantissaWidth)
-                  .ofInts(e2, m2, sign: subtract == 1);
+              final fv2 = fpvPopulator().ofInts(e2, m2, sign: subtract == 1);
               fp1.put(fv1.value);
               fp2.put(fv2.value);
 
               final computed = adder.sum.floatingPointValue;
               final dbl = fv1.toDouble() + fv2.toDouble();
-              final expectedNoRound = FloatingPointValue.populator(
-                      exponentWidth: exponentWidth,
-                      mantissaWidth: mantissaWidth)
-                  .ofDoubleUnrounded(dbl);
-              final expectedRound = FloatingPointValue.populator(
-                      exponentWidth: exponentWidth,
-                      mantissaWidth: mantissaWidth)
-                  .ofDouble(dbl);
+              final expectedNoRound = fpvPopulator().ofDoubleUnrounded(dbl);
+              final expectedRound = fpvPopulator().ofDouble(dbl);
               expect(computed, equals(expectedNoRound), reason: '''
       $fv1 (${fv1.toDouble()})\t+
       $fv2 (${fv2.toDouble()})\t=
@@ -244,9 +221,11 @@ void main() {
   test('FP: simple adder rounding exhaustive', () {
     const exponentWidth = 4;
     const mantissaWidth = 4;
-    final fp1 = FloatingPoint(
+    FloatingPoint fpConstructor() => FloatingPoint(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    final fp2 = FloatingPoint(
+    final fp1 = fpConstructor();
+    final fp2 = fpConstructor();
+    FloatingPointValuePopulator fpvPopulator() => FloatingPointValue.populator(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
     fp1.put(0);
     fp2.put(0);
@@ -257,28 +236,17 @@ void main() {
       final mantLimit = pow(2, mantissaWidth);
       for (var e1 = 0; e1 < expLimit; e1++) {
         for (var m1 = 0; m1 < mantLimit; m1++) {
-          final fv1 = FloatingPointValue.populator(
-                  exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-              .ofInts(e1, m1);
+          final fv1 = fpvPopulator().ofInts(e1, m1);
           for (var e2 = 0; e2 < expLimit; e2++) {
             for (var m2 = 0; m2 < mantLimit; m2++) {
-              final fv2 = FloatingPointValue.populator(
-                      exponentWidth: exponentWidth,
-                      mantissaWidth: mantissaWidth)
-                  .ofInts(e2, m2, sign: subtract == 1);
+              final fv2 = fpvPopulator().ofInts(e2, m2, sign: subtract == 1);
               fp1.put(fv1.value);
               fp2.put(fv2.value);
 
               final computed = adder.sum.floatingPointValue;
               final dbl = fv1.toDouble() + fv2.toDouble();
-              final expectedNoRound = FloatingPointValue.populator(
-                      exponentWidth: exponentWidth,
-                      mantissaWidth: mantissaWidth)
-                  .ofDoubleUnrounded(dbl);
-              final expectedRound = FloatingPointValue.populator(
-                      exponentWidth: exponentWidth,
-                      mantissaWidth: mantissaWidth)
-                  .ofDouble(dbl);
+              final expectedNoRound = fpvPopulator().ofDoubleUnrounded(dbl);
+              final expectedRound = fpvPopulator().ofDouble(dbl);
               expect(computed, equals(expectedRound), reason: '''
       $fv1 (${fv1.toDouble()})\t+
       $fv2 (${fv2.toDouble()})\t=
@@ -299,14 +267,16 @@ void main() {
     });
     const exponentWidth = 4;
     const mantissaWidth = 4;
+    FloatingPoint fpConstructor() => FloatingPoint(
+        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
+    final fp1 = fpConstructor();
+    final fp2 = fpConstructor();
 
     FloatingPointValue ofString(String s) =>
         FloatingPointValue.ofSpacedBinaryString(s);
+    FloatingPointValuePopulator fpvPopulator() => FloatingPointValue.populator(
+        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
 
-    final fp1 = FloatingPoint(
-        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    final fp2 = FloatingPoint(
-        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
     fp1.put(0);
     fp2.put(0);
     test('FP: simple adder narrow corner tests', () {
@@ -351,14 +321,12 @@ void main() {
         final expectedDouble = fp1.floatingPointValue.toDouble() +
             fp2.floatingPointValue.toDouble();
 
-        final expectedNoRound = FloatingPointValue.populator(
-                exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-            .ofDoubleUnrounded(expectedDouble);
+        final expectedNoRound =
+            fpvPopulator().ofDoubleUnrounded(expectedDouble);
 
         final computed = adder.sum.floatingPointValue;
-        final expectedRound = FloatingPointValue.populator(
-                exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-            .ofDouble(fv1.toDouble() + fv2.toDouble());
+        final expectedRound =
+            fpvPopulator().ofDouble(fv1.toDouble() + fv2.toDouble());
         expect(computed, equals(expectedRound), reason: '''
       $fv1 (${fv1.toDouble()})\t+
       $fv2 (${fv2.toDouble()})\t=
@@ -376,9 +344,7 @@ void main() {
       final expectedDouble =
           fp1.floatingPointValue.toDouble() + fp2.floatingPointValue.toDouble();
 
-      final expectedNoRound = FloatingPointValue.populator(
-              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-          .ofDoubleUnrounded(expectedDouble);
+      final expectedNoRound = fpvPopulator().ofDoubleUnrounded(expectedDouble);
       expect(adder.sum.floatingPointValue, equals(expectedNoRound));
     });
 
@@ -390,9 +356,7 @@ void main() {
       final expectedDouble =
           fp1.floatingPointValue.toDouble() + fp2.floatingPointValue.toDouble();
 
-      final expectedNoRound = FloatingPointValue.populator(
-              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-          .ofDoubleUnrounded(expectedDouble);
+      final expectedNoRound = fpvPopulator().ofDoubleUnrounded(expectedDouble);
 
       final FloatingPointValue expected;
       expected = expectedNoRound;
@@ -422,12 +386,8 @@ void main() {
       final rand = Random(513);
 
       for (var i = 0; i < 500; i++) {
-        final fv1 = FloatingPointValue.populator(
-                exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-            .random(rand, normal: true);
-        final fv2 = FloatingPointValue.populator(
-                exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-            .random(rand, normal: true);
+        final fv1 = fpvPopulator().random(rand, normal: true);
+        final fv2 = fpvPopulator().random(rand, normal: true);
 
         fp1.put(fv1.value);
         fp2.put(fv2.value);
@@ -437,12 +397,10 @@ void main() {
 
         final computed = adder.sum.floatingPointValue;
 
-        final expectedNoRound = FloatingPointValue.populator(
-                exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-            .ofDoubleUnrounded(fv1.toDouble() + fv2.toDouble());
-        final expectedRound = FloatingPointValue.populator(
-                exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-            .ofDouble(fv1.toDouble() + fv2.toDouble());
+        final expectedNoRound =
+            fpvPopulator().ofDoubleUnrounded(fv1.toDouble() + fv2.toDouble());
+        final expectedRound =
+            fpvPopulator().ofDouble(fv1.toDouble() + fv2.toDouble());
         expect(computed, equals(expectedRound), reason: '''
       $fv1 (${fv1.toDouble()})\t+
       $fv2 (${fv2.toDouble()})\t=
@@ -457,35 +415,33 @@ void main() {
   test('FP: adder simple wide mantissa singleton', () async {
     const exponentWidth = 2;
     const mantissaWidth = 20;
-    final fp1 = FloatingPoint(
+    FloatingPoint fpConstructor() => FloatingPoint(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    final fp2 = FloatingPoint(
+    FloatingPointValuePopulator fpvPopulator() => FloatingPointValue.populator(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    final fpout = FloatingPoint(
-        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
+
+    final fp1 = fpConstructor();
+    final fp2 = fpConstructor();
+    final fpout = fpConstructor();
     fp1.put(0);
     fp2.put(0);
 
     final adder = FloatingPointAdderSinglePath(fp1, fp2, outSum: fpout);
-    final fv1 = FloatingPointValue.populator(
-            exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-        .ofLogicValue(LogicValue.ofRadixString("23'h50bd0d"));
-    final fv2 = FloatingPointValue.populator(
-            exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-        .ofLogicValue(LogicValue.ofRadixString("23'h4ff000"));
+    final fv1 =
+        fpvPopulator().ofLogicValue(LogicValue.ofRadixString("23'h50bd0d"));
+    final fv2 =
+        fpvPopulator().ofLogicValue(LogicValue.ofRadixString("23'h4ff000"));
 
     fp1.put(fv1.value);
     fp2.put(fv2.value);
 
     final computed = adder.sum.floatingPointValue;
 
-    final expectedNoRound = FloatingPointValue.populator(
-            exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-        .ofDoubleUnrounded(fv1.toDouble() + fv2.toDouble());
+    final expectedNoRound =
+        fpvPopulator().ofDoubleUnrounded(fv1.toDouble() + fv2.toDouble());
 
-    final expectedRound = FloatingPointValue.populator(
-            exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-        .ofDouble(fv1.toDouble() + fv2.toDouble());
+    final expectedRound =
+        fpvPopulator().ofDouble(fv1.toDouble() + fv2.toDouble());
     expect(computed, equals(expectedRound), reason: '''
       $fv1 (${fv1.toDouble()})\t+
       $fv2 (${fv2.toDouble()})\t=
@@ -498,12 +454,14 @@ void main() {
   test('FP: adder simple wide mantissa random', () async {
     const exponentWidth = 2;
     const mantissaWidth = 20;
-    final fp1 = FloatingPoint(
+    FloatingPoint fpConstructor() => FloatingPoint(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    final fp2 = FloatingPoint(
+    FloatingPointValuePopulator fpvPopulator() => FloatingPointValue.populator(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    final fpout = FloatingPoint(
-        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
+
+    final fp1 = fpConstructor();
+    final fp2 = fpConstructor();
+    final fpout = fpConstructor();
     fp1.put(0);
     fp2.put(0);
 
@@ -514,25 +472,19 @@ void main() {
     final rand = Random(513);
 
     for (var i = 0; i < 500; i++) {
-      final fv1 = FloatingPointValue.populator(
-              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-          .random(rand);
-      final fv2 = FloatingPointValue.populator(
-              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-          .random(rand);
+      final fv1 = fpvPopulator().random(rand);
+      final fv2 = fpvPopulator().random(rand);
 
       fp1.put(fv1.value);
       fp2.put(fv2.value);
 
       final computed = adder.sum.floatingPointValue;
 
-      final expectedNoRound = FloatingPointValue.populator(
-              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-          .ofDoubleUnrounded(fv1.toDouble() + fv2.toDouble());
+      final expectedNoRound =
+          fpvPopulator().ofDoubleUnrounded(fv1.toDouble() + fv2.toDouble());
 
-      final expectedRound = FloatingPointValue.populator(
-              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-          .ofDouble(fv1.toDouble() + fv2.toDouble());
+      final expectedRound =
+          fpvPopulator().ofDouble(fv1.toDouble() + fv2.toDouble());
       expect(computed, equals(expectedRound), reason: '''
       $fv1 ${fv1.value} (${fv1.toDouble()})\t+
       $fv2 ${fv2.value} (${fv2.toDouble()})\t=
@@ -546,10 +498,13 @@ void main() {
   test('FP: adder simple wide exponent random', () async {
     const exponentWidth = 10;
     const mantissaWidth = 3;
-    final fp1 = FloatingPoint(
+    FloatingPoint fpConstructor() => FloatingPoint(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    final fp2 = FloatingPoint(
+    FloatingPointValuePopulator fpvPopulator() => FloatingPointValue.populator(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
+
+    final fp1 = fpConstructor();
+    final fp2 = fpConstructor();
 
     fp1.put(0);
     fp2.put(0);
@@ -560,12 +515,8 @@ void main() {
     final rand = Random(513);
 
     for (var i = 0; i < 5000; i++) {
-      final fv1 = FloatingPointValue.populator(
-              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-          .random(rand);
-      final fv2 = FloatingPointValue.populator(
-              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-          .random(rand);
+      final fv1 = fpvPopulator().random(rand);
+      final fv2 = fpvPopulator().random(rand);
       if ((fv1.exponent.toInt() - fv2.exponent.toInt()).abs() >
           51 - mantissaWidth) {
         // Native double math cannot verify unrounded result
@@ -577,12 +528,10 @@ void main() {
 
       final computed = adder.sum.floatingPointValue;
 
-      final expectedNoRound = FloatingPointValue.populator(
-              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-          .ofDoubleUnrounded(fv1.toDouble() + fv2.toDouble());
-      final expectedRound = FloatingPointValue.populator(
-              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-          .ofDouble(fv1.toDouble() + fv2.toDouble());
+      final expectedNoRound =
+          fpvPopulator().ofDoubleUnrounded(fv1.toDouble() + fv2.toDouble());
+      final expectedRound =
+          fpvPopulator().ofDouble(fv1.toDouble() + fv2.toDouble());
       expect(computed, equals(expectedRound), reason: '''
       $fv1 (${fv1.toDouble()})\t+
       $fv2 (${fv2.toDouble()})\t=
@@ -600,15 +549,18 @@ void main() {
     const exponentWidth = 4;
     const mantissaWidth = 4;
     const outMantissaWidth = 20;
+    FloatingPoint fpConstructor() => FloatingPoint(
+        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
     FloatingPointValue ofString(String s) =>
         FloatingPointValue.ofSpacedBinaryString(s);
+    FloatingPointValuePopulator fpvPopulator() => FloatingPointValue.populator(
+        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
+
+    final fp1 = fpConstructor();
+    final fp2 = fpConstructor();
     final fv1 = ofString('0 0000 0001');
     final fv2 = ofString('1 0000 0000');
 
-    final fp1 = FloatingPoint(
-        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    final fp2 = FloatingPoint(
-        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
     final fpout = FloatingPoint(
         exponentWidth: exponentWidth, mantissaWidth: outMantissaWidth);
     fp1.put(fv1);
@@ -618,12 +570,8 @@ void main() {
 
     final expectedDouble = fv1.toDouble() + fv2.toDouble();
 
-    final expectedRound = FloatingPointValue.populator(
-            exponentWidth: exponentWidth, mantissaWidth: outMantissaWidth)
-        .ofDouble(expectedDouble);
-    final expectedNoRound = FloatingPointValue.populator(
-            exponentWidth: exponentWidth, mantissaWidth: outMantissaWidth)
-        .ofDoubleUnrounded(expectedDouble);
+    final expectedRound = fpvPopulator().ofDouble(expectedDouble);
+    final expectedNoRound = fpvPopulator().ofDoubleUnrounded(expectedDouble);
 
     expect(computed, equals(expectedRound), reason: '''
       $fv1 (${fv1.toDouble()})\t+
@@ -637,11 +585,13 @@ void main() {
   test('FP: simple adder widening mantissa exhaustive', () {
     const exponentWidth = 3;
     const mantissaWidth = 3;
+    FloatingPoint fpConstructor() => FloatingPoint(
+        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
+    FloatingPointValuePopulator fpvPopulator() => FloatingPointValue.populator(
+        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
 
-    final fp1 = FloatingPoint(
-        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    final fp2 = FloatingPoint(
-        exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
+    final fp1 = fpConstructor();
+    final fp2 = fpConstructor();
     for (final outMantissaWidth in [6, 7, 8, 9, 15]) {
       final fpout = FloatingPoint(
           exponentWidth: exponentWidth, mantissaWidth: outMantissaWidth);
@@ -654,28 +604,17 @@ void main() {
         final mantLimit = pow(2, mantissaWidth);
         for (var e1 = 0; e1 < expLimit; e1++) {
           for (var m1 = 0; m1 < mantLimit; m1++) {
-            final fv1 = FloatingPointValue.populator(
-                    exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-                .ofInts(e1, m1);
+            final fv1 = fpvPopulator().ofInts(e1, m1);
             for (var e2 = 0; e2 < expLimit; e2++) {
               for (var m2 = 0; m2 < mantLimit; m2++) {
-                final fv2 = FloatingPointValue.populator(
-                        exponentWidth: exponentWidth,
-                        mantissaWidth: mantissaWidth)
-                    .ofInts(e2, m2, sign: subtract == 1);
+                final fv2 = fpvPopulator().ofInts(e2, m2, sign: subtract == 1);
                 fp1.put(fv1.value);
                 fp2.put(fv2.value);
 
                 final computed = adder.sum.floatingPointValue;
                 final dbl = fv1.toDouble() + fv2.toDouble();
-                final expectedNoRound = FloatingPointValue.populator(
-                        exponentWidth: exponentWidth,
-                        mantissaWidth: outMantissaWidth)
-                    .ofDoubleUnrounded(dbl);
-                final expectedRound = FloatingPointValue.populator(
-                        exponentWidth: exponentWidth,
-                        mantissaWidth: outMantissaWidth)
-                    .ofDouble(dbl);
+                final expectedNoRound = fpvPopulator().ofDoubleUnrounded(dbl);
+                final expectedRound = fpvPopulator().ofDouble(dbl);
                 expect(computed, equals(expectedRound), reason: '''
       $fv1 (${fv1.toDouble()})\t+
       $fv2 (${fv2.toDouble()})\t=
@@ -695,7 +634,7 @@ void main() {
     const exponentWidth = 3;
     const mantissaWidth = 3;
 
-    FloatingPointValuePopulator fpPopulator({required bool explicitJBit}) =>
+    FloatingPointValuePopulator fpvPopulator({required bool explicitJBit}) =>
         FloatingPointValue.populator(
             exponentWidth: exponentWidth,
             mantissaWidth: mantissaWidth,
@@ -717,28 +656,17 @@ void main() {
       final fpout = fpConstructor(explicitJBit: outputExplicitJBit);
 
       // Subtraction fails from i to e should not round.
-      var fv1 = ofString('0 000 001');
-      var fv2 = ofString('1 110 011');
-      // These allow to keep as var instead of final.
-      fv1 = ofString('0 000 001');
-      fv2 = ofString('1 110 011');
-      // // I/E->I  fails here both unrounded and rounded
-      // fv1 = ofString('0 000 000');
-      // fv2 = ofString('0 001 001', explicitJBit: input2ExplicitJBit);
-      // fv1 = ofString('0 000 000');
-      // fv2 = ofString('0 110 111');
-      // // I/E->E fails to compute Infinity
-      // fv1 = ofString('0 110 111');
-      // fv2 = ofString('0 110 111', explicitJBit: input2ExplicitJBit);
+      final fv1 = ofString('0 000 001');
+      final fv2 = ofString('1 110 011');
 
       fp1.put(fv1);
       fp2.put(fv2);
       final adder = FloatingPointAdderSinglePath(fp1, fp2, outSum: fpout);
-      final computed = fpPopulator(explicitJBit: outputExplicitJBit)
+      final computed = fpvPopulator(explicitJBit: outputExplicitJBit)
           .ofFloatingPointValue(adder.sum.floatingPointValue);
-      final expectedNoRound = fpPopulator(explicitJBit: outputExplicitJBit)
+      final expectedNoRound = fpvPopulator(explicitJBit: outputExplicitJBit)
           .ofDoubleUnrounded(fv1.toDouble() + fv2.toDouble());
-      final expectedRound = fpPopulator(explicitJBit: outputExplicitJBit)
+      final expectedRound = fpvPopulator(explicitJBit: outputExplicitJBit)
           .ofDouble(fv1.toDouble() + fv2.toDouble());
 
       expect(computed, predicate((e) => e == expectedRound), reason: '''
@@ -771,13 +699,13 @@ void main() {
               final mantLimit = pow(2, mantissaWidth);
               for (var e1 = 0; e1 < expLimit; e1++) {
                 for (var m1 = 0; m1 < mantLimit; m1++) {
-                  final fv1 = fpPopulator(explicitJBit: input1ExplicitJBit)
+                  final fv1 = fpvPopulator(explicitJBit: input1ExplicitJBit)
                       .ofInts(e1, m1);
                   if (fv1.isLegalValue()) {
                     for (var e2 = 0; e2 < expLimit; e2++) {
                       for (var m2 = 0; m2 < mantLimit; m2++) {
                         final fv2 =
-                            fpPopulator(explicitJBit: input2ExplicitJBit)
+                            fpvPopulator(explicitJBit: input2ExplicitJBit)
                                 .ofInts(e2, m2, sign: subtract == 1);
                         if (fv2.isLegalValue()) {
                           if ((fv1.exponent.toInt() - fv2.exponent.toInt())
@@ -790,17 +718,17 @@ void main() {
                           fp2.put(fv2.value);
 
                           final computed =
-                              fpPopulator(explicitJBit: outputExplicitJBit)
+                              fpvPopulator(explicitJBit: outputExplicitJBit)
                                   .ofFloatingPointValue(
                                       adder.sum.floatingPointValue,
                                       canonicalizeExplicit: true);
                           final expectedNoRound =
-                              fpPopulator(explicitJBit: outputExplicitJBit)
+                              fpvPopulator(explicitJBit: outputExplicitJBit)
                                   .ofDoubleUnrounded(
                                       fv1.toDouble() + fv2.toDouble())
                                   .canonicalize();
                           final expectedRound =
-                              fpPopulator(explicitJBit: outputExplicitJBit)
+                              fpvPopulator(explicitJBit: outputExplicitJBit)
                                   .ofDouble(fv1.toDouble() + fv2.toDouble())
                                   .canonicalize();
 
@@ -846,13 +774,13 @@ void main() {
       fp1.put(fv1);
       fp2.put(fv2);
       final adder = FloatingPointAdderSinglePath(fp1, fp2, outSum: fpout);
-      final computed = fpPopulator(explicitJBit: outputExplicitJBit)
+      final computed = fpvPopulator(explicitJBit: outputExplicitJBit)
           .ofFloatingPointValue(adder.sum.floatingPointValue,
               canonicalizeExplicit: true);
-      final expectedNoRound = fpPopulator(explicitJBit: outputExplicitJBit)
+      final expectedNoRound = fpvPopulator(explicitJBit: outputExplicitJBit)
           .ofDoubleUnrounded(fv1.toDouble() + fv2.toDouble())
           .canonicalize();
-      final expectedRound = fpPopulator(explicitJBit: outputExplicitJBit)
+      final expectedRound = fpvPopulator(explicitJBit: outputExplicitJBit)
           .ofDouble(fv1.toDouble() + fv2.toDouble())
           .canonicalize();
 
@@ -878,7 +806,7 @@ void main() {
                 exponentWidth: exponentWidth,
                 mantissaWidth: outMantissaWidth,
                 explicitJBit: explicitJBit);
-        FloatingPoint fpOutConstructor({required bool explicitJBit}) =>
+        FloatingPoint fpOutConstructor({bool explicitJBit = false}) =>
             FloatingPoint(
                 exponentWidth: exponentWidth,
                 mantissaWidth: outMantissaWidth,
@@ -901,13 +829,13 @@ void main() {
                 final mantLimit = pow(2, mantissaWidth);
                 for (var e1 = 0; e1 < expLimit; e1++) {
                   for (var m1 = 0; m1 < mantLimit; m1++) {
-                    final fv1 = fpPopulator(explicitJBit: input1ExplicitJBit)
+                    final fv1 = fpvPopulator(explicitJBit: input1ExplicitJBit)
                         .ofInts(e1, m1);
                     if (fv1.isLegalValue()) {
                       for (var e2 = 0; e2 < expLimit; e2++) {
                         for (var m2 = 0; m2 < mantLimit; m2++) {
                           final fv2 =
-                              fpPopulator(explicitJBit: input2ExplicitJBit)
+                              fpvPopulator(explicitJBit: input2ExplicitJBit)
                                   .ofInts(e2, m2, sign: subtract == 1);
                           if (fv2.isLegalValue()) {
                             if ((fv1.exponent.toInt() - fv2.exponent.toInt())
@@ -961,119 +889,103 @@ void main() {
         }
       }
     });
+  });
 
-    test('FP: simple j-bit adder wide mantissa random', () {
-      const exponentWidth = 8;
-      const mantissaWidth = 25;
+  test('FP: simple j-bit adder wide mantissa random', () {
+    const exponentWidth = 8;
+    const mantissaWidth = 25;
+    FloatingPoint fpConstructor({bool explicitJBit = false}) => FloatingPoint(
+        exponentWidth: exponentWidth,
+        mantissaWidth: mantissaWidth,
+        explicitJBit: explicitJBit);
+    FloatingPointValuePopulator fpvPopulator({bool explicitJBit = false}) =>
+        FloatingPointValue.populator(
+            exponentWidth: exponentWidth,
+            mantissaWidth: mantissaWidth,
+            explicitJBit: explicitJBit);
 
-      final fp1 = FloatingPoint(
-          exponentWidth: exponentWidth,
-          mantissaWidth: mantissaWidth,
-          explicitJBit: true);
-      final fp2 = FloatingPoint(
-          exponentWidth: exponentWidth,
-          mantissaWidth: mantissaWidth,
-          explicitJBit: true);
-      final fpout = FloatingPoint(
-          exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-      fp1.put(0);
-      fp2.put(0);
-      final adder = FloatingPointAdderSinglePath(fp1, fp2, outSum: fpout);
-      final rand = Random(513);
-      for (var i = 0; i < 500; i++) {
-        final fv1 = FloatingPointValue.populator(
-                exponentWidth: exponentWidth,
-                mantissaWidth: mantissaWidth,
-                explicitJBit: true)
-            .random(rand);
-        final fv2 = FloatingPointValue.populator(
-                exponentWidth: exponentWidth,
-                mantissaWidth: mantissaWidth,
-                explicitJBit: true)
-            .random(rand);
-        if (fv1.isLegalValue() & fv2.isLegalValue()) {
-          fp1.put(fv1);
-          fp2.put(fv2);
-          final computed = adder.sum.floatingPointValue;
+    final fp1 = fpConstructor(explicitJBit: true);
+    final fp2 = fpConstructor(explicitJBit: true);
+    final fpout = fpConstructor();
+    fp1.put(0);
+    fp2.put(0);
+    final adder = FloatingPointAdderSinglePath(fp1, fp2, outSum: fpout);
+    final rand = Random(513);
+    for (var i = 0; i < 500; i++) {
+      final fv1 = fpvPopulator(explicitJBit: true).random(rand);
+      final fv2 = fpvPopulator(explicitJBit: true).random(rand);
+      if (fv1.isLegalValue() & fv2.isLegalValue()) {
+        fp1.put(fv1);
+        fp2.put(fv2);
+        final computed = adder.sum.floatingPointValue;
 
-          final expectedDouble = fp1.floatingPointValue.toDouble() +
-              fp2.floatingPointValue.toDouble();
+        final expectedDouble = fp1.floatingPointValue.toDouble() +
+            fp2.floatingPointValue.toDouble();
 
-          final expectedNoRound = FloatingPointValue.populator(
-                  exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-              .ofDoubleUnrounded(expectedDouble);
-          final expectedRound = FloatingPointValue.populator(
-                  exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-              .ofDouble(fv1.toDouble() + fv2.toDouble());
-          expect(computed, equals(expectedRound), reason: '''
+        final expectedNoRound =
+            fpvPopulator().ofDoubleUnrounded(expectedDouble);
+        final expectedRound =
+            fpvPopulator().ofDouble(fv1.toDouble() + fv2.toDouble());
+        expect(computed, equals(expectedRound), reason: '''
       $fv1 (${fv1.toDouble()})\t+
       $fv2 (${fv2.toDouble()})\t=
       $computed (${computed.toDouble()})\tcomputed
       $expectedNoRound (${expectedNoRound.toDouble()})\texpected
 ''');
-        }
       }
-    });
+    }
+  });
 
-    test('FP: simple j-bit adder wide exponent random', () {
-      const exponentWidth = 6;
-      const mantissaWidth = 4;
+  test('FP: simple j-bit adder wide exponent random', () {
+    const exponentWidth = 6;
+    const mantissaWidth = 4;
+    FloatingPoint fpConstructor({bool explicitJBit = false}) => FloatingPoint(
+        exponentWidth: exponentWidth,
+        mantissaWidth: mantissaWidth,
+        explicitJBit: explicitJBit);
+    FloatingPointValuePopulator fpvPopulator({bool explicitJBit = false}) =>
+        FloatingPointValue.populator(
+            exponentWidth: exponentWidth,
+            mantissaWidth: mantissaWidth,
+            explicitJBit: explicitJBit);
 
-      final fp1 = FloatingPoint(
-          exponentWidth: exponentWidth,
-          mantissaWidth: mantissaWidth,
-          explicitJBit: true);
-      final fp2 = FloatingPoint(
-          exponentWidth: exponentWidth,
-          mantissaWidth: mantissaWidth,
-          explicitJBit: true);
-      final fpout = FloatingPoint(
-          exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-      fp1.put(0);
-      fp2.put(0);
-      final adder = FloatingPointAdderSinglePath(fp1, fp2, outSum: fpout);
-      final rand = Random(513);
-      for (var i = 0; i < 5000; i++) {
-        final fv1 = FloatingPointValue.populator(
-                exponentWidth: exponentWidth,
-                mantissaWidth: mantissaWidth,
-                explicitJBit: true)
-            .random(rand);
-        final fv2 = FloatingPointValue.populator(
-                exponentWidth: exponentWidth,
-                mantissaWidth: mantissaWidth,
-                explicitJBit: true)
-            .random(rand);
-        if (fv1.isLegalValue() & fv2.isLegalValue()) {
-          if (fv1.isAnInfinity | fv2.isAnInfinity) {
-            continue;
-          }
-          if ((fv1.exponent.toInt() - fv2.exponent.toInt()).abs() >
-              51 - mantissaWidth) {
-            // Native double math cannot verify unrounded result
-            continue;
-          }
-          fp1.put(fv1);
-          fp2.put(fv2);
-          final computed = adder.sum.floatingPointValue;
+    final fp1 = fpConstructor(explicitJBit: true);
+    final fp2 = fpConstructor(explicitJBit: true);
+    final fpout = fpConstructor();
+    fp1.put(0);
+    fp2.put(0);
+    final adder = FloatingPointAdderSinglePath(fp1, fp2, outSum: fpout);
+    final rand = Random(513);
+    for (var i = 0; i < 5000; i++) {
+      final fv1 = fpvPopulator(explicitJBit: true).random(rand);
+      final fv2 = fpvPopulator(explicitJBit: true).random(rand);
+      if (fv1.isLegalValue() & fv2.isLegalValue()) {
+        if (fv1.isAnInfinity | fv2.isAnInfinity) {
+          continue;
+        }
+        if ((fv1.exponent.toInt() - fv2.exponent.toInt()).abs() >
+            51 - mantissaWidth) {
+          // Native double math cannot verify unrounded result
+          continue;
+        }
+        fp1.put(fv1);
+        fp2.put(fv2);
+        final computed = adder.sum.floatingPointValue;
 
-          final expectedDouble = fp1.floatingPointValue.toDouble() +
-              fp2.floatingPointValue.toDouble();
+        final expectedDouble = fp1.floatingPointValue.toDouble() +
+            fp2.floatingPointValue.toDouble();
 
-          final expectedNoRound = FloatingPointValue.populator(
-                  exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-              .ofDoubleUnrounded(expectedDouble);
-          final expectedRound = FloatingPointValue.populator(
-                  exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
-              .ofDouble(fv1.toDouble() + fv2.toDouble());
-          expect(computed, equals(expectedRound), reason: '''
+        final expectedNoRound =
+            fpvPopulator().ofDoubleUnrounded(expectedDouble);
+        final expectedRound =
+            fpvPopulator().ofDouble(fv1.toDouble() + fv2.toDouble());
+        expect(computed, equals(expectedRound), reason: '''
       $fv1 (${fv1.toDouble()})\t+
       $fv2 (${fv2.toDouble()})\t=
       $computed (${computed.toDouble()})\tcomputed
       $expectedNoRound (${expectedNoRound.toDouble()})\texpected
 ''');
-        }
       }
-    });
+    }
   });
 }

--- a/test/arithmetic/floating_point/floating_point_conversion_test.dart
+++ b/test/arithmetic/floating_point/floating_point_conversion_test.dart
@@ -14,9 +14,12 @@ import 'package:test/test.dart';
 
 void main() {
   test('FP: singleton conversion wide to narrow exponent', () async {
-    final fv1 = FloatingPointValue.ofBinaryStrings('0', '010', '1111');
-    final exponentWidth = fv1.exponent.width;
-    final mantissaWidth = fv1.mantissa.width;
+    const exponentWidth = 3;
+    const mantissaWidth = 4;
+
+    final fv1 = FloatingPointValue.populator(
+            exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
+        .ofBinaryStrings('0', '010', '1111');
 
     final fp1 = FloatingPoint(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
@@ -52,9 +55,12 @@ void main() {
   });
 
   test('FP: singleton conversion narrow to wide exponent', () {
-    final fv1 = FloatingPointValue.ofBinaryStrings('0', '010', '1111');
-    final exponentWidth = fv1.exponent.width;
-    final mantissaWidth = fv1.mantissa.width;
+    const exponentWidth = 3;
+    const mantissaWidth = 4;
+
+    final fv1 = FloatingPointValue.populator(
+            exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
+        .ofBinaryStrings('0', '010', '1111');
     final fp1 = FloatingPoint(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
 
@@ -336,7 +342,11 @@ void main() {
       const delta = -1;
 
       FloatingPointValue ofExplicitString(String s) =>
-          FloatingPointValue.ofSpacedBinaryString(s, explicitJBit: true);
+          FloatingPointValue.populator(
+                  exponentWidth: exponentWidth,
+                  mantissaWidth: mantissaWidth,
+                  explicitJBit: true)
+              .ofSpacedBinaryString(s);
 
       final fpj = FloatingPoint(
           exponentWidth: exponentWidth,
@@ -419,8 +429,9 @@ expected:   $expected ${expected.toDouble()}
       const mantissaWidth = 6;
       const delta = -2;
 
-      FloatingPointValue ofString(String s) =>
-          FloatingPointValue.ofSpacedBinaryString(s);
+      FloatingPointValue ofString(String s) => FloatingPointValue.populator(
+              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
+          .ofSpacedBinaryString(s);
 
       final fpj = FloatingPoint(
           exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
@@ -499,7 +510,11 @@ expected:   $fpv
       const delta = -2;
 
       FloatingPointValue ofExplicitString(String s) =>
-          FloatingPointValue.ofSpacedBinaryString(s, explicitJBit: true);
+          FloatingPointValue.populator(
+                  exponentWidth: exponentWidth,
+                  mantissaWidth: mantissaWidth,
+                  explicitJBit: true)
+              .ofSpacedBinaryString(s);
 
       final fpj = FloatingPoint(
           exponentWidth: exponentWidth,

--- a/test/arithmetic/floating_point/floating_point_conversion_test.dart
+++ b/test/arithmetic/floating_point/floating_point_conversion_test.dart
@@ -17,6 +17,7 @@ void main() {
     final fv1 = FloatingPointValue.ofBinaryStrings('0', '010', '1111');
     final exponentWidth = fv1.exponent.width;
     final mantissaWidth = fv1.mantissa.width;
+
     final fp1 = FloatingPoint(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
 
@@ -282,7 +283,6 @@ void main() {
       final computed = convert.destination.floatingPointValue;
 
       expect(computed, equals(fp2.floatingPointValue));
-
       expect(computed, equals(expected), reason: '''
                               $fv1 (${fv1.toDouble()})\t=>
                               $computed (${computed.toDouble()})\tcomputed
@@ -308,7 +308,6 @@ void main() {
       final computed = convert.destination.floatingPointValue;
 
       expect(computed, equals(fp2.floatingPointValue));
-
       expect(computed, equals(expected), reason: '''
                               $fv1 (${fv1.toDouble()})\t=>
                               $computed (${computed.toDouble()})\tcomputed

--- a/test/arithmetic/floating_point/floating_point_multiplier_test.dart
+++ b/test/arithmetic/floating_point/floating_point_multiplier_test.dart
@@ -74,8 +74,9 @@ void main() {
           exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
       fp1.put(fv);
       fp2.put(fv);
-      FloatingPointValue ofString(String s) =>
-          FloatingPointValue.ofSpacedBinaryString(s);
+      FloatingPointValue ofString(String s) => FloatingPointValue.populator(
+              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
+          .ofSpacedBinaryString(s);
       final testCases = [
         (ofString('0 0001 0000'), ofString('0 0000 0000')),
         (ofString('0 0111 0010'), ofString('0 1110 1111')),
@@ -262,11 +263,15 @@ void main() {
       const mantissaWidth = 4;
       final fp1 = FloatingPoint(
           exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-      final fv1 = FloatingPointValue.ofBinaryStrings('1', '1100', '0111');
+      final fv1 = FloatingPointValue.populator(
+              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
+          .ofBinaryStrings('1', '1100', '0111');
 
       final fp2 = FloatingPoint(
           exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-      final fv2 = FloatingPointValue.ofBinaryStrings('1', '1100', '0000');
+      final fv2 = FloatingPointValue.populator(
+              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
+          .ofBinaryStrings('1', '1100', '0000');
 
       final doubleProduct = fv1.toDouble() * fv2.toDouble();
       final expected = FloatingPointValue.populator(
@@ -293,11 +298,15 @@ void main() {
       const mantissaWidth = 4;
       final fp1 = FloatingPoint(
           exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-      final fv1 = FloatingPointValue.ofBinaryStrings('1', '1000', '0011');
+      final fv1 = FloatingPointValue.populator(
+              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
+          .ofBinaryStrings('1', '1000', '0011');
 
       final fp2 = FloatingPoint(
           exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-      final fv2 = FloatingPointValue.ofBinaryStrings('1', '0001', '0001');
+      final fv2 = FloatingPointValue.populator(
+              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
+          .ofBinaryStrings('1', '0001', '0001');
 
       final doubleProduct = fv1.toDouble() * fv2.toDouble();
 
@@ -330,13 +339,15 @@ void main() {
       const mantissaWidth = 7;
       final fp1 = FloatingPoint(
           exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-      final fv1 =
-          FloatingPointValue.ofBinaryStrings('0', '00000110', '1010000');
+      final fv1 = FloatingPointValue.populator(
+              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
+          .ofBinaryStrings('0', '00000110', '1010000');
 
       final fp2 = FloatingPoint(
           exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-      final fv2 =
-          FloatingPointValue.ofBinaryStrings('1', '01100010', '1110000');
+      final fv2 = FloatingPointValue.populator(
+              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
+          .ofBinaryStrings('1', '01100010', '1110000');
 
       final doubleProduct = fv1.toDouble() * fv2.toDouble();
 
@@ -487,11 +498,15 @@ void main() {
       const mantissaWidth = 4;
       final fp1 = FloatingPoint(
           exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-      final fv1 = FloatingPointValue.ofBinaryStrings('0', '0111', '0000');
+      final fv1 = FloatingPointValue.populator(
+              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
+          .ofBinaryStrings('0', '0111', '0000');
 
       final fp2 = FloatingPoint(
           exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-      final fv2 = FloatingPointValue.ofBinaryStrings('0', '1101', '0101');
+      final fv2 = FloatingPointValue.populator(
+              exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
+          .ofBinaryStrings('0', '1101', '0101');
 
       final expected = FloatingPointValue.populator(
               exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
@@ -554,11 +569,15 @@ void main() {
     const mantissaWidth = 4;
     final fp1 = FloatingPoint(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    final fv1 = FloatingPointValue.ofBinaryStrings('0', '0111', '0000');
+    final fv1 = FloatingPointValue.populator(
+            exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
+        .ofBinaryStrings('0', '0111', '0000');
 
     final fp2 = FloatingPoint(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
-    final fv2 = FloatingPointValue.ofBinaryStrings('0', '1101', '0101');
+    final fv2 = FloatingPointValue.populator(
+            exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
+        .ofBinaryStrings('0', '1101', '0101');
 
     final expected = FloatingPointValue.populator(
             exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)

--- a/test/arithmetic/values/floating_point_value_test.dart
+++ b/test/arithmetic/values/floating_point_value_test.dart
@@ -25,8 +25,9 @@ void main() {
         final expStr = exponent.bitString;
         for (var i = 0; i < pow(2.0, mantissaWidth).toInt(); i++) {
           final mantStr = mantissa.bitString;
-          final fp =
-              FloatingPointValue.ofBinaryStrings(signStr, expStr, mantStr);
+          final fp = FloatingPointValue.populator(
+                  exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
+              .ofBinaryStrings(signStr, expStr, mantStr);
           final dbl = fp.toDouble();
           final fp2 = FloatingPointValue.populator(
                   exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
@@ -46,7 +47,9 @@ void main() {
       final mantissa = LogicValue.one.zeroExtend(mantissaWidth);
       for (var i = 0; i < mantissaWidth; i++) {
         final mantStr = (mantissa << i).bitString;
-        final fp = FloatingPointValue.ofBinaryStrings(signStr, expStr, mantStr);
+        final fp = FloatingPointValue.populator(
+                exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
+            .ofBinaryStrings(signStr, expStr, mantStr);
         expect(fp.toString(), '$signStr $expStr $mantStr');
         final fp2 = FloatingPointValue.populator(
                 exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
@@ -66,8 +69,9 @@ void main() {
         final mantissa = LogicValue.one.zeroExtend(mantissaWidth);
         for (var i = 0; i < mantissaWidth; i++) {
           final mantStr = (mantissa << i).bitString;
-          final fp =
-              FloatingPointValue.ofBinaryStrings(signStr, expStr, mantStr);
+          final fp = FloatingPointValue.populator(
+                  exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
+              .ofBinaryStrings(signStr, expStr, mantStr);
           expect(fp.toString(), '$signStr $expStr $mantStr');
           final fp2 = FloatingPointValue.populator(
                   exponentWidth: exponentWidth, mantissaWidth: mantissaWidth)
@@ -235,7 +239,9 @@ void main() {
     final fp64 = FloatingPoint64Value.populator().ofBinaryStrings('0',
         '10000000000', '0000100000000000000000000000000000000000000000000001');
 
-    final fpRound = FloatingPointValue.ofBinaryStrings('0', '1000', '0001');
+    final fpRound =
+        FloatingPointValue.populator(exponentWidth: 4, mantissaWidth: 4)
+            .ofBinaryStrings('0', '1000', '0001');
     final val = fp64.toDouble();
     final fpConvert =
         FloatingPointValue.populator(exponentWidth: 4, mantissaWidth: 4)
@@ -247,7 +253,9 @@ void main() {
     final fp64 = FloatingPoint64Value.populator().ofBinaryStrings('0',
         '10000000000', '0000110000000000000000000000000000000000000000000000');
 
-    final fpRound = FloatingPointValue.ofBinaryStrings('0', '1000', '0001');
+    final fpRound =
+        FloatingPointValue.populator(exponentWidth: 4, mantissaWidth: 4)
+            .ofBinaryStrings('0', '1000', '0001');
     final val = fp64.toDouble();
 
     final fpConvert =
@@ -260,7 +268,9 @@ void main() {
     final fp64 = FloatingPoint64Value.populator().ofBinaryStrings('0',
         '10000000000', '0001100000000000000000000000000000000000000000000000');
 
-    final fpRound = FloatingPointValue.ofBinaryStrings('0', '1000', '0010');
+    final fpRound =
+        FloatingPointValue.populator(exponentWidth: 4, mantissaWidth: 4)
+            .ofBinaryStrings('0', '1000', '0010');
     final val = fp64.toDouble();
     final fpConvert =
         FloatingPointValue.populator(exponentWidth: 4, mantissaWidth: 4)
@@ -272,7 +282,9 @@ void main() {
     final fp64 = FloatingPoint64Value.populator().ofBinaryStrings('0',
         '10000000000', '1111100000000000000000000000000000000000000000000000');
 
-    final fpRound = FloatingPointValue.ofBinaryStrings('0', '1001', '0000');
+    final fpRound =
+        FloatingPointValue.populator(exponentWidth: 4, mantissaWidth: 4)
+            .ofBinaryStrings('0', '1001', '0000');
     final val = fp64.toDouble();
     final fpConvert =
         FloatingPointValue.populator(exponentWidth: 4, mantissaWidth: 4)
@@ -284,7 +296,9 @@ void main() {
     final fp64 = FloatingPoint64Value.populator().ofBinaryStrings('0',
         '10000000000', '0010100000000000000000000000000000000000000000000000');
 
-    final fpTrunc = FloatingPointValue.ofBinaryStrings('0', '1000', '0010');
+    final fpTrunc =
+        FloatingPointValue.populator(exponentWidth: 4, mantissaWidth: 4)
+            .ofBinaryStrings('0', '1000', '0010');
     final val = fp64.toDouble();
     final fpConvert =
         FloatingPointValue.populator(exponentWidth: 4, mantissaWidth: 4)
@@ -359,17 +373,30 @@ void main() {
     expect(fp, equals(fp2));
   });
   test('FPV Value comparison', () {
-    final fp = FloatingPointValue.ofSpacedBinaryString('1 0101 0101');
-    expect(fp.compareTo(FloatingPointValue.ofSpacedBinaryString('1 0101 0101')),
+    final fp = FloatingPointValue.populator(exponentWidth: 4, mantissaWidth: 4)
+        .ofSpacedBinaryString('1 0101 0101');
+    expect(
+        fp.compareTo(
+            FloatingPointValue.populator(exponentWidth: 4, mantissaWidth: 4)
+                .ofSpacedBinaryString('1 0101 0101')),
         0);
-    expect(fp.compareTo(FloatingPointValue.ofSpacedBinaryString('1 0100 0101')),
+    expect(
+        fp.compareTo(
+            FloatingPointValue.populator(exponentWidth: 4, mantissaWidth: 4)
+                .ofSpacedBinaryString('1 0100 0101')),
         lessThan(0));
-    expect(fp.compareTo(FloatingPointValue.ofSpacedBinaryString('1 0101 0100')),
+    expect(
+        fp.compareTo(
+            FloatingPointValue.populator(exponentWidth: 4, mantissaWidth: 4)
+                .ofSpacedBinaryString('1 0101 0100')),
         lessThan(0));
 
-    final fp2 = FloatingPointValue.ofSpacedBinaryString('1 0000 0000');
+    final fp2 = FloatingPointValue.populator(exponentWidth: 4, mantissaWidth: 4)
+        .ofSpacedBinaryString('1 0000 0000');
     expect(
-        fp2.compareTo(FloatingPointValue.ofSpacedBinaryString('0 0000 0000')),
+        fp2.compareTo(
+            FloatingPointValue.populator(exponentWidth: 4, mantissaWidth: 4)
+                .ofSpacedBinaryString('0 0000 0000')),
         equals(0));
   });
   test('FPV: infinity/NaN conversion tests', () async {
@@ -546,9 +573,11 @@ void main() {
           for (var m = 0; m < pow(2.0, mantissaWidth).toInt(); m++) {
             final mantStr = mantissa.bitString;
 
-            final efp = FloatingPointValue.ofBinaryStrings(
-                signStr, expStr, mantStr,
-                explicitJBit: true);
+            final efp = FloatingPointValue.populator(
+                    exponentWidth: exponentWidth,
+                    mantissaWidth: mantissaWidth,
+                    explicitJBit: true)
+                .ofBinaryStrings(signStr, expStr, mantStr);
             if (efp.isLegalValue()) {
               final dbl = efp.toDouble();
               final efp2 = explicitPopulator().ofDouble(dbl,

--- a/test/arithmetic/values/floating_point_value_test.dart
+++ b/test/arithmetic/values/floating_point_value_test.dart
@@ -15,6 +15,40 @@ import 'package:rohd_hcl/rohd_hcl.dart';
 import 'package:test/test.dart';
 
 void main() {
+  group('FPV: subNormalAsZero', () {
+    const exponentWidth = 4;
+    const mantissaWidth = 4;
+    final expLimit = pow(2.0, exponentWidth).toInt();
+    final mantLimit = pow(2.0, mantissaWidth).toInt();
+    FloatingPointValuePopulator fpvPopulator(
+            {int exponentWidth = exponentWidth,
+            int mantissaWidth = mantissaWidth,
+            bool subNormalAsZero = false}) =>
+        FloatingPointValue.populator(
+            exponentWidth: exponentWidth,
+            mantissaWidth: mantissaWidth,
+            subNormalAsZero: subNormalAsZero);
+
+    test('FPV: subNormalAsZero exhaustive', () {
+      for (final negate in [0, 1]) {
+        for (var e1 = 0; e1 < expLimit; e1++) {
+          for (var m1 = 0; m1 < mantLimit; m1++) {
+            final fpv = fpvPopulator().ofInts(e1, m1, sign: negate == 1);
+            final fpvSaZ = fpvPopulator(subNormalAsZero: true)
+                .ofInts(e1, m1, sign: negate == 1);
+            expect(fpv.toString(), equals(fpvSaZ.toString()));
+            if (fpv.isSubnormal()) {
+              expect(fpvSaZ.toDouble(), equals(0.0));
+              expect(fpvSaZ.isAZero, true);
+            } else if (!fpv.isNaN) {
+              expect(fpvSaZ.toDouble(), equals(fpv.toDouble()));
+            }
+          }
+        }
+      }
+    });
+  });
+
   test('FPV: exhaustive round-trip', () {
     const exponentWidth = 4;
     const mantissaWidth = 4;


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

This PR adds an option to the FloatingPoint / FloatingPointValue classes to treat subnormals as zero.

## Related Issue(s)

<!-- If there are any issues related to this PR, please link to the issues here. -->

## Testing

Exhaustive testing of daz/ftz for inputs and outputs of both dual-path and single-path adders.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No.  subNormalAsZero is an optional boolean.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Documentation will be added later.
