### PR TITLE
update deployment workflow to install SystemVerilog to Verilog conver…

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -124,6 +124,9 @@ jobs:
       - name: Install CAD Suite (includes yosys)
         run: tool/gh_actions/install_opencadsuite.sh
 
+      - name: Install SystemVerilog to Verilog converter
+        run: tool/gh_actions/install_sv2v.sh
+
       - name: Install D3 Schematic viewer
         run: tool/gh_actions/install_d3_hwschematic.sh
 


### PR DESCRIPTION
…ter, fixing offline schematic file deployment

<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Update workflow to fix lack of sv2v in deployment.  The issue this causes was that schematics were not being generated resulting in some dead links in API documentation.

## Related Issue(s)

None.

## Testing

No testing. This will require a full deployment run.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No need.
