### PR TITLE
updated broken html links in markdown

### DIFF
--- a/doc/components/memory.md
+++ b/doc/components/memory.md
@@ -16,7 +16,7 @@ Currently, `RegisterFile` only generates flop-based memory (no latches).
 
 The read path is combinational, so data is provided immediately according to the control signals.
 
-[RegisterFile Schematic](https://intel.github.io/rohd-hcl/RegisterFile_WP1_RP1_E8.html)
+[RegisterFile Schematic](https://intel.github.io/rohd-hcl/RegisterFile_WP1_RP1_E4.html)
 
 ## Memory Models
 

--- a/doc/components/onehot.md
+++ b/doc/components/onehot.md
@@ -8,4 +8,4 @@ The encoders take a Logic bit-vector, with the constraint that only a single bit
 
 The decoders take a Logic input representing the bit position to be set to '1', and returns a Logic bit-vector with that bit position set to '1', and all others set to '0'
 
-[OneHotToBinary Schematic](https://intel.github.io/rohd-hcl/OneHotToBinary_W4.html)
+[OneHotToBinary Schematic](https://intel.github.io/rohd-hcl/OneHotToBinary_W8.html)


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Broken html links because we changed generator parameters.

## Related Issue(s)

None

## Testing

Need to test in deployment

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

This is a doc change.
