### PR TITLE
Widen the confapp sidebar to allow for names to be displayed properly

### DIFF
--- a/confapp/lib/hcl/view/screen/sidebar_widget.dart
+++ b/confapp/lib/hcl/view/screen/sidebar_widget.dart
@@ -100,7 +100,7 @@ class _ComponentsSidebarState extends State<ComponentsSidebar> {
             ),
           ),
           extendedTheme: const SidebarXTheme(
-            width: 200,
+            width: 230,
             decoration: BoxDecoration(
               color: canvasColor,
             ),


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

The generator app displays names incorrectly in the sidebar to the point they are unreadable.
This only happens on wider names where some kind of highlighting or font change happens when wrapping.

## Related Issue(s)

Fix #128 

## Testing

Running flutter locally and attaching to web generator app.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No change needed.
