### PR TITLE
Runtime configuration using dynamic

### DIFF
--- a/lib/src/arithmetic/carry_save_mutiplier.dart
+++ b/lib/src/arithmetic/carry_save_mutiplier.dart
@@ -39,8 +39,8 @@ class CarrySaveMultiplier extends Multiplier {
       {required super.clk,
       required super.reset,
       super.enable,
-      super.signedMultiplicandConfig,
-      super.signedMultiplierConfig,
+      super.signedMultiplicandParam,
+      super.signedMultiplierParam,
       super.name = 'carry_save_multiplier'})
       : super(definitionName: 'CarrySaveMultiplier_W${a.width}') {
     if (a.width != b.width) {

--- a/lib/src/arithmetic/carry_save_mutiplier.dart
+++ b/lib/src/arithmetic/carry_save_mutiplier.dart
@@ -39,11 +39,10 @@ class CarrySaveMultiplier extends Multiplier {
       {required super.clk,
       required super.reset,
       super.enable,
+      super.signedMultiplicandConfig,
+      super.signedMultiplierConfig,
       super.name = 'carry_save_multiplier'})
-      : super(
-            signedMultiplicand: false,
-            signedMultiplier: false,
-            definitionName: 'CarrySaveMultiplier_W${a.width}') {
+      : super(definitionName: 'CarrySaveMultiplier_W${a.width}') {
     if (a.width != b.width) {
       throw RohdHclException('inputs of a and b should have same width.');
     }

--- a/lib/src/arithmetic/floating_point/floating_point_adder.dart
+++ b/lib/src/arithmetic/floating_point/floating_point_adder.dart
@@ -52,6 +52,7 @@ abstract class FloatingPointAdder<FpTypeIn extends FloatingPoint,
   late final FpTypeOut internalSum;
 
   /// The rounding mode to use for the adder.
+  @protected
   late final FloatingPointRoundingMode roundingMode;
 
   /// Add two floating point numbers [a] and [b], returning result in [sum].

--- a/lib/src/arithmetic/floating_point/floating_point_adder_dualpath.dart
+++ b/lib/src/arithmetic/floating_point/floating_point_adder_dualpath.dart
@@ -30,6 +30,7 @@ class FloatingPointAdderDualPath<FpTypeIn extends FloatingPoint,
       super.clk,
       super.reset,
       super.enable,
+      super.outSum,
       super.roundingMode = FloatingPointRoundingMode.roundNearestEven,
       Adder Function(Logic a, Logic b, {Logic? carryIn, String name}) adderGen =
           NativeAdder.new,

--- a/lib/src/arithmetic/multiplier.dart
+++ b/lib/src/arithmetic/multiplier.dart
@@ -40,6 +40,18 @@ class Config {
     }
   }
 
+  /// Factory constructor to create a [Config] instance from a dynamic.
+  factory Config.ofDynamic(dynamic config) {
+    if (config is Logic) {
+      return RuntimeConfig(config, name: config.name);
+    } else if (config is bool) {
+      return BooleanConfig(staticConfig: config);
+    } else {
+      throw RohdHclException(
+          'Unsupported configuration type: ${config.runtimeType}');
+    }
+  }
+
   /// Return a bool representing the value of the configuration.
   @visibleForTesting
   bool get value =>

--- a/lib/src/arithmetic/multiplier.dart
+++ b/lib/src/arithmetic/multiplier.dart
@@ -13,6 +13,69 @@ import 'package:meta/meta.dart';
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
 
+/// A general configuration class for specifying parameters that are
+/// for both static or runtime configurations of a component feature.
+class Config {
+  /// The runtime configuration logic that can be used to configure the
+  /// component at runtime
+  final Logic? runtimeConfig;
+
+  /// The static configuration flag that indicates whether the
+  /// feature is statically configured or not.
+  late final bool staticConfig;
+
+  /// The name of the configuration, especially needed for runtime to add as
+  /// a module input.
+  final String name;
+
+  /// Creates a new [Config] instance.
+  Config({required this.name, this.runtimeConfig, bool? staticConfig = false}) {
+    if (runtimeConfig != null && staticConfig != null) {
+      throw RohdHclException(
+          'Only provide either runtimeConfig or staticConfig, not both.');
+    } else if (staticConfig != null) {
+      this.staticConfig = staticConfig;
+    } else {
+      this.staticConfig = false;
+    }
+  }
+
+  /// Return a bool representing the value of the configuration.
+  @visibleForTesting
+  bool get value =>
+      staticConfig ||
+      (runtimeConfig != null && runtimeConfig!.value == LogicValue.one);
+
+  /// Return the internal [Logic] signal that represents the configuration,
+  /// either static or runtime.
+  Logic logic(Module module) =>
+      staticConfig ? Const(1) : (tryInput(module) ?? Const(0));
+
+  /// Construct and return a [Logic]? that is a true input to the [module]
+  /// if this is a runtime configuration signal.
+  Logic? runtime(Module module) =>
+      (runtimeConfig != null) ? module.addInput(name, runtimeConfig!) : null;
+
+  /// Returns a [Logic]? that represents the module internalruntime input.
+  Logic? tryInput(Module module) =>
+      runtimeConfig != null ? module.tryInput(name) : null;
+}
+
+/// A configuration class for boolean configurations, which can be used to
+/// statically enable or disable features in a component.
+class BooleanConfig extends Config {
+  /// Creates a new [BooleanConfig] instance.
+  BooleanConfig({super.staticConfig}) : super(name: 'boolean_config');
+}
+
+/// A configuration class for runtime configurations, which can be used to
+/// dynamically configure a component at runtime.
+class RuntimeConfig extends Config {
+  /// Creates a new [RuntimeConfig] instance.
+  RuntimeConfig(Logic runtimeConfig, {required super.name})
+      : super(runtimeConfig: runtimeConfig, staticConfig: null);
+}
+
 /// An abstract class for all multiplier implementations.
 abstract class Multiplier extends Module {
   /// The clk for pipelining the multiplication.
@@ -38,23 +101,32 @@ abstract class Multiplier extends Module {
   /// The multiplication result [product].
   Logic get product => output('product');
 
+  /// Configuration for signed multiplicand [a].
+  @protected
+  final Config? signedMultiplicandConfig;
+
+  /// Configuration for signed multiplier [b].
+  @protected
+  final Config? signedMultiplierConfig;
+
   /// The multiplier treats input [a] always as a signed input.
   @protected
-  final bool signedMultiplicand;
+  late bool signedMultiplicand;
 
   /// The multiplier treats input [b] always as a signed input.
   @protected
-  final bool signedMultiplier;
+  late bool signedMultiplier;
 
   /// If not null, use this signal to select between signed and unsigned
   /// multiplicand [a].
   @protected
-  Logic? get selectSignedMultiplicand => tryInput('selectSignedMultiplicand');
+  Logic? get selectSignedMultiplicand =>
+      signedMultiplicandConfig?.tryInput(this);
 
   /// If not null, use this signal to select between signed and unsigned
   /// multiplier [b]
   @protected
-  Logic? get selectSignedMultiplier => tryInput('selectSignedMultiplier');
+  Logic? get selectSignedMultiplier => signedMultiplierConfig?.tryInput(this);
 
   /// Logic that tells us [product] is signed.
   @protected
@@ -83,44 +155,43 @@ abstract class Multiplier extends Module {
       {Logic? clk,
       Logic? reset,
       Logic? enable,
-      this.signedMultiplicand = false,
-      this.signedMultiplier = false,
-      Logic? selectSignedMultiplicand,
-      Logic? selectSignedMultiplier,
+      this.signedMultiplicandConfig,
+      this.signedMultiplierConfig,
+      // this.signedMultiplicand = false,
+      // this.signedMultiplier = false,
+      // Logic? selectSignedMultiplier,
       super.name = 'multiplier',
       String? definitionName})
       : super(
             definitionName:
                 definitionName ?? 'Multiplier_W${a.width}x${b.width}') {
-    if (signedMultiplicand && (selectSignedMultiplicand != null)) {
-      throw RohdHclException('multiplicand sign reconfiguration requires '
-          'signedMultiplicand=false');
-    }
-    if (signedMultiplier && (selectSignedMultiplier != null)) {
-      throw RohdHclException('sign reconfiguration requires signed=false');
-    }
+    // if (signedMultiplicand && (selectSignedMultiplicand != null)) {
+    //   throw RohdHclException('multiplicand sign reconfiguration requires '
+    //       'signedMultiplicand=false');
+    // }
+    // if (signedMultiplier && (selectSignedMultiplier != null)) {
+    //   throw RohdHclException('sign reconfiguration requires signed=false');
+    // }
     this.clk = (clk != null) ? addInput('clk', clk) : null;
     this.reset = (reset != null) ? addInput('reset', reset) : null;
     this.enable = (enable != null) ? addInput('enable', enable) : null;
     a = addInput('a', a, width: a.width);
     b = addInput('b', b, width: b.width);
 
-    selectSignedMultiplicand = (selectSignedMultiplicand != null)
-        ? addInput('selectSignedMultiplicand', selectSignedMultiplicand)
-        : null;
-    selectSignedMultiplier = (selectSignedMultiplier != null)
-        ? addInput('selectSignedMultiplier', selectSignedMultiplier)
-        : null;
+    signedMultiplicandConfig?.runtime(this);
+    signedMultiplicand = signedMultiplicandConfig?.staticConfig ?? false;
+
+    signedMultiplierConfig?.runtime(this);
+    signedMultiplier = signedMultiplierConfig?.staticConfig ?? false;
 
     addOutput('product', width: a.width + b.width);
     addOutput('isProductSigned') <=
-        (signedMultiplicand | signedMultiplier ? Const(1) : Const(0)) |
-            ((selectSignedMultiplicand != null)
-                ? selectSignedMultiplicand
+        ((signedMultiplicandConfig != null
+                ? signedMultiplicandConfig!.logic(this)
                 : Const(0)) |
-            ((selectSignedMultiplier != null)
-                ? selectSignedMultiplier
-                : Const(0));
+            (signedMultiplierConfig != null
+                ? signedMultiplierConfig!.logic(this)
+                : Const(0)));
   }
 }
 
@@ -132,10 +203,8 @@ class NativeMultiplier extends Multiplier {
       {super.clk,
       super.reset,
       super.enable,
-      super.signedMultiplicand = false,
-      super.signedMultiplier = false,
-      super.selectSignedMultiplicand,
-      super.selectSignedMultiplier,
+      super.signedMultiplicandConfig,
+      super.signedMultiplierConfig,
       super.name = 'native_multiplier'})
       : super(definitionName: 'NativeMultiplier_W${a.width}') {
     if (a.width != b.width) {
@@ -212,10 +281,8 @@ class CompressionTreeMultiplier extends Multiplier {
       {super.clk,
       super.reset,
       super.enable,
-      super.signedMultiplicand = false,
-      super.signedMultiplier = false,
-      super.selectSignedMultiplicand,
-      super.selectSignedMultiplier,
+      super.signedMultiplicandConfig,
+      super.signedMultiplierConfig,
       Adder Function(Logic a, Logic b, {Logic? carryIn}) adderGen =
           NativeAdder.new,
       PartialProductSignExtension Function(PartialProductGeneratorBase pp,
@@ -224,11 +291,11 @@ class CompressionTreeMultiplier extends Multiplier {
       super.name = 'compression_tree_multiplier'})
       : super(
             definitionName: 'CompressionTreeMultiplier_W${a.width}x'
-                '${b.width}_'
-                '${signedMultiplicand ? 'SD_' : ''}'
-                '${signedMultiplier ? 'SM_' : ''}'
-                '${selectSignedMultiplicand != null ? 'SSD_' : ''}'
-                '${selectSignedMultiplier != null ? 'SSM_' : ''}'
+                // '${b.width}_'
+                // '${signedMultiplicand ? 'SD_' : ''}'
+                // '${signedMultiplier ? 'SM_' : ''}'
+                // '${selectSignedMultiplicand != null ? 'SSD_' : ''}'
+                // '${selectSignedMultiplier != null ? 'SSM_' : ''}'
                 'with${adderGen(a, a).definitionName}') {
     final pp = PartialProduct(a, b, RadixEncoder(radix),
         selectSignedMultiplicand: selectSignedMultiplicand,

--- a/lib/src/arithmetic/multiply_accumulate.dart
+++ b/lib/src/arithmetic/multiply_accumulate.dart
@@ -258,59 +258,59 @@ class CompressionTreeMultiplyAccumulate extends MultiplyAccumulate {
 
 /// A subclass of [MultiplyAccumulate] which ignores the third ([c]) accumulate
 /// term and applies the multiplier function.
-@visibleForTesting
-class MultiplyOnly extends MultiplyAccumulate {
-  // static String _genName(
-  //         Multiplier Function(Logic a, Logic b,
-  //                 {Config? selectSignedMultiplicandConfig,
-  //                 Config? selectSignedMultiplierConfig})
-  //             fn,
-  //         Logic a,
-  //         Logic b,
-  //         Config? selectSignedMultiplicandConfig,
-  //         Config? selectSignedMultiplierConfig) =>
-  //     fn(a, b,
-  //             selectSignedMultiplicandConfig: selectSignedMultiplicandConfig,
-  //             selectSignedMultiplierConfig: selectSignedMultiplierConfig)
-  //         .name;
+// @visibleForTesting
+// class MultiplyOnly extends MultiplyAccumulate {
+//   // static String _genName(
+//   //         Multiplier Function(Logic a, Logic b,
+//   //                 {Config? selectSignedMultiplicandConfig,
+//   //                 Config? selectSignedMultiplierConfig})
+//   //             fn,
+//   //         Logic a,
+//   //         Logic b,
+//   //         Config? selectSignedMultiplicandConfig,
+//   //         Config? selectSignedMultiplierConfig) =>
+//   //     fn(a, b,
+//   //             selectSignedMultiplicandConfig: selectSignedMultiplicandConfig,
+//   //             selectSignedMultiplierConfig: selectSignedMultiplierConfig)
+//   //         .name;
 
-  /// Construct a MultiplyAccumulate that only multiplies to enable
-  /// using the same tester with zero accumulate addend [c].
-  MultiplyOnly(
-    super.a,
-    super.b,
-    super.c,
-    Multiplier Function(Logic a, Logic b,
-            {Logic? selectSignedMultiplicand, Logic? selectSignedMultiplier})
-        mulGen, {
-    super.signedMultiplicandConfig,
-    super.signedMultiplierConfig,
-    super.signedAddendConfig,
-  }) // Will be overrwridden by multiplyGenerator
-  : super(
-            // ignore: prefer_interpolation_to_compose_strings
-            name: 'Multiply Only: '
-            // +
-            //     _genName(mulGen, a, b, selectSignedMultiplicandConfig,
-            //         selectSignedMultiplier)
-            ) {
-    final multiply = mulGen(a, b,
-        selectSignedMultiplicand: selectSignedMultiplicand,
-        selectSignedMultiplier: selectSignedMultiplier);
+//   /// Construct a MultiplyAccumulate that only multiplies to enable
+//   /// using the same tester with zero accumulate addend [c].
+//   MultiplyOnly(
+//     super.a,
+//     super.b,
+//     super.c,
+//     Multiplier Function(Logic a, Logic b,
+//             {Logic? selectSignedMultiplicand, Logic? selectSignedMultiplier})
+//         mulGen, {
+//     super.signedMultiplicandConfig,
+//     super.signedMultiplierConfig,
+//     super.signedAddendConfig,
+//   }) // Will be overrwridden by multiplyGenerator
+//   : super(
+//             // ignore: prefer_interpolation_to_compose_strings
+//             name: 'Multiply Only: '
+//             // +
+//             //     _genName(mulGen, a, b, selectSignedMultiplicandConfig,
+//             //         selectSignedMultiplier)
+//             ) {
+//     final multiply = mulGen(a, b,
+//         selectSignedMultiplicand: selectSignedMultiplicand,
+//         selectSignedMultiplier: selectSignedMultiplier);
 
-    accumulate <=
-        mux(
-            // ignore: invalid_use_of_protected_member
-            multiply.isProductSigned,
-            multiply.product.signExtend(accumulate.width),
-            multiply.product.zeroExtend(accumulate.width));
-  }
-}
+//     accumulate <=
+//         mux(
+//             // ignore: invalid_use_of_protected_member
+//             multiply.isProductSigned,
+//             multiply.product.signExtend(accumulate.width),
+//             multiply.product.zeroExtend(accumulate.width));
+//   }
+// }
 
 /// A subclass of [MultiplyAccumulate] which ignores the third ([c]) accumulate
 /// term and applies the multiplier function.
 @visibleForTesting
-class MultiplyOnly2 extends MultiplyAccumulate {
+class MultiplyOnly extends MultiplyAccumulate {
   // static String _genName(
   //         Multiplier Function(Logic a, Logic b,
   //                 {Logic? selectSignedMultiplicand,
@@ -327,7 +327,7 @@ class MultiplyOnly2 extends MultiplyAccumulate {
 
   /// Construct a MultiplyAccumulate that only multiplies to enable
   /// using the same tester with zero accumulate addend [c].
-  MultiplyOnly2(
+  MultiplyOnly(
     super.a,
     super.b,
     super.c,

--- a/lib/src/arithmetic/multiply_accumulate.dart
+++ b/lib/src/arithmetic/multiply_accumulate.dart
@@ -45,32 +45,45 @@ abstract class MultiplyAccumulate extends Module {
   /// The multiplication and addition or [accumulate] result.
   Logic get accumulate => output('accumulate');
 
+  /// Configuration for signed multiplicand [a].
+  @protected
+  final Config? signedMultiplicandConfig;
+
+  /// Configuration for signed multiplier [b].
+  @protected
+  final Config? signedMultiplierConfig;
+
+  /// Configuration for signed addend [c].
+  @protected
+  final Config? signedAddendConfig;
+
   /// The MAC treats multiplicand [a] as always signed.
   @protected
-  final bool signedMultiplicand;
+  late bool signedMultiplicand;
 
   /// The MAC treats multiplier [b] as always signed.
   @protected
-  final bool signedMultiplier;
+  late bool signedMultiplier;
 
   /// The MAC treats addend [c] as always signed.
   @protected
-  final bool signedAddend;
+  late bool signedAddend;
 
   /// If not null, use this signal to select between signed and unsigned
   /// multiplicand [a].
   @protected
-  Logic? get selectSignedMultiplicand => tryInput('selectSignedMultiplicand');
+  Logic? get selectSignedMultiplicand =>
+      signedMultiplicandConfig?.tryInput(this);
 
   /// If not null, use this signal to select between signed and unsigned
   /// multiplier [b]
   @protected
-  Logic? get selectSignedMultiplier => tryInput('selectSignedMultiplier');
+  Logic? get selectSignedMultiplier => signedMultiplierConfig?.tryInput(this);
 
   /// If not null, use this signal to select between signed and unsigned
-  /// addend [c]
+  /// multiplier [b]
   @protected
-  Logic? get selectSignedAddend => tryInput('selectSignedAddend');
+  Logic? get selectSignedAddend => signedAddendConfig?.tryInput(this);
 
   /// Logic that tells us [accumulate] is signed.
   @protected
@@ -94,12 +107,15 @@ abstract class MultiplyAccumulate extends Module {
       {Logic? clk,
       Logic? reset,
       Logic? enable,
-      this.signedMultiplicand = false,
-      this.signedMultiplier = false,
-      this.signedAddend = false,
-      Logic? selectSignedMultiplicand,
-      Logic? selectSignedMultiplier,
-      Logic? selectSignedAddend,
+      this.signedMultiplicandConfig,
+      this.signedMultiplierConfig,
+      this.signedAddendConfig,
+      // this.signedMultiplicand = false,
+      // this.signedMultiplier = false,
+      // this.signedAddend = false,
+      // Logic? selectSignedMultiplicand,
+      // Logic? selectSignedMultiplier,
+      // Logic? selectSignedAddend,
       super.name = 'multiply_accumulate',
       String? definitionName})
       : super(
@@ -112,28 +128,37 @@ abstract class MultiplyAccumulate extends Module {
     a = addInput('a', a, width: a.width);
     b = addInput('b', b, width: b.width);
     c = addInput('c', c, width: c.width);
-    selectSignedMultiplicand = (selectSignedMultiplicand != null)
-        ? addInput('selectSignedMultiplicand', selectSignedMultiplicand)
-        : null;
-    selectSignedMultiplier = (selectSignedMultiplier != null)
-        ? addInput('selectSignedMultiplier', selectSignedMultiplier)
-        : null;
-    selectSignedAddend = (selectSignedAddend != null)
-        ? addInput('selectSignedAddend', selectSignedAddend)
-        : null;
+
+    signedMultiplicandConfig?.runtime(this);
+    signedMultiplicand = signedMultiplicandConfig?.staticConfig ?? false;
+
+    signedMultiplierConfig?.runtime(this);
+    signedMultiplier = signedMultiplierConfig?.staticConfig ?? false;
+
+    signedAddendConfig?.runtime(this);
+    signedAddend = signedAddendConfig?.staticConfig ?? false;
+
+    // selectSignedMultiplicand = (selectSignedMultiplicand != null)
+    //     ? addInput('selectSignedMultiplicand', selectSignedMultiplicand)
+    //     : null;
+    // selectSignedMultiplier = (selectSignedMultiplier != null)
+    //     ? addInput('selectSignedMultiplier', selectSignedMultiplier)
+    //     : null;
+    // selectSignedAddend = (selectSignedAddend != null)
+    //     ? addInput('selectSignedAddend', selectSignedAddend)
+    //     : null;
     addOutput('accumulate', width: a.width + b.width + 1);
 
     addOutput('isAccumulateSigned') <=
-        (signedMultiplicand | signedMultiplier | signedAddend
-                ? Const(1)
+        ((signedMultiplicandConfig != null
+                ? signedMultiplicandConfig!.logic(this)
                 : Const(0)) |
-            ((selectSignedMultiplicand != null)
-                ? selectSignedMultiplicand
+            (signedMultiplierConfig != null
+                ? signedMultiplierConfig!.logic(this)
                 : Const(0)) |
-            ((selectSignedMultiplier != null)
-                ? selectSignedMultiplier
-                : Const(0)) |
-            ((selectSignedAddend != null) ? selectSignedAddend : Const(0));
+            (signedAddendConfig != null
+                ? signedAddendConfig!.logic(this)
+                : Const(0)));
   }
 }
 
@@ -177,12 +202,9 @@ class CompressionTreeMultiplyAccumulate extends MultiplyAccumulate {
       {Logic? clk,
       Logic? reset,
       Logic? enable,
-      super.signedMultiplicand = false,
-      super.signedMultiplier = false,
-      super.signedAddend = false,
-      super.selectSignedMultiplicand,
-      super.selectSignedMultiplier,
-      super.selectSignedAddend,
+      super.signedMultiplicandConfig,
+      super.signedMultiplierConfig,
+      super.signedAddendConfig,
       Adder Function(Logic a, Logic b, {Logic? carryIn}) adderGen =
           NativeAdder.new,
       PartialProductSignExtension Function(PartialProductGeneratorBase pp,
@@ -238,19 +260,19 @@ class CompressionTreeMultiplyAccumulate extends MultiplyAccumulate {
 /// term and applies the multiplier function.
 @visibleForTesting
 class MultiplyOnly extends MultiplyAccumulate {
-  static String _genName(
-          Multiplier Function(Logic a, Logic b,
-                  {Logic? selectSignedMultiplicand,
-                  Logic? selectSignedMultiplier})
-              fn,
-          Logic a,
-          Logic b,
-          Logic? selectSignedMultiplicand,
-          Logic? selectSignedMultiplier) =>
-      fn(a, b,
-              selectSignedMultiplicand: selectSignedMultiplicand,
-              selectSignedMultiplier: selectSignedMultiplier)
-          .name;
+  // static String _genName(
+  //         Multiplier Function(Logic a, Logic b,
+  //                 {Config? selectSignedMultiplicandConfig,
+  //                 Config? selectSignedMultiplierConfig})
+  //             fn,
+  //         Logic a,
+  //         Logic b,
+  //         Config? selectSignedMultiplicandConfig,
+  //         Config? selectSignedMultiplierConfig) =>
+  //     fn(a, b,
+  //             selectSignedMultiplicandConfig: selectSignedMultiplicandConfig,
+  //             selectSignedMultiplierConfig: selectSignedMultiplierConfig)
+  //         .name;
 
   /// Construct a MultiplyAccumulate that only multiplies to enable
   /// using the same tester with zero accumulate addend [c].
@@ -261,21 +283,87 @@ class MultiplyOnly extends MultiplyAccumulate {
     Multiplier Function(Logic a, Logic b,
             {Logic? selectSignedMultiplicand, Logic? selectSignedMultiplier})
         mulGen, {
-    super.signedMultiplicand = false,
-    super.signedMultiplier = false,
-    super.signedAddend = false,
-    super.selectSignedMultiplicand,
-    super.selectSignedMultiplier,
-    super.selectSignedAddend,
+    super.signedMultiplicandConfig,
+    super.signedMultiplierConfig,
+    super.signedAddendConfig,
   }) // Will be overrwridden by multiplyGenerator
   : super(
             // ignore: prefer_interpolation_to_compose_strings
-            name: 'Multiply Only: ' +
-                _genName(mulGen, a, b, selectSignedMultiplicand,
-                    selectSignedMultiplier)) {
+            name: 'Multiply Only: '
+            // +
+            //     _genName(mulGen, a, b, selectSignedMultiplicandConfig,
+            //         selectSignedMultiplier)
+            ) {
     final multiply = mulGen(a, b,
         selectSignedMultiplicand: selectSignedMultiplicand,
         selectSignedMultiplier: selectSignedMultiplier);
+
+    accumulate <=
+        mux(
+            // ignore: invalid_use_of_protected_member
+            multiply.isProductSigned,
+            multiply.product.signExtend(accumulate.width),
+            multiply.product.zeroExtend(accumulate.width));
+  }
+}
+
+/// A subclass of [MultiplyAccumulate] which ignores the third ([c]) accumulate
+/// term and applies the multiplier function.
+@visibleForTesting
+class MultiplyOnly2 extends MultiplyAccumulate {
+  // static String _genName(
+  //         Multiplier Function(Logic a, Logic b,
+  //                 {Logic? selectSignedMultiplicand,
+  //                 Logic? selectSignedMultiplier})
+  //             fn,
+  //         Logic a,
+  //         Logic b,
+  //         Logic? selectSignedMultiplicand,
+  //         Logic? selectSignedMultiplier) =>
+  //     fn(a, b,
+  //             selectSignedMultiplicand: selectSignedMultiplicand,
+  //             selectSignedMultiplier: selectSignedMultiplier)
+  //         .name;
+
+  /// Construct a MultiplyAccumulate that only multiplies to enable
+  /// using the same tester with zero accumulate addend [c].
+  MultiplyOnly2(
+    super.a,
+    super.b,
+    super.c,
+    Multiplier Function(Logic a, Logic b,
+            {Config? signedMultiplicandConfig, Config? signedMultiplierConfig})
+        mulGen, {
+    super.signedMultiplicandConfig,
+    super.signedMultiplierConfig,
+    super.signedAddendConfig,
+  }) // Will be overrwridden by multiplyGenerator
+  : super(
+            // ignore: prefer_interpolation_to_compose_strings
+            name: 'Multiply Only2: '
+            // +
+            //     _genName(mulGen, a, b, selectSignedMultiplicand,
+            //         selectSignedMultiplier)
+            ) {
+    // Here we need to copy the Config and make sure we access our module's
+    // input by calling .logic(this) on the runtimeConfig.
+    final multiply = mulGen(a, b,
+        signedMultiplicandConfig: Config(
+            name: 'selectSignedMultiplicand',
+            runtimeConfig: signedMultiplicandConfig?.runtimeConfig != null
+                ? signedMultiplicandConfig?.logic(this)
+                : null,
+            staticConfig: signedMultiplicandConfig?.runtimeConfig == null
+                ? signedMultiplicandConfig?.staticConfig
+                : null),
+        signedMultiplierConfig: Config(
+            name: 'selectSignedMultiplier',
+            runtimeConfig: signedMultiplierConfig?.runtimeConfig != null
+                ? signedMultiplierConfig?.logic(this)
+                : null,
+            staticConfig: signedMultiplierConfig?.runtimeConfig == null
+                ? signedMultiplierConfig?.staticConfig
+                : null));
 
     accumulate <=
         mux(

--- a/lib/src/arithmetic/multiply_accumulate.dart
+++ b/lib/src/arithmetic/multiply_accumulate.dart
@@ -258,72 +258,21 @@ class CompressionTreeMultiplyAccumulate extends MultiplyAccumulate {
 
 /// A subclass of [MultiplyAccumulate] which ignores the third ([c]) accumulate
 /// term and applies the multiplier function.
-// @visibleForTesting
-// class MultiplyOnly extends MultiplyAccumulate {
-//   // static String _genName(
-//   //         Multiplier Function(Logic a, Logic b,
-//   //                 {Config? selectSignedMultiplicandConfig,
-//   //                 Config? selectSignedMultiplierConfig})
-//   //             fn,
-//   //         Logic a,
-//   //         Logic b,
-//   //         Config? selectSignedMultiplicandConfig,
-//   //         Config? selectSignedMultiplierConfig) =>
-//   //     fn(a, b,
-//   //             selectSignedMultiplicandConfig: selectSignedMultiplicandConfig,
-//   //             selectSignedMultiplierConfig: selectSignedMultiplierConfig)
-//   //         .name;
-
-//   /// Construct a MultiplyAccumulate that only multiplies to enable
-//   /// using the same tester with zero accumulate addend [c].
-//   MultiplyOnly(
-//     super.a,
-//     super.b,
-//     super.c,
-//     Multiplier Function(Logic a, Logic b,
-//             {Logic? selectSignedMultiplicand, Logic? selectSignedMultiplier})
-//         mulGen, {
-//     super.signedMultiplicandConfig,
-//     super.signedMultiplierConfig,
-//     super.signedAddendConfig,
-//   }) // Will be overrwridden by multiplyGenerator
-//   : super(
-//             // ignore: prefer_interpolation_to_compose_strings
-//             name: 'Multiply Only: '
-//             // +
-//             //     _genName(mulGen, a, b, selectSignedMultiplicandConfig,
-//             //         selectSignedMultiplier)
-//             ) {
-//     final multiply = mulGen(a, b,
-//         selectSignedMultiplicand: selectSignedMultiplicand,
-//         selectSignedMultiplier: selectSignedMultiplier);
-
-//     accumulate <=
-//         mux(
-//             // ignore: invalid_use_of_protected_member
-//             multiply.isProductSigned,
-//             multiply.product.signExtend(accumulate.width),
-//             multiply.product.zeroExtend(accumulate.width));
-//   }
-// }
-
-/// A subclass of [MultiplyAccumulate] which ignores the third ([c]) accumulate
-/// term and applies the multiplier function.
 @visibleForTesting
 class MultiplyOnly extends MultiplyAccumulate {
-  // static String _genName(
-  //         Multiplier Function(Logic a, Logic b,
-  //                 {Logic? selectSignedMultiplicand,
-  //                 Logic? selectSignedMultiplier})
-  //             fn,
-  //         Logic a,
-  //         Logic b,
-  //         Logic? selectSignedMultiplicand,
-  //         Logic? selectSignedMultiplier) =>
-  //     fn(a, b,
-  //             selectSignedMultiplicand: selectSignedMultiplicand,
-  //             selectSignedMultiplier: selectSignedMultiplier)
-  //         .name;
+  static String _genName(
+          Multiplier Function(Logic a, Logic b,
+                  {Config? signedMultiplicandConfig,
+                  Config? signedMultiplierConfig})
+              fn,
+          Logic a,
+          Logic b,
+          Config? signedMultiplicandConfig,
+          Config? signedMultiplierConfig) =>
+      fn(a, b,
+              signedMultiplicandConfig: signedMultiplicandConfig,
+              signedMultiplierConfig: signedMultiplierConfig)
+          .name;
 
   /// Construct a MultiplyAccumulate that only multiplies to enable
   /// using the same tester with zero accumulate addend [c].
@@ -340,11 +289,9 @@ class MultiplyOnly extends MultiplyAccumulate {
   }) // Will be overrwridden by multiplyGenerator
   : super(
             // ignore: prefer_interpolation_to_compose_strings
-            name: 'Multiply Only2: '
-            // +
-            //     _genName(mulGen, a, b, selectSignedMultiplicand,
-            //         selectSignedMultiplier)
-            ) {
+            name: 'multiply_only_' +
+                _genName(mulGen, a, b, signedMultiplicandConfig,
+                    signedMultiplierConfig)) {
     // Here we need to copy the Config and make sure we access our module's
     // input by calling .logic(this) on the runtimeConfig.
     final multiply = mulGen(a, b,

--- a/lib/src/arithmetic/multiply_accumulate.dart
+++ b/lib/src/arithmetic/multiply_accumulate.dart
@@ -110,12 +110,6 @@ abstract class MultiplyAccumulate extends Module {
       this.signedMultiplicandConfig,
       this.signedMultiplierConfig,
       this.signedAddendConfig,
-      // this.signedMultiplicand = false,
-      // this.signedMultiplier = false,
-      // this.signedAddend = false,
-      // Logic? selectSignedMultiplicand,
-      // Logic? selectSignedMultiplier,
-      // Logic? selectSignedAddend,
       super.name = 'multiply_accumulate',
       String? definitionName})
       : super(
@@ -137,16 +131,6 @@ abstract class MultiplyAccumulate extends Module {
 
     signedAddendConfig?.runtime(this);
     signedAddend = signedAddendConfig?.staticConfig ?? false;
-
-    // selectSignedMultiplicand = (selectSignedMultiplicand != null)
-    //     ? addInput('selectSignedMultiplicand', selectSignedMultiplicand)
-    //     : null;
-    // selectSignedMultiplier = (selectSignedMultiplier != null)
-    //     ? addInput('selectSignedMultiplier', selectSignedMultiplier)
-    //     : null;
-    // selectSignedAddend = (selectSignedAddend != null)
-    //     ? addInput('selectSignedAddend', selectSignedAddend)
-    //     : null;
     addOutput('accumulate', width: a.width + b.width + 1);
 
     addOutput('isAccumulateSigned') <=


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

This is a change to the integer multiplier API to configure signed vs unsigned operands using a dynamic instead of pairs of bool/Logic? parameters.

## Related Issue(s)

fix #185 

## Testing

Used existing regression tests.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

Yes.  The parameters passed to configure the integer multipliers are now single dynamic inputs rather than a boolean or a Logic?

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Only API documentation has changed.  The markdown still needs updating.
