### PR TITLE
AXI4 Subordinate BFM bug fix for tight consecutive write/read

### DIFF
--- a/lib/src/models/axi4_bfm/axi4_main_write_driver.dart
+++ b/lib/src/models/axi4_bfm/axi4_main_write_driver.dart
@@ -128,11 +128,15 @@ class Axi4WriteMainDriver extends PendingClockedDriver<Axi4WriteRequestPacket> {
         await wIntf.wReady.nextPosedge;
       }
       Simulator.injectAction(() {
+        final isLast = i == packet.data.length - 1;
         wIntf.wValid.put(1);
         wIntf.wData.put(packet.data[i]);
         wIntf.wStrb.put(packet.strobe[i]);
-        wIntf.wLast.put(i == packet.data.length - 1 ? 1 : 0);
+        wIntf.wLast.put(isLast ? 1 : 0);
         wIntf.wUser?.put(packet.wUser);
+        if (isLast) {
+          packet.complete();
+        }
       });
       await sIntf.clk.nextPosedge;
     }
@@ -141,7 +145,6 @@ class Axi4WriteMainDriver extends PendingClockedDriver<Axi4WriteRequestPacket> {
     // in the future, we may want to wait for the response to complete
     Simulator.injectAction(() {
       wIntf.wValid.put(0);
-      packet.complete();
     });
   }
 }

--- a/lib/src/models/axi4_bfm/axi4_subordinate.dart
+++ b/lib/src/models/axi4_bfm/axi4_subordinate.dart
@@ -178,16 +178,19 @@ class Axi4SubordinateAgent extends Agent {
     while (!Simulator.simulationHasEnded) {
       await sIntf.clk.nextNegedge;
       for (var i = 0; i < channels.length; i++) {
-        if (channels[i].hasRead) {
-          _driveReadReadys(index: i);
-          _respondRead(index: i);
-          _receiveRead(index: i);
-        }
+        // write handling should come before reads for the edge case in which a
+        // read happens in the cycle after the final WVALID for the same
+        // channel/address
         if (channels[i].hasWrite) {
           _driveWriteReadys(index: i);
           _respondWrite(index: i);
           _captureWriteData(index: i);
           _receiveWrite(index: i);
+        }
+        if (channels[i].hasRead) {
+          _driveReadReadys(index: i);
+          _respondRead(index: i);
+          _receiveRead(index: i);
         }
       }
     }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

If a main sends a write on a particular channel/address and then in the cycle after WLAST for the write data sends a read on the same channel/address, the subordinate would return the old data instead of the new data.

## Related Issue(s)

N/A

## Testing

Added a unit test for this case.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

This change is fully backwards compatible.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No doc updates needed.
