### PR TITLE
add definitionName to all components and update configurator/markdown…

### DIFF
--- a/doc/components/arbiter.md
+++ b/doc/components/arbiter.md
@@ -10,7 +10,7 @@ A `StatefulArbiter` is an `Arbiter` which can hold state, and thus requires a `c
 
 The [`PriorityArbiter`](https://intel.github.io/rohd-hcl/rohd_hcl/PriorityArbiter-class.html) is a combinational (stateless) arbiter that always grants to the lowest-indexed request.
 
-[PriorityArbiter Schematic](https://intel.github.io/rohd-hcl/PriorityArbiter_W8.html)
+[PriorityArbiter Schematic](https://intel.github.io/rohd-hcl/PriorityArbiter.html)
 
 ## Round Robin Arbiter
 

--- a/doc/components/fifo.md
+++ b/doc/components/fifo.md
@@ -32,7 +32,7 @@ Occupancy information can optionally be generated and provided if `generateOccup
 
 ## Example Schematic
 
-An example schematic for one configuration is viewable here: [FIFO Schematic](https://intel.github.io/rohd-hcl/Fifo_D4_W8.html)
+An example schematic for one configuration is viewable here: [FIFO Schematic](https://intel.github.io/rohd-hcl/Fifo.html)
 
 ## Testbench Utilities
 

--- a/doc/components/memory.md
+++ b/doc/components/memory.md
@@ -16,7 +16,7 @@ Currently, `RegisterFile` only generates flop-based memory (no latches).
 
 The read path is combinational, so data is provided immediately according to the control signals.
 
-[RegisterFile Schematic](https://intel.github.io/rohd-hcl/RegisterFile_WP1_RP1_E4.html)
+[RegisterFile Schematic](https://intel.github.io/rohd-hcl/RegisterFile.html)
 
 ## Memory Models
 

--- a/doc/components/onehot.md
+++ b/doc/components/onehot.md
@@ -8,4 +8,4 @@ The encoders take a Logic bit-vector, with the constraint that only a single bit
 
 The decoders take a Logic input representing the bit position to be set to '1', and returns a Logic bit-vector with that bit position set to '1', and all others set to '0'
 
-[OneHotToBinary Schematic](https://intel.github.io/rohd-hcl/OneHotToBinary_W8.html)
+[OneHotToBinary Schematic](https://intel.github.io/rohd-hcl/OneHotToBinary.html)

--- a/doc/components/parallel_prefix_operations.md
+++ b/doc/components/parallel_prefix_operations.md
@@ -42,4 +42,4 @@ types:
 - ['Brent-Kung](https://intel.github.io/rohd-hcl/rohd_hcl/BrentKung-class.html)
 
 Here is an example adder schematic:
-[ParallelPrefixAdder Schematic](https://intel.github.io/rohd-hcl/ParallelPrefixAdder_W4.html)
+[ParallelPrefixAdder Schematic](https://intel.github.io/rohd-hcl/ParallelPrefixAdder.html)

--- a/doc/components/rotate.md
+++ b/doc/components/rotate.md
@@ -61,4 +61,4 @@ Also included are `extension`s for `LogicValue` with a similar rotation API for 
 LogicValue.ofInt(0xf000, 16).rotateLeft(8); // results in 0x00f0
 ```
 
-[Rotate Right Schematic](https://intel.github.io/rohd-hcl/Rotate_right_W16.html)
+[Rotate Right Schematic](https://intel.github.io/rohd-hcl/RotateRight.html)

--- a/lib/src/arbiters/mask_round_robin_arbiter.dart
+++ b/lib/src/arbiters/mask_round_robin_arbiter.dart
@@ -34,8 +34,10 @@ class MaskRoundRobinArbiter extends StatefulArbiter
   /// and keeping record of requests already granted, in order to mask it until
   /// granting the turn of each request to start again
   MaskRoundRobinArbiter(super.requests,
-      {required super.clk, required super.reset})
-      : super(definitionName: 'MaskRoundRobinArbiter_W${requests.length}') {
+      {required super.clk, required super.reset, String? definitionName})
+      : super(
+            definitionName:
+                definitionName ?? 'MaskRoundRobinArbiter_W${requests.length}') {
     _requestMask = List.generate(count, (i) => Logic(name: 'requestMask$i'));
     _grantMask = List.generate(count, (i) => Logic(name: 'grantMask$i'));
     Sequential(clk, [

--- a/lib/src/arbiters/priority_arbiter.dart
+++ b/lib/src/arbiters/priority_arbiter.dart
@@ -14,8 +14,11 @@ import 'package:rohd_hcl/rohd_hcl.dart';
 class PriorityArbiter extends Arbiter {
   /// Constructs an arbiter where the grant is given to the lowest-indexed
   /// request.
-  PriorityArbiter(super.requests, {super.name = 'priority_arbiter'})
-      : super(definitionName: 'PriorityArbiter_W${requests.length}') {
+  PriorityArbiter(super.requests,
+      {super.name = 'priority_arbiter', String? definitionName})
+      : super(
+            definitionName:
+                definitionName ?? 'PriorityArbiter_W${requests.length}') {
     Combinational([
       CaseZ(requests.rswizzle(), conditionalType: ConditionalType.priority, [
         for (var i = 0; i < count; i++)

--- a/lib/src/arbiters/rotate_round_robin_arbiter.dart
+++ b/lib/src/arbiters/rotate_round_robin_arbiter.dart
@@ -15,8 +15,10 @@ class RotateRoundRobinArbiter extends StatefulArbiter
     implements RoundRobinArbiter {
   /// Creates an [Arbiter] that fairly takes turns between [requests].
   RotateRoundRobinArbiter(super.requests,
-      {required super.clk, required super.reset})
-      : super(definitionName: 'RotateRoundRobinArbiter_W${requests.length}') {
+      {required super.clk, required super.reset, String? definitionName})
+      : super(
+            definitionName: definitionName ??
+                'RotateRoundRobinArbiter_W${requests.length}') {
     final preference = Logic(name: 'preference', width: log2Ceil(count));
 
     final rotatedReqs = requests

--- a/lib/src/arbiters/round_robin_arbiter.dart
+++ b/lib/src/arbiters/round_robin_arbiter.dart
@@ -14,6 +14,7 @@ import 'package:rohd_hcl/rohd_hcl.dart';
 abstract class RoundRobinArbiter extends StatefulArbiter {
   /// By default, creates an instance of a [MaskRoundRobinArbiter].
   factory RoundRobinArbiter(List<Logic> requests,
-          {required Logic clk, required Logic reset}) =>
-      MaskRoundRobinArbiter(requests, clk: clk, reset: reset);
+          {required Logic clk, required Logic reset, String? definitionName}) =>
+      MaskRoundRobinArbiter(requests,
+          clk: clk, reset: reset, definitionName: definitionName);
 }

--- a/lib/src/arithmetic/carry_save_mutiplier.dart
+++ b/lib/src/arithmetic/carry_save_mutiplier.dart
@@ -41,8 +41,11 @@ class CarrySaveMultiplier extends Multiplier {
       super.enable,
       super.signedMultiplicand,
       super.signedMultiplier,
-      super.name = 'carry_save_multiplier'})
-      : super(definitionName: 'CarrySaveMultiplier_W${a.width}') {
+      super.name = 'carry_save_multiplier',
+      String? definitionName})
+      : super(
+            definitionName:
+                definitionName ?? 'CarrySaveMultiplier_W${a.width}') {
     if (a.width != b.width) {
       throw RohdHclException('inputs of a and b should have same width.');
     }

--- a/lib/src/arithmetic/compound_adder.dart
+++ b/lib/src/arithmetic/compound_adder.dart
@@ -237,9 +237,10 @@ class CarrySelectOnesComplementCompoundAdder extends CompoundAdder {
       bool subtract = false,
       List<int> Function(int) widthGen =
           CarrySelectCompoundAdder.splitSelectAdderAlgorithmSingleBlock,
-      super.name})
+      super.name,
+      String? definitionName})
       : super(
-            definitionName:
+            definitionName: definitionName ??
                 'CarrySelectOnesComplementCompoundAdder_W${a.width}') {
     subtractIn = (subtractIn != null)
         ? addInput('subtractIn', subtractIn, width: subtractIn.width)

--- a/lib/src/arithmetic/divider.dart
+++ b/lib/src/arithmetic/divider.dart
@@ -125,12 +125,14 @@ class MultiCycleDivider extends Module {
   late final int logDataWidth;
 
   /// The Divider module's constructor
-  MultiCycleDivider(MultiCycleDividerInterface interface)
+  MultiCycleDivider(MultiCycleDividerInterface interface,
+      {String? definitionName})
       : dataWidth = interface.dataWidth,
         logDataWidth = log2Ceil(interface.dataWidth),
         super(
             name: 'divider',
-            definitionName: 'MultiCycleDivider_W${interface.dataWidth}') {
+            definitionName:
+                definitionName ?? 'MultiCycleDivider_W${interface.dataWidth}') {
     intf = MultiCycleDividerInterface.match(interface)
       ..pairConnectIO(
         this,
@@ -152,6 +154,7 @@ class MultiCycleDivider extends Module {
     required Logic divisor,
     required Logic isSigned,
     required Logic readyOut,
+    String? definitionName,
   }) {
     assert(dividend.width == divisor.width,
         'Widths of all data signals do not match!');
@@ -164,7 +167,9 @@ class MultiCycleDivider extends Module {
     intf.divisor <= divisor;
     intf.isSigned <= isSigned;
     intf.readyOut <= readyOut;
-    return MultiCycleDivider(intf);
+    return MultiCycleDivider(intf,
+        definitionName:
+            definitionName ?? 'MultiCycleDivider_W${intf.dataWidth}');
   }
 
   void _build() {

--- a/lib/src/arithmetic/fixed_to_float.dart
+++ b/lib/src/arithmetic/fixed_to_float.dart
@@ -39,11 +39,12 @@ class FixedToFloat extends Module {
   FixedToFloat(FixedPoint fixed, this.outFloat,
       {bool signed = true,
       Logic? leadingDigitPredict,
-      super.name = 'FixedToFloat'})
+      super.name = 'FixedToFloat',
+      String? definitionName})
       : super(
-            definitionName:
+            definitionName: definitionName ??
                 'Fixed${fixed.width}ToFloatE${outFloat.exponent.width}'
-                'M$outFloat.mantissa.width') {
+                    'M$outFloat.mantissa.width') {
     fixed = fixed.clone()..gets(addInput('fixed', fixed, width: fixed.width));
     final exponentWidth = outFloat.exponent.width;
     final mantissaWidth = outFloat.mantissa.width;

--- a/lib/src/arithmetic/float_to_fixed.dart
+++ b/lib/src/arithmetic/float_to_fixed.dart
@@ -53,10 +53,12 @@ class FloatToFixed extends Module {
       {super.name = 'FloatToFixed',
       int? integerWidth,
       int? fractionWidth,
-      this.checkOverflow = false})
+      this.checkOverflow = false,
+      String? definitionName})
       : super(
-            definitionName: 'FloatE${float.exponent.width}'
-                'M${float.mantissa.width}ToFixed') {
+            definitionName: definitionName ??
+                'FloatE${float.exponent.width}'
+                    'M${float.mantissa.width}ToFixed') {
     float = float.clone()..gets(addInput('float', float, width: float.width));
 
     final bias = float.floatingPointValue.bias;

--- a/lib/src/arithmetic/floating_point/floating_point_adder_dualpath.dart
+++ b/lib/src/arithmetic/floating_point/floating_point_adder_dualpath.dart
@@ -43,10 +43,12 @@ class FloatingPointAdderDualPath<FpTypeIn extends FloatingPoint,
       ParallelPrefix Function(
               List<Logic> inps, Logic Function(Logic term1, Logic term2) op)
           ppTree = KoggeStone.new,
-      super.name = 'floating_point_adder_dualpath'})
+      super.name = 'floating_point_adder_dualpath',
+      String? definitionName})
       : super(
-            definitionName: 'FloatingPointAdderDualPath_'
-                'E${a.exponent.width}M${a.mantissa.width}') {
+            definitionName: definitionName ??
+                'FloatingPointAdderDualPath_'
+                    'E${a.exponent.width}M${a.mantissa.width}') {
     if (a.explicitJBit || b.explicitJBit) {
       throw ArgumentError(
           'FloatingPointAdderDualPath does not support explicit J bit.');

--- a/lib/src/arithmetic/floating_point/floating_point_adder_singlepath.dart
+++ b/lib/src/arithmetic/floating_point/floating_point_adder_singlepath.dart
@@ -39,10 +39,12 @@ class FloatingPointAdderSinglePath<FpTypeIn extends FloatingPoint,
           NativeAdder.new,
       List<int> Function(int) widthGen =
           CarrySelectCompoundAdder.splitSelectAdderAlgorithmSingleBlock,
-      super.name = 'floatingpoint_adder_singlepath'})
+      super.name = 'floatingpoint_adder_singlepath',
+      String? definitionName})
       : super(
-            definitionName: 'FloatingPointAdderSinglePath_'
-                'E${a.exponent.width}M${a.mantissa.width}') {
+            definitionName: definitionName ??
+                'FloatingPointAdderSinglePath_'
+                    'E${a.exponent.width}M${a.mantissa.width}') {
     if (internalSum.exponent.width != a.exponent.width) {
       throw RohdHclException('This adder currently only supports '
           'output exponent width equal to input exponent width.');

--- a/lib/src/arithmetic/floating_point/floating_point_converter.dart
+++ b/lib/src/arithmetic/floating_point/floating_point_converter.dart
@@ -49,12 +49,14 @@ class FloatingPointConverter<FpTypeIn extends FloatingPoint,
           priorityGen = RecursiveModulePriorityEncoder.new,
       Adder Function(Logic a, Logic b, {Logic? carryIn}) adderGen =
           NativeAdder.new,
-      super.name = 'floating_point_converter'})
+      super.name = 'floating_point_converter',
+      String? definitionName})
       : sourceExponentWidth = source.exponent.width,
         sourceMantissaWidth = source.mantissa.width,
         super(
-            definitionName: 'FloatingPointConverter_${source.runtimeType}_'
-                '${destination.runtimeType}') {
+            definitionName: definitionName ??
+                'FloatingPointConverter_${source.runtimeType}_'
+                    '${destination.runtimeType}') {
     if (source.subNormalAsZero) {
       throw ArgumentError(
           'FloatingPointConverter does not support denormal as zero (DAZ)');

--- a/lib/src/arithmetic/floating_point/floating_point_multiplier_simple.dart
+++ b/lib/src/arithmetic/floating_point/floating_point_multiplier_simple.dart
@@ -35,12 +35,14 @@ class FloatingPointMultiplierSimple<FpTypeIn extends FloatingPoint,
       PriorityEncoder Function(Logic bitVector,
               {bool generateValid, String name})
           priorityGen = RecursiveModulePriorityEncoder.new,
-      super.name})
+      super.name,
+      String? definitionName})
       : super(
-            definitionName: 'FloatingPointMultiplierSimple_'
-                'E${a.exponent.width}M${a.mantissa.width}'
-                '${outProduct != null ? '_OE${outProduct.exponent.width}_'
-                    'OM${outProduct.mantissa.width}' : ''}') {
+            definitionName: definitionName ??
+                'FloatingPointMultiplierSimple_'
+                    'E${a.exponent.width}M${a.mantissa.width}'
+                    '${outProduct != null ? '_OE${outProduct.exponent.width}_'
+                        'OM${outProduct.mantissa.width}' : ''}') {
     if (exponentWidth < a.exponent.width) {
       throw RohdHclException('product exponent width must be >= '
           ' input exponent width');

--- a/lib/src/arithmetic/floating_point/floating_point_sqrt_simple.dart
+++ b/lib/src/arithmetic/floating_point/floating_point_sqrt_simple.dart
@@ -21,10 +21,12 @@ class FloatingPointSqrtSimple<FpType extends FloatingPoint>
       {super.clk,
       super.reset,
       super.enable,
-      super.name = 'floatingpoint_square_root_simple'})
+      super.name = 'floatingpoint_square_root_simple',
+      String? definitionName})
       : super(
-            definitionName: 'FloatingPointSquareRootSimple_'
-                'E${a.exponent.width}M${a.mantissa.width}') {
+            definitionName: definitionName ??
+                'FloatingPointSquareRootSimple_'
+                    'E${a.exponent.width}M${a.mantissa.width}') {
     final outputSqrt = FloatingPoint(
         exponentWidth: exponentWidth,
         mantissaWidth: mantissaWidth,

--- a/lib/src/arithmetic/leading_digit_anticipate.dart
+++ b/lib/src/arithmetic/leading_digit_anticipate.dart
@@ -50,7 +50,8 @@ abstract class LeadingZeroAnticipateBase extends Module {
   /// less than the leading zero of the sum or subtraction of [a] and [b].
   /// [validLeadOne] indicates a leading one was found.
   LeadingZeroAnticipateBase(Logic aSign, Logic a, Logic bSign, Logic b,
-      {super.name = 'leading_zero_anticipate'}) {
+      {super.name = 'leading_zero_anticipate', String? definitionName})
+      : super(definitionName: definitionName ?? 'LeadingZeroAnticipate') {
     aSign = addInput('aSign', aSign);
     a = addInput('a', a, width: a.width);
     bSign = addInput('bSign', bSign);
@@ -97,7 +98,8 @@ class LeadingZeroAnticipate extends LeadingZeroAnticipateBase {
   /// [a] and [b]. [leadingOneConverse] should be used if [b] >= [a] during
   /// subtraction.
   LeadingZeroAnticipate(super.aSign, super.a, super.bSign, super.b,
-      {super.name = 'leading_zero_anticipate'}) {
+      {super.name = 'leading_zero_anticipate', String? definitionName})
+      : super(definitionName: definitionName ?? 'LeadingDigitAnticipate') {
     leadingOne <= leadOneEncoder.out;
     validLeadOne <= leadOneEncoder.valid!;
     addOutput('leadingOneConverse', width: leadOneEncoderConverse.out.width);
@@ -116,7 +118,9 @@ class LeadingZeroAnticipateCarry extends LeadingZeroAnticipateBase {
   /// prediction pair. and output as [leadingOne] and [validLeadOne].
   LeadingZeroAnticipateCarry(super.aSign, super.a, super.bSign, super.b,
       {required Logic endAroundCarry,
-      super.name = 'leading_zero_anticipate_carry'}) {
+      super.name = 'leading_zero_anticipate_carry',
+      String? definitionName})
+      : super(definitionName: definitionName ?? 'LeadingDigitAnticipate') {
     endAroundCarry = addInput('endAroundCarry', endAroundCarry);
 
     leadingOne <=
@@ -144,7 +148,8 @@ class LeadingDigitAnticipate extends Module {
   /// change (leading 1 position for positive sum, leading 0 position for
   /// negative sum).
   LeadingDigitAnticipate(Logic a, Logic b,
-      {super.name = 'leading_digit_anticipate'}) {
+      {super.name = 'leading_digit_anticipate', String? definitionName})
+      : super(definitionName: definitionName ?? 'LeadingDigitAnticipate') {
     a = addInput('a', a, width: a.width);
     b = addInput('b', b, width: b.width);
     final pA = a.reversed;

--- a/lib/src/arithmetic/multiplier.dart
+++ b/lib/src/arithmetic/multiplier.dart
@@ -160,11 +160,13 @@ class NativeMultiplier extends Multiplier {
       super.enable,
       super.signedMultiplicand,
       super.signedMultiplier,
-      super.name = 'native_multiplier'})
+      super.name = 'native_multiplier',
+      String? definitionName})
       : super(
-            definitionName: 'NativeMultiplier_W${a.width}x'
-                '${b.width}_${Multiplier.signedMD(signedMultiplicand)}_'
-                '${Multiplier.signedML(signedMultiplier)}') {
+            definitionName: definitionName ??
+                'NativeMultiplier_W${a.width}x'
+                    '${b.width}_${Multiplier.signedMD(signedMultiplicand)}_'
+                    '${Multiplier.signedML(signedMultiplier)}') {
     if (a.width != b.width) {
       throw RohdHclException('inputs of a and b should have same width.');
     }
@@ -218,24 +220,28 @@ class CompressionTreeMultiplier extends Multiplier {
   /// after compression.  [reset] and [enable] are optional
   /// inputs to control these flops when [clk] is provided. If [clk] is null,
   /// the Column Compressor is built as a combinational tree of compressors.
-  CompressionTreeMultiplier(super.a, super.b,
-      {int radix = 4,
-      super.clk,
-      super.reset,
-      super.enable,
-      super.signedMultiplicand,
-      super.signedMultiplier,
-      Adder Function(Logic a, Logic b, {Logic? carryIn}) adderGen =
-          NativeAdder.new,
-      PartialProductSignExtension Function(PartialProductGeneratorBase pp,
-              {String name})
-          signExtensionGen = CompactRectSignExtension.new,
-      super.name = 'compression_tree_multiplier'})
-      : super(
-            definitionName: 'CompressionTreeMultiplier_W${a.width}x'
-                '${b.width}_${Multiplier.signedMD(signedMultiplicand)}_'
-                '${Multiplier.signedML(signedMultiplier)}_'
-                'with${adderGen(a, a).definitionName}') {
+  CompressionTreeMultiplier(
+    super.a,
+    super.b, {
+    int radix = 4,
+    super.clk,
+    super.reset,
+    super.enable,
+    super.signedMultiplicand,
+    super.signedMultiplier,
+    Adder Function(Logic a, Logic b, {Logic? carryIn}) adderGen =
+        NativeAdder.new,
+    PartialProductSignExtension Function(PartialProductGeneratorBase pp,
+            {String name})
+        signExtensionGen = CompactRectSignExtension.new,
+    super.name = 'compression_tree_multiplier',
+    String? definitionName,
+  }) : super(
+            definitionName: definitionName ??
+                'CompressionTreeMultiplier_W${a.width}x'
+                    '${b.width}_${Multiplier.signedMD(signedMultiplicand)}_'
+                    '${Multiplier.signedML(signedMultiplier)}_'
+                    'with${adderGen(a, a).definitionName}') {
     final pp = PartialProduct(a, b, RadixEncoder(radix),
         selectSignedMultiplicand: selectSignedMultiplicand,
         signedMultiplicand: signedMultiplicand,

--- a/lib/src/arithmetic/multiplier_components/column_compressor.dart
+++ b/lib/src/arithmetic/multiplier_components/column_compressor.dart
@@ -25,7 +25,9 @@ abstract class BitCompressor extends Module {
   Logic get carry => output('carry');
 
   /// Construct a column compressor
-  BitCompressor(Logic compressBits, {super.name = 'bit_compressor'}) {
+  BitCompressor(Logic compressBits,
+      {super.name = 'bit_compressor', String? definitionName})
+      : super(definitionName: definitionName ?? 'bit_compressor') {
     this.compressBits = addInput(
       'compressBits',
       compressBits,
@@ -39,7 +41,9 @@ abstract class BitCompressor extends Module {
 /// 2-input column compressor (half-adder)
 class Compressor2 extends BitCompressor {
   /// Construct a 2-input compressor (half-adder)
-  Compressor2(super.compressBits, {super.name = 'compressor_2'}) {
+  Compressor2(super.compressBits,
+      {super.name = 'compressor_2', String? definitionName})
+      : super(definitionName: definitionName ?? 'compressor_2') {
     sum <= compressBits.xor();
     carry <= compressBits.and();
   }
@@ -48,7 +52,9 @@ class Compressor2 extends BitCompressor {
 /// 3-input column compressor (full-adder)
 class Compressor3 extends BitCompressor {
   /// Construct a 3-input column compressor (full-adder)
-  Compressor3(super.compressBits, {super.name = 'compressor_3'}) {
+  Compressor3(super.compressBits,
+      {super.name = 'compressor_3', String? definitionName})
+      : super(definitionName: definitionName ?? 'compressor_3') {
     sum <= compressBits.xor();
     carry <=
         mux(compressBits[0], compressBits.slice(2, 1).or(),
@@ -207,9 +213,10 @@ class ColumnCompressor extends Module {
       Logic? reset,
       Logic? enable,
       @visibleForTesting bool dontCompress = false,
-      super.name = 'column_compressor'})
+      super.name = 'column_compressor',
+      String? definitionName})
       : super(
-            definitionName:
+            definitionName: definitionName ??
                 'ColumnCompressor_L${inRows.length}_W${inRows[0].width}') {
     this.clk = (clk != null) ? addInput('clk', clk) : null;
     this.reset = (reset != null) ? addInput('reset', reset) : null;

--- a/lib/src/arithmetic/multiplier_components/partial_product_generator.dart
+++ b/lib/src/arithmetic/multiplier_components/partial_product_generator.dart
@@ -302,7 +302,9 @@ abstract class PartialProductMatrix extends Module {
   late final PartialProductGeneratorBase _array;
 
   /// Base constructor for the matrix
-  PartialProductMatrix({super.name = 'partial_product_matrix'});
+  PartialProductMatrix(
+      {super.name = 'partial_product_matrix', String? definitionName})
+      : super(definitionName: definitionName ?? 'partial_product_matrix');
 
   /// Generate the output vectors from the array
   void generateOutputs() {
@@ -331,7 +333,9 @@ class PartialProduct extends PartialProductMatrix {
               Logic? selectSignedMultiplicand,
               Logic? selectSignedMultiplier})
           genPPG = PartialProductGenerator.new,
-      super.name = 'partial_product'}) {
+      super.name = 'partial_product',
+      String? definitionName})
+      : super(definitionName: definitionName ?? 'partial_product') {
     final selectSignedMultiplicandInternal = selectSignedMultiplicand != null
         ? addInput(selectSignedMultiplicand.name, selectSignedMultiplicand)
         : null;

--- a/lib/src/arithmetic/multiply_accumulate.dart
+++ b/lib/src/arithmetic/multiply_accumulate.dart
@@ -200,7 +200,12 @@ class CompressionTreeMultiplyAccumulate extends MultiplyAccumulate {
       PartialProductSignExtension Function(PartialProductGeneratorBase pp,
               {String name})
           seGen = CompactRectSignExtension.new,
-      super.name = 'compression_tree_mac'}) {
+      super.name = 'compression_tree_mac',
+      String? definitionName})
+      : super(
+            definitionName: definitionName ??
+                'CompressionTreeMAC_W${a.width}x${b.width}_Acc${c.width}_'
+                    '${MultiplyAccumulate.signedAD(signedAddend)}') {
     final pp = PartialProduct(
       a,
       b,

--- a/lib/src/arithmetic/parallel_prefix_operations.dart
+++ b/lib/src/arithmetic/parallel_prefix_operations.dart
@@ -29,10 +29,11 @@ class ParallelPrefix extends Module {
   List<Logic> get val => UnmodifiableListView(_oseq);
 
   /// ParallePrefix recursion
-  ParallelPrefix(List<Logic> inps, String name)
+  ParallelPrefix(List<Logic> inps, String name, {String? definitionName})
       : super(
             name: name,
-            definitionName: 'ParallelPrefix_${name}_W${inps.length}') {
+            definitionName:
+                definitionName ?? 'ParallelPrefix_${name}_W${inps.length}') {
     if (inps.isEmpty) {
       throw Exception("Don't use {name} with an empty sequence");
     }
@@ -172,8 +173,11 @@ class ParallelPrefixOrScan extends Module {
       {ParallelPrefix Function(
               List<Logic> inps, Logic Function(Logic term1, Logic term2) op)
           ppGen = KoggeStone.new,
-      super.name = 'parallel_prefix_orscan'})
-      : super(definitionName: 'ParallelPrefixOrScan_W${inp.width}') {
+      super.name = 'parallel_prefix_orscan',
+      String? definitionName})
+      : super(
+            definitionName:
+                definitionName ?? 'ParallelPrefixOrScan_W${inp.width}') {
     inp = addInput('inp', inp, width: inp.width);
     final u = ppGen(inp.elements, (a, b) => a | b);
     addOutput('out', width: inp.width) <= u.val.rswizzle();
@@ -191,8 +195,11 @@ class ParallelPrefixPriorityFinder extends Module {
       {ParallelPrefix Function(
               List<Logic> inps, Logic Function(Logic term1, Logic term2) op)
           ppGen = KoggeStone.new,
-      super.name = 'parallel_prefix_finder'})
-      : super(definitionName: 'ParallelPrefixPriorityFinder_W${inp.width}') {
+      super.name = 'parallel_prefix_finder',
+      String? definitionName})
+      : super(
+            definitionName: definitionName ??
+                'ParallelPrefixPriorityFinder_W${inp.width}') {
     inp = addInput('inp', inp, width: inp.width);
     final u = ParallelPrefixOrScan(inp, ppGen: ppGen);
     addOutput('out', width: inp.width) <=
@@ -208,8 +215,11 @@ class ParallelPrefixAdder extends Adder {
       ParallelPrefix Function(
               List<Logic> inps, Logic Function(Logic term1, Logic term2) op)
           ppGen = KoggeStone.new,
-      super.name = 'parallel_prefix_adder'})
-      : super(definitionName: 'ParallelPrefixAdder_W${a.width}') {
+      super.name = 'parallel_prefix_adder',
+      String? definitionName})
+      : super(
+            definitionName:
+                definitionName ?? 'ParallelPrefixAdder_W${a.width}') {
     final l = List<Logic>.generate(a.width - 1,
         (i) => [a[i + 1] & b[i + 1], a[i + 1] | b[i + 1]].swizzle());
     final cin = carryIn ?? Const(0);
@@ -246,8 +256,11 @@ class ParallelPrefixIncr extends Module {
       {ParallelPrefix Function(
               List<Logic> inps, Logic Function(Logic term1, Logic term2) op)
           ppGen = KoggeStone.new,
-      super.name = 'parallel_prefix_incr'})
-      : super(definitionName: 'ParallelPrefixIncr_W${inp.width}') {
+      super.name = 'parallel_prefix_incr',
+      String? definitionName})
+      : super(
+            definitionName:
+                definitionName ?? 'ParallelPrefixIncr_W${inp.width}') {
     inp = addInput('inp', inp, width: inp.width);
     final u = ppGen(inp.elements, (lhs, rhs) => rhs & lhs);
     addOutput('out', width: inp.width) <=
@@ -269,8 +282,11 @@ class ParallelPrefixDecr extends Module {
       {ParallelPrefix Function(
               List<Logic> inps, Logic Function(Logic term1, Logic term2) op)
           ppGen = KoggeStone.new,
-      super.name = 'parallel_prefix_decr'})
-      : super(definitionName: 'ParallelPrefixDecr_W${inp.width}') {
+      super.name = 'parallel_prefix_decr',
+      String? definitionName})
+      : super(
+            definitionName:
+                definitionName ?? 'ParallelPrefixDecr_W${inp.width}') {
     inp = addInput('inp', inp, width: inp.width);
     final u = ppGen((~inp).elements, (lhs, rhs) => rhs & lhs);
     addOutput('out', width: inp.width) <=

--- a/lib/src/arithmetic/ripple_carry_adder.dart
+++ b/lib/src/arithmetic/ripple_carry_adder.dart
@@ -19,8 +19,11 @@ import 'package:rohd_hcl/rohd_hcl.dart';
 class RippleCarryAdder extends Adder {
   /// Constructs an n-bit adder based on inputs List of inputs.
   RippleCarryAdder(super.a, super.b,
-      {super.carryIn, super.name = 'ripple_carry_adder_carry_in'})
-      : super(definitionName: 'RippleCarryAdder_W${a.width}') {
+      {super.carryIn,
+      super.name = 'ripple_carry_adder_carry_in',
+      String? definitionName})
+      : super(
+            definitionName: definitionName ?? 'RippleCarryAdder_W${a.width}') {
     Logic? carry;
     final sumList = <Logic>[];
     for (var i = 0; i < a.width; i++) {

--- a/lib/src/binary_gray.dart
+++ b/lib/src/binary_gray.dart
@@ -30,8 +30,10 @@ class BinaryToGrayConverter extends Module {
   /// The [binary] parameter is the binary input that you want to convert
   /// to Gray code. The width of the input [binary] determines the width
   /// of the Gray code output.
-  BinaryToGrayConverter(Logic binary)
-      : super(definitionName: 'BinaryToGrayConverter_W${binary.width}') {
+  BinaryToGrayConverter(Logic binary, {String? definitionName})
+      : super(
+            definitionName:
+                definitionName ?? 'BinaryToGrayConverter_W${binary.width}') {
     final inputWidth = binary.width;
     binary = addInput('binary', binary, width: inputWidth);
     final grayVal = addOutput('gray', width: inputWidth);
@@ -98,8 +100,10 @@ class GrayToBinaryConverter extends Module {
   /// The [gray] parameter is the Gray code input that you want to convert to
   /// binary. The width of the input [gray] determines the width of the binary
   /// output.
-  GrayToBinaryConverter(Logic gray)
-      : super(definitionName: 'GrayToBinaryConverter_W${gray.width}') {
+  GrayToBinaryConverter(Logic gray, {String? definitionName})
+      : super(
+            definitionName:
+                definitionName ?? 'GrayToBinaryConverter_W${gray.width}') {
     final inputWidth = gray.width;
     gray = addInput('gray', gray, width: inputWidth);
     final binaryVal = addOutput('binary', width: inputWidth);

--- a/lib/src/clock_gating.dart
+++ b/lib/src/clock_gating.dart
@@ -205,14 +205,13 @@ class ClockGate extends Module {
   /// that synchronous resets work properly, and the [enable] is extended for an
   /// appropriate duration (if [delayControlledSignals]) to ensure proper
   /// capture of data.
-  ClockGate(
-    Logic freeClk, {
-    required Logic enable,
-    Logic? reset,
-    ClockGateControlInterface? controlIntf,
-    this.delayControlledSignals = false,
-    super.name = 'clock_gate',
-  }) {
+  ClockGate(Logic freeClk,
+      {required Logic enable,
+      Logic? reset,
+      ClockGateControlInterface? controlIntf,
+      this.delayControlledSignals = false,
+      super.name = 'clock_gate',
+      super.definitionName}) {
     // if this clock gating is not intended to be present, then just do nothing
     if (!(controlIntf?.isPresent ?? true)) {
       _controlIntf = null;

--- a/lib/src/component_config/components/config_fixed_to_float.dart
+++ b/lib/src/component_config/components/config_fixed_to_float.dart
@@ -57,5 +57,6 @@ class FixedToFloatConfigurator extends Configurator {
           mantissaWidth: mantissaWidthKnob.value),
       leadingDigitPredict: leadingDigitPredictionKnob.value
           ? Logic(width: log2Ceil(integerWidthKnob.value))
-          : null);
+          : null,
+      definitionName: 'FixedToFloat');
 }

--- a/lib/src/component_config/components/config_float_to_fixed.dart
+++ b/lib/src/component_config/components/config_float_to_fixed.dart
@@ -30,7 +30,10 @@ class FloatToFixedConfigurator extends Configurator {
   });
 
   @override
-  Module createModule() => FloatToFixed(FloatingPoint(
-      exponentWidth: exponentWidthKnob.value,
-      mantissaWidth: mantissaWidthKnob.value));
+  Module createModule() => FloatToFixed(
+        FloatingPoint(
+            exponentWidth: exponentWidthKnob.value,
+            mantissaWidth: mantissaWidthKnob.value),
+        definitionName: 'FloatToFixed',
+      );
 }

--- a/lib/src/component_config/components/config_floating_point_adder.dart
+++ b/lib/src/component_config/components/config_floating_point_adder.dart
@@ -84,7 +84,8 @@ class FloatingPointAdderConfigurator extends Configurator {
               mantissaWidth: mantissaWidthKnob.value,
               subNormalAsZero: subNormalAsZeroSelecKnob.denormalAsZeroB.value),
           adderGen: adderSelectionKnob.selectedAdder(),
-          ppTree: treeGeneratorMap[prefixTreeKnob.value]!)
+          ppTree: treeGeneratorMap[prefixTreeKnob.value]!,
+          definitionName: 'FloatingPointAdderDualPath')
       : FloatingPointAdderSinglePath(
           clk: pipelinedKnob.value ? Logic() : null,
           FloatingPoint(
@@ -95,7 +96,9 @@ class FloatingPointAdderConfigurator extends Configurator {
               exponentWidth: exponentWidthKnob.value,
               mantissaWidth: mantissaWidthKnob.value,
               subNormalAsZero: subNormalAsZeroSelecKnob.flushToZero.value),
-          adderGen: adderSelectionKnob.selectedAdder());
+          adderGen: adderSelectionKnob.selectedAdder(),
+          definitionName: 'FloatingPointAdderSinglePath',
+        );
 
   @override
   late final Map<String, ConfigKnob<dynamic>> knobs = UnmodifiableMapView({

--- a/lib/src/component_config/components/config_floating_point_multiplier.dart
+++ b/lib/src/component_config/components/config_floating_point_multiplier.dart
@@ -65,7 +65,8 @@ class FloatingPointMultiplierSimpleConfigurator extends Configurator {
       FloatingPoint(
           exponentWidth: exponentWidthKnob.value,
           mantissaWidth: mantissaWidthKnob.value),
-      multGen: multiplierSelectKnob.selectedMultiplier());
+      multGen: multiplierSelectKnob.selectedMultiplier(),
+      definitionName: 'FlatingPointMultiplierSimple');
 
   @override
   late final Map<String, ConfigKnob<dynamic>> knobs = UnmodifiableMapView({

--- a/lib/src/component_config/components/config_floating_point_sqrt.dart
+++ b/lib/src/component_config/components/config_floating_point_sqrt.dart
@@ -23,7 +23,8 @@ class FloatingPointSqrtConfigurator extends Configurator {
     final inp = FloatingPoint(
         exponentWidth: exponentWidthKnob.value,
         mantissaWidth: mantissaWidthKnob.value);
-    return FloatingPointSqrtSimple(inp);
+    return FloatingPointSqrtSimple(inp,
+        definitionName: 'FloatingPointSqrtSimple');
   }
 
   @override

--- a/lib/src/component_config/components/config_leading_digit_anticipate.dart
+++ b/lib/src/component_config/components/config_leading_digit_anticipate.dart
@@ -35,10 +35,11 @@ class LeadingDigitAnticipateConfigurator extends Configurator {
       if (anticipator.value == LeadingDigitAnticipate)
         LeadingDigitAnticipate(inp1, inp2)
       else if (anticipator.value == LeadingZeroAnticipate)
-        LeadingZeroAnticipate(sgn1, inp1, sgn2, inp2)
+        LeadingZeroAnticipate(sgn1, inp1, sgn2, inp2,
+            definitionName: 'LeadingZeroAnticipate')
       else
         LeadingZeroAnticipateCarry(sgn1, inp1, sgn2, inp2,
-            endAroundCarry: carry)
+            endAroundCarry: carry, definitionName: 'LeadingZeroAnticipate')
     ].first;
   }
 

--- a/lib/src/component_config/components/config_multiplier.dart
+++ b/lib/src/component_config/components/config_multiplier.dart
@@ -18,11 +18,10 @@ class MultiplierConfigurator extends Configurator {
 
   @override
   Module createModule() => multiplierSelectKnob.selectedMultiplier()(
-        clk: multiplierSelectKnob.pipelinedKnob.value ? Logic() : null,
-        Logic(
-            name: 'a', width: multiplierSelectKnob.multiplicandWidthKnob.value),
-        Logic(name: 'b', width: multiplierSelectKnob.multiplierWidthKnob.value),
-      );
+      clk: multiplierSelectKnob.pipelinedKnob.value ? Logic() : null,
+      Logic(name: 'a', width: multiplierSelectKnob.multiplicandWidthKnob.value),
+      Logic(name: 'b', width: multiplierSelectKnob.multiplierWidthKnob.value),
+      definitionName: 'Multiplier');
 
   @override
   Map<String, ConfigKnob<dynamic>> get knobs => {

--- a/lib/src/component_config/components/config_one_hot.dart
+++ b/lib/src/component_config/components/config_one_hot.dart
@@ -27,8 +27,10 @@ class OneHotConfigurator extends Configurator {
   Module createModule() {
     final inp = Logic(width: inputWidthKnob.value);
     return directionKnob.value == BinaryToOneHot
-        ? BinaryToOneHot(inp)
-        : OneHotToBinary(inp, generateError: generateErrorKnob.value);
+        ? BinaryToOneHot(inp, definitionName: 'BinaryToOneHot')
+        : OneHotToBinary(inp,
+            generateError: generateErrorKnob.value,
+            definitionName: 'OneHotToBinary');
   }
 
   @override

--- a/lib/src/component_config/components/config_parallel_prefix_adder.dart
+++ b/lib/src/component_config/components/config_parallel_prefix_adder.dart
@@ -38,7 +38,8 @@ class ParallelPrefixAdderConfigurator extends Configurator {
       Logic(name: 'a', width: dataWidthKnob.value),
       Logic(name: 'b', width: dataWidthKnob.value),
       carryIn: Logic(name: 'carryIn'),
-      ppGen: generatorMap[prefixTreeKnob.value]!);
+      ppGen: generatorMap[prefixTreeKnob.value]!,
+      definitionName: 'ParallelPrefixAdder');
 
   @override
   late final Map<String, ConfigKnob<dynamic>> knobs = UnmodifiableMapView({

--- a/lib/src/component_config/components/config_priority_arbiter.dart
+++ b/lib/src/component_config/components/config_priority_arbiter.dart
@@ -27,6 +27,6 @@ class PriorityArbiterConfigurator extends Configurator {
   @override
   Module createModule() {
     final reqs = List.generate(numRequestKnob.value, (i) => Logic());
-    return PriorityArbiter(reqs);
+    return PriorityArbiter(reqs, definitionName: 'PriorityArbiter');
   }
 }

--- a/lib/src/component_config/components/config_rf.dart
+++ b/lib/src/component_config/components/config_rf.dart
@@ -44,20 +44,20 @@ class RegisterFileConfigurator extends Configurator {
 
   @override
   Module createModule() => RegisterFile(
-        Logic(),
-        Logic(),
-        List.generate(
-            numWritePortsKnobs.value,
-            (index) => maskedWritesKnob.value
-                ? MaskedDataPortInterface(
-                    dataWidthKnob.value, addrWidthKnob.value)
-                : DataPortInterface(dataWidthKnob.value, addrWidthKnob.value)),
-        List.generate(
-            numReadPortsKnobs.value,
-            (index) =>
-                DataPortInterface(dataWidthKnob.value, addrWidthKnob.value)),
-        numEntries: numEntriesKnob.value,
-      );
+      Logic(),
+      Logic(),
+      List.generate(
+          numWritePortsKnobs.value,
+          (index) => maskedWritesKnob.value
+              ? MaskedDataPortInterface(
+                  dataWidthKnob.value, addrWidthKnob.value)
+              : DataPortInterface(dataWidthKnob.value, addrWidthKnob.value)),
+      List.generate(
+          numReadPortsKnobs.value,
+          (index) =>
+              DataPortInterface(dataWidthKnob.value, addrWidthKnob.value)),
+      numEntries: numEntriesKnob.value,
+      definitionName: 'RegisterFile');
 
   @override
   final String name = 'Register File';

--- a/lib/src/component_config/components/config_ripple_carry_adder.dart
+++ b/lib/src/component_config/components/config_ripple_carry_adder.dart
@@ -27,5 +27,5 @@ class RippleCarryAdderConfigurator extends Configurator {
   @override
   Module createModule() => RippleCarryAdder(
       Logic(width: logicWidthKnob.value), Logic(width: logicWidthKnob.value),
-      carryIn: Logic());
+      carryIn: Logic(), definitionName: 'RippleCarryAdder');
 }

--- a/lib/src/component_config/components/config_rotate.dart
+++ b/lib/src/component_config/components/config_rotate.dart
@@ -41,13 +41,13 @@ class RotateConfigurator extends Configurator {
 
   @override
   Module createModule() {
-    final rotateConstructor = directionKnob.value == RotateDirection.left
-        ? RotateLeft.new
-        : RotateRight.new;
-    return rotateConstructor(
-      Logic(width: originalWidthKnob.value),
-      Logic(width: rotateWidthKnob.value),
-      maxAmount: maxAmountKnob.value,
-    );
+    final val = directionKnob.value;
+    final rotateConstructor =
+        val == RotateDirection.left ? RotateLeft.new : RotateRight.new;
+    return rotateConstructor(Logic(width: originalWidthKnob.value),
+        Logic(width: rotateWidthKnob.value),
+        maxAmount: maxAmountKnob.value,
+        definitionName:
+            'Rotate${val == RotateDirection.left ? "Left" : "Right"}');
   }
 }

--- a/lib/src/component_config/components/config_round_robin_arbiter.dart
+++ b/lib/src/component_config/components/config_round_robin_arbiter.dart
@@ -36,9 +36,15 @@ class RoundRobinArbiterConfigurator extends Configurator {
     final reqs = List.generate(numRequestKnob.value, (i) => Logic());
 
     if (implementationKnob.value == MaskRoundRobinArbiter) {
-      return MaskRoundRobinArbiter(reqs, clk: Logic(), reset: Logic());
+      return MaskRoundRobinArbiter(reqs,
+          clk: Logic(),
+          reset: Logic(),
+          definitionName: 'MaskRoundRobinArbiter');
     } else if (implementationKnob.value == RotateRoundRobinArbiter) {
-      return RotateRoundRobinArbiter(reqs, clk: Logic(), reset: Logic());
+      return RotateRoundRobinArbiter(reqs,
+          clk: Logic(),
+          reset: Logic(),
+          definitionName: 'RotateRoundRobinArbiter');
     }
 
     throw RohdHclException('Unknown round robin type.');

--- a/lib/src/component_config/components/config_serialization.dart
+++ b/lib/src/component_config/components/config_serialization.dart
@@ -33,9 +33,15 @@ class SerializationConfigurator extends Configurator {
     final enable = Logic(name: 'enable');
     return directionKnob.value == Serializer
         ? Serializer(LogicArray([inputLengthKnob.value], inputWidthKnob.value),
-            enable: enableKnob.value ? enable : null, clk: clk, reset: reset)
+            enable: enableKnob.value ? enable : null,
+            clk: clk,
+            reset: reset,
+            definitionName: 'Serializer')
         : Deserializer(deserializeIn, inputLengthKnob.value,
-            enable: enableKnob.value ? enable : null, clk: clk, reset: reset);
+            enable: enableKnob.value ? enable : null,
+            clk: clk,
+            reset: reset,
+            definitionName: 'Deserializer');
   }
 
   @override

--- a/lib/src/component_config/components/config_sort.dart
+++ b/lib/src/component_config/components/config_sort.dart
@@ -39,11 +39,9 @@ class BitonicSortConfigurator extends Configurator {
       (index) => Logic(width: logicWidthKnob.value),
     );
 
-    return BitonicSort(
-      Logic(),
-      Logic(),
-      isAscending: isAscendingKnob.value,
-      toSort: listToSort,
-    );
+    return BitonicSort(Logic(), Logic(),
+        isAscending: isAscendingKnob.value,
+        toSort: listToSort,
+        definitionName: 'BitonicSort');
   }
 }

--- a/lib/src/component_config/components/config_summation.dart
+++ b/lib/src/component_config/components/config_summation.dart
@@ -86,22 +86,22 @@ class SumConfigurator extends SummationConfigurator {
 
   @override
   Module createModule() => Sum(
-        sumInterfaceKnobs.knobs
-            .map((e) => e as SumInterfaceKnob)
-            .map((e) => SumInterface(
-                  hasEnable: e.hasEnableKnob.value,
-                  fixedAmount:
-                      e.isFixedValueKnob.value ? e.fixedValueKnob.value : null,
-                  width: e.widthKnob.value,
-                  increments: e.incrementsKnob.value,
-                ))
-            .toList(),
-        initialValue: initialValueKnob.value,
-        width: widthKnob.value,
-        minValue: minValueKnob.value,
-        maxValue: maxValueKnob.value,
-        saturates: saturatesKnob.value,
-      );
+      sumInterfaceKnobs.knobs
+          .map((e) => e as SumInterfaceKnob)
+          .map((e) => SumInterface(
+                hasEnable: e.hasEnableKnob.value,
+                fixedAmount:
+                    e.isFixedValueKnob.value ? e.fixedValueKnob.value : null,
+                width: e.widthKnob.value,
+                increments: e.incrementsKnob.value,
+              ))
+          .toList(),
+      initialValue: initialValueKnob.value,
+      width: widthKnob.value,
+      minValue: minValueKnob.value,
+      maxValue: maxValueKnob.value,
+      saturates: saturatesKnob.value,
+      definitionName: 'Sum');
 
   @override
   String get name => 'Sum';

--- a/lib/src/component_config/config_knobs/multiplier_select_knob.dart
+++ b/lib/src/component_config/config_knobs/multiplier_select_knob.dart
@@ -78,19 +78,22 @@ class MultiplierSelectKnob extends GroupOfKnobs {
       {Logic? clk,
       Logic? reset,
       Logic? enable,
-      String name}) selectedMultiplier() {
+      String name,
+      String? definitionName}) selectedMultiplier() {
     if (compressionTreeMultiplierKnob.value) {
       return (Logic term1, Logic term2,
               {Logic? clk,
               Logic? reset,
               Logic? enable,
-              String name = 'comp_tree_multiplier'}) =>
+              String name = 'comp_tree_multiplier',
+              String? definitionName}) =>
           CompressionTreeMultiplier(term1, term2,
               radix: radixKnob.value,
               adderGen: adderSelectionKnob.selectedAdder(),
               clk: clk,
               reset: reset,
-              enable: enable);
+              enable: enable,
+              definitionName: definitionName);
     }
     return NativeMultiplier.new;
   }

--- a/lib/src/count.dart
+++ b/lib/src/count.dart
@@ -28,8 +28,9 @@ class Count extends Module {
   ///
   /// Takes in [bus] of type [Logic]. by default performs [countOne] (`1`)
   /// if [countOne] is `false` will count `0`
-  Count(Logic bus, {bool countOne = true, super.name = 'count'})
-      : super(definitionName: 'Count_W${bus.width}') {
+  Count(Logic bus,
+      {bool countOne = true, super.name = 'count', String? definitionName})
+      : super(definitionName: definitionName ?? 'Count_W${bus.width}') {
     bus = addInput('bus', bus, width: bus.width);
     Logic count = Const(0, width: max(1, log2Ceil(bus.width + 1)));
     for (var i = 0; i < bus.width; i++) {

--- a/lib/src/edge_detector.dart
+++ b/lib/src/edge_detector.dart
@@ -31,16 +31,17 @@ class EdgeDetector extends Module {
   /// If a [reset] is provided, then the first cycle after [reset] is
   /// deasserted, [signal] will be compared to [resetValue] (or 0, if not
   /// provided).
-  EdgeDetector(
-    Logic signal, {
-    required Logic clk,
-    Logic? reset,
-    dynamic resetValue,
-    this.edgeType = Edge.pos,
-    String? name,
-  }) : super(
+  EdgeDetector(Logic signal,
+      {required Logic clk,
+      Logic? reset,
+      dynamic resetValue,
+      this.edgeType = Edge.pos,
+      String? name,
+      String? definitionName})
+      : super(
             name: name ?? '${edgeType.name}_edge_detector',
-            definitionName: 'EdgeDetector_T${edgeType.name}') {
+            definitionName:
+                definitionName ?? 'EdgeDetector_T${edgeType.name}') {
     if (signal.width != 1 ||
         (resetValue is Logic && resetValue.width != 1) ||
         (resetValue is LogicValue && resetValue.width != 1)) {

--- a/lib/src/encodings/binary_to_one_hot.dart
+++ b/lib/src/encodings/binary_to_one_hot.dart
@@ -17,8 +17,11 @@ class BinaryToOneHot extends Module {
 
   /// Constructs a [Module] which encodes a 2's complement number [binary]
   /// into a one-hot, or thermometer code
-  BinaryToOneHot(Logic binary, {super.name = 'binary_to_one_hot'})
-      : super(definitionName: 'BinaryToOneHot_W${binary.width}') {
+  BinaryToOneHot(Logic binary,
+      {super.name = 'binary_to_one_hot', String? definitionName})
+      : super(
+            definitionName:
+                definitionName ?? 'BinaryToOneHot_W${binary.width}') {
     binary = addInput('binary', binary, width: binary.width);
     addOutput('encoded', width: pow(2, binary.width).toInt());
     encoded <= Const(1, width: encoded.width) << binary;

--- a/lib/src/encodings/case_one_hot_to_binary.dart
+++ b/lib/src/encodings/case_one_hot_to_binary.dart
@@ -21,7 +21,9 @@ class CaseOneHotToBinary extends OneHotToBinary {
   /// [TreeOneHotToBinary]. The implementation does not support widths exceeding
   /// the maximum width of an `int`.
   CaseOneHotToBinary(super.onehot,
-      {super.generateError = false, super.name = 'one_hot_to_binary'})
+      {super.generateError = false,
+      super.name = 'one_hot_to_binary',
+      super.definitionName})
       : super.base() {
     if (onehot.width >= 32) {
       throw RohdHclException('Should not be used for large widths.');

--- a/lib/src/encodings/one_hot_to_binary.dart
+++ b/lib/src/encodings/one_hot_to_binary.dart
@@ -29,14 +29,15 @@ abstract class OneHotToBinary extends Module {
   /// By default, creates an instance of a [CaseOneHotToBinary] for smaller
   /// widths and a [TreeOneHotToBinary] for larger widths.
   factory OneHotToBinary(Logic onehot,
-      {bool generateError = false, String name = 'one_hot_to_binary'}) {
+      {bool generateError = false,
+      String name = 'one_hot_to_binary',
+      String? definitionName}) {
     final isSmall = onehot.width <= 8;
 
-    return (isSmall ? CaseOneHotToBinary.new : TreeOneHotToBinary.new)(
-      onehot,
-      generateError: generateError,
-      name: name,
-    );
+    return (isSmall ? CaseOneHotToBinary.new : TreeOneHotToBinary.new)(onehot,
+        generateError: generateError,
+        name: name,
+        definitionName: definitionName);
   }
 
   /// The [input] of this instance.

--- a/lib/src/encodings/tree_one_hot_to_binary.dart
+++ b/lib/src/encodings/tree_one_hot_to_binary.dart
@@ -14,7 +14,9 @@ import 'package:rohd_hcl/rohd_hcl.dart';
 class TreeOneHotToBinary extends OneHotToBinary {
   /// Top level module for computing binary to one-hot using recursion
   TreeOneHotToBinary(super.onehot,
-      {super.generateError, super.name = 'tree_one_hot_to_binary'})
+      {super.generateError,
+      super.name = 'tree_one_hot_to_binary',
+      super.definitionName})
       : super.base() {
     final node = _NodeOneHotToBinary(onehot, generateMultiple: generateError);
     binary <= node.binary;

--- a/lib/src/error_checking/ecc.dart
+++ b/lib/src/error_checking/ecc.dart
@@ -127,12 +127,15 @@ class HammingEccReceiver extends ErrorCheckingReceiver {
   /// the [originalData] contains errors and possibly correct it to
   /// [correctedData], depending on the specified [hammingType].
   HammingEccReceiver(super.transmission,
-      {super.name = 'hamming_ecc_rx', this.hammingType = HammingType.sec})
+      {super.name = 'hamming_ecc_rx',
+      this.hammingType = HammingType.sec,
+      String? definitionName})
       : super(
           codeWidth: _codeWidthFromTransmissionWidth(
                   transmission.width - hammingType._extraParityBits) +
               hammingType._extraParityBits,
-          definitionName: 'hamming_ecc_receiver_${hammingType.name}',
+          definitionName:
+              definitionName ?? 'hamming_ecc_receiver_${hammingType.name}',
           supportsErrorCorrection: hammingType.hasCorrection,
         ) {
     final tx = HammingEccTransmitter(originalData, hammingType: hammingType);

--- a/lib/src/error_checking/parity.dart
+++ b/lib/src/error_checking/parity.dart
@@ -32,11 +32,13 @@ class ParityReceiver extends ErrorCheckingReceiver {
   /// correct parity. This will split the transmitted data in [transmission]
   /// into 2 parts: the [originalData], and the error bit upon which [error] is
   /// calculated for parity error checking.
-  ParityReceiver(super.transmission, {super.name = 'parity_rx'})
+  ParityReceiver(super.transmission,
+      {super.name = 'parity_rx', String? definitionName})
       : super(
             codeWidth: 1,
             supportsErrorCorrection: false,
-            definitionName: 'ParityReceiver_W${transmission.width}');
+            definitionName:
+                definitionName ?? 'ParityReceiver_W${transmission.width}');
 
   @override
   @protected

--- a/lib/src/extrema.dart
+++ b/lib/src/extrema.dart
@@ -25,8 +25,8 @@ class Extrema extends Module {
   /// If [max] is `true`, will find maximum value, else will find minimum.
   ///
   /// Outputs the [index] and [val] of the extrema in the list of [signals].
-  Extrema(List<Logic> signals, {bool max = true})
-      : super(definitionName: 'Extrema_L${signals.length}') {
+  Extrema(List<Logic> signals, {bool max = true, String? definitionName})
+      : super(definitionName: definitionName ?? 'Extrema_L${signals.length}') {
     // List to consume inputs internally.
     final logics = <Logic>[];
 

--- a/lib/src/fifo.dart
+++ b/lib/src/fifo.dart
@@ -86,10 +86,13 @@ class Fifo extends Module {
       this.generateError = false,
       this.generateOccupancy = false,
       this.generateBypass = false,
-      super.name = 'fifo'})
+      super.name = 'fifo',
+      String? definitionName})
       : dataWidth = writeData.width,
         _addrWidth = max(1, log2Ceil(depth)),
-        super(definitionName: 'Fifo_D${depth}_W${writeData.width}') {
+        super(
+            definitionName:
+                definitionName ?? 'Fifo_D${depth}_W${writeData.width}') {
     if (depth <= 0) {
       throw RohdHclException('Depth must be at least 1.');
     }

--- a/lib/src/find.dart
+++ b/lib/src/find.dart
@@ -40,8 +40,9 @@ class Find extends Module {
       {bool countOne = true,
       Logic? n,
       this.generateError = false,
-      super.name = 'find'})
-      : super(definitionName: 'Find_W${bus.width}') {
+      super.name = 'find',
+      String? definitionName})
+      : super(definitionName: definitionName ?? 'Find_W${bus.width}') {
     bus = addInput('bus', bus, width: bus.width);
     final oneHotList = <Logic>[];
 

--- a/lib/src/find_pattern.dart
+++ b/lib/src/find_pattern.dart
@@ -52,8 +52,13 @@ class FindPattern extends Module {
   ///
   /// [index] will be `0` when pattern is not found.
   FindPattern(Logic bus, Logic pattern,
-      {bool fromStart = true, Logic? n, this.generateError = false})
-      : super(definitionName: 'FindPattern_W${bus.width}_P${pattern.width}') {
+      {bool fromStart = true,
+      Logic? n,
+      this.generateError = false,
+      String? definitionName})
+      : super(
+            definitionName: definitionName ??
+                'FindPattern_W${bus.width}_P${pattern.width}') {
     bus = addInput('bus', bus, width: bus.width);
     pattern = addInput('pattern', pattern, width: pattern.width);
 

--- a/lib/src/gaskets/spi/spi_main.dart
+++ b/lib/src/gaskets/spi/spi_main.dart
@@ -33,7 +33,13 @@ class SpiMain extends Module {
       required Logic reset,
       required Logic start,
       required Logic busIn,
-      super.name = 'spiMain'}) {
+      super.name = 'spiMain',
+      String? definitionName})
+      : super(
+            definitionName: definitionName ??
+                'SpiMain_W${busIn.width}_'
+                    '${intf.dataLength}_'
+                    '${intf.sclk.width}') {
     busIn = addInput('busIn', busIn, width: busIn.width);
 
     clk = addInput('clk', clk);

--- a/lib/src/gaskets/spi/spi_sub.dart
+++ b/lib/src/gaskets/spi/spi_sub.dart
@@ -34,7 +34,13 @@ class SpiSub extends Module {
       {required SpiInterface intf,
       Logic? busIn,
       Logic? reset,
-      super.name = 'spiSub'}) {
+      super.name = 'spiSub',
+      String? definitionName})
+      : super(
+            definitionName: definitionName ??
+                'SpiSub_W${busIn?.width ?? 0}_'
+                    '${intf.dataLength}_'
+                    '${intf.sclk.width}') {
     // SPI Interface
     intf = SpiInterface.clone(intf)
       ..pairConnectIO(this, intf, PairRole.consumer);

--- a/lib/src/memory/csr/csr_container.dart
+++ b/lib/src/memory/csr/csr_container.dart
@@ -55,14 +55,20 @@ abstract class CsrContainer extends Module {
   final bool allowLargerRegisters;
 
   /// Constructs a base container.
-  CsrContainer({
-    required Logic clk,
-    required Logic reset,
-    required DataPortInterface? frontWrite,
-    required DataPortInterface? frontRead,
-    required this.config,
-    this.allowLargerRegisters = false,
-  }) : super(name: config.name) {
+  CsrContainer(
+      {required Logic clk,
+      required Logic reset,
+      required DataPortInterface? frontWrite,
+      required DataPortInterface? frontRead,
+      required this.config,
+      this.allowLargerRegisters = false,
+      String? definitionName})
+      : super(
+            definitionName: definitionName ??
+                'CsrContainer_W${clk.width}_'
+                    '${frontWrite?.dataWidth ?? 0}_'
+                    '${frontRead?.dataWidth ?? 0}',
+            name: config.name) {
     this.clk = addInput('clk', clk);
     this.reset = addInput('reset', reset);
 

--- a/lib/src/memory/csr/csr_top.dart
+++ b/lib/src/memory/csr/csr_top.dart
@@ -84,15 +84,15 @@ class CsrTop extends CsrContainer {
   }
 
   /// Create the CsrBlock from a configuration
-  CsrTop({
-    required CsrTopConfig super.config,
-    required super.clk,
-    required super.reset,
-    required super.frontWrite,
-    required super.frontRead,
-    super.allowLargerRegisters,
-    this.logicalRegisterIncrement = 1,
-  }) {
+  CsrTop(
+      {required CsrTopConfig super.config,
+      required super.clk,
+      required super.reset,
+      required super.frontWrite,
+      required super.frontRead,
+      super.allowLargerRegisters,
+      this.logicalRegisterIncrement = 1,
+      super.definitionName}) {
     _validate();
 
     for (final block in config.blocks) {

--- a/lib/src/memory/register_file.dart
+++ b/lib/src/memory/register_file.dart
@@ -23,10 +23,11 @@ class RegisterFile extends Memory {
   /// [MaskedDataPortInterface]s are supported on `writePorts`, but not on
   /// `readPorts`.
   RegisterFile(super.clk, super.reset, super.writePorts, super.readPorts,
-      {this.numEntries = 8, super.name = 'rf'})
+      {this.numEntries = 8, super.name = 'rf', String? definitionName})
       : super(
-            definitionName: 'RegisterFile_WP${writePorts.length}'
-                '_RP${readPorts.length}_E$numEntries') {
+            definitionName: definitionName ??
+                'RegisterFile_WP${writePorts.length}'
+                    '_RP${readPorts.length}_E$numEntries') {
     _buildLogic();
   }
 

--- a/lib/src/models/memory_model.dart
+++ b/lib/src/models/memory_model.dart
@@ -39,6 +39,7 @@ class MemoryModel extends Memory {
     this.readLatency = 1,
     this.asyncReset = true,
     MemoryStorage? storage,
+    super.definitionName,
   }) {
     this.storage = storage ??
         SparseMemoryStorage(addrWidth: addrWidth, dataWidth: dataWidth);

--- a/lib/src/reduction_tree.dart
+++ b/lib/src/reduction_tree.dart
@@ -106,9 +106,11 @@ class ReductionTree extends Module {
       Logic? clk,
       Logic? enable,
       Logic? reset,
-      super.name = 'reduction_tree'})
+      super.name = 'reduction_tree',
+      String? definitionName})
       : super(
-            definitionName: 'ReductionTreeNode_R${radix}_L${sequence.length}') {
+            definitionName: definitionName ??
+                'ReductionTreeNode_R${radix}_L${sequence.length}') {
     if (sequence.isEmpty) {
       throw RohdHclException("Don't use ReductionTree "
           'with an empty sequence');

--- a/lib/src/rotate.dart
+++ b/lib/src/rotate.dart
@@ -39,10 +39,12 @@ abstract class _Rotate extends Module {
   /// [original].  The [maxAmount] will be not be larger than what could be
   /// represented by the maximum value of [rotateAmount].
   _Rotate(this._direction, Logic original, Logic rotateAmount,
-      {int? maxAmount, super.name = 'rotate'})
+      {int? maxAmount, super.name = 'rotate', String? definitionName})
       : maxAmount = min(maxAmount ?? original.width,
             pow(2, rotateAmount.width).toInt() - 1),
-        super(definitionName: 'Rotate_${_direction.name}_W${original.width}') {
+        super(
+            definitionName: definitionName ??
+                'Rotate_${_direction.name}_W${original.width}') {
     original = addInput('original', original, width: original.width);
     rotateAmount =
         addInput('rotate_amount', rotateAmount, width: rotateAmount.width);
@@ -75,7 +77,8 @@ class RotateLeft extends _Rotate {
   /// If no [maxAmount] is provided, it will default to the `width` of
   /// [original].  The [maxAmount] will be not be larger than what could be
   /// represented by the maximum value of [rotateAmount].
-  RotateLeft(Logic original, Logic rotateAmount, {super.maxAmount, super.name})
+  RotateLeft(Logic original, Logic rotateAmount,
+      {super.maxAmount, super.name, super.definitionName})
       : super(RotateDirection.left, original, rotateAmount);
 }
 
@@ -91,7 +94,8 @@ class RotateRight extends _Rotate {
   /// If no [maxAmount] is provided, it will default to the `width` of
   /// [original].  The [maxAmount] will be not be larger than what could be
   /// represented by the maximum value of [rotateAmount].
-  RotateRight(Logic original, Logic rotateAmount, {super.maxAmount, super.name})
+  RotateRight(Logic original, Logic rotateAmount,
+      {super.maxAmount, super.name, super.definitionName})
       : super(RotateDirection.right, original, rotateAmount);
 }
 
@@ -107,10 +111,11 @@ class _RotateFixed extends Module {
 
   /// Rotates [original] by [rotateAmount] to the [_direction].
   _RotateFixed(this._direction, Logic original, this.rotateAmount,
-      {super.name = 'rotate_fixed'})
+      {super.name = 'rotate_fixed', String? definitionName})
       : super(
-            definitionName: 'RotateFixed_${_direction.name}_'
-                'by_$rotateAmount') {
+            definitionName: definitionName ??
+                'RotateFixed_${_direction.name}_'
+                    'by_$rotateAmount') {
     original = addInput('original', original, width: original.width);
     addOutput('rotated', width: original.width);
 
@@ -138,14 +143,16 @@ class _RotateFixed extends Module {
 /// Rotates left by a fixed amount.
 class RotateLeftFixed extends _RotateFixed {
   /// Rotates [original] by [rotateAmount] to the left.
-  RotateLeftFixed(Logic original, int rotateAmount, {super.name})
+  RotateLeftFixed(Logic original, int rotateAmount,
+      {super.name, super.definitionName})
       : super(RotateDirection.left, original, rotateAmount);
 }
 
 /// Rotates right by a fixed amount.
 class RotateRightFixed extends _RotateFixed {
   /// Rotates [original] by [rotateAmount] to the right.
-  RotateRightFixed(Logic original, int rotateAmount, {super.name})
+  RotateRightFixed(Logic original, int rotateAmount,
+      {super.name, super.definitionName})
       : super(RotateDirection.right, original, rotateAmount);
 }
 

--- a/lib/src/serialization/deserializer.dart
+++ b/lib/src/serialization/deserializer.dart
@@ -36,8 +36,11 @@ class Deserializer extends Module {
       {required Logic clk,
       required Logic reset,
       Logic? enable,
-      super.name = 'deserializer'})
-      : super(definitionName: 'Deserializer_W${serialized.width}_L$length') {
+      super.name = 'deserializer',
+      String? definitionName})
+      : super(
+            definitionName: definitionName ??
+                'Deserializer_W${serialized.width}_L$length') {
     clk = addInput('clk', clk);
     reset = addInput('reset', reset);
     if (enable != null) {

--- a/lib/src/serialization/serializer.dart
+++ b/lib/src/serialization/serializer.dart
@@ -38,10 +38,12 @@ class Serializer extends Module {
       required Logic reset,
       Logic? enable,
       bool flopInput = false,
-      super.name = 'serializer'})
+      super.name = 'serializer',
+      String? definitionName})
       : super(
-            definitionName: 'Serializer_W${deserialized.width}_'
-                '${deserialized.elementWidth}') {
+            definitionName: definitionName ??
+                'Serializer_W${deserialized.width}_'
+                    '${deserialized.elementWidth}') {
     clk = addInput('clk', clk);
     reset = addInput('reset', reset);
     if (enable != null) {

--- a/lib/src/shift_register.dart
+++ b/lib/src/shift_register.dart
@@ -53,11 +53,13 @@ class ShiftRegister extends Module {
     bool asyncReset = false,
     dynamic resetValue,
     this.dataName = 'data',
+    String? definitionName,
   })  : width = dataIn.width,
         super(
             name: '${dataName}_shift_register',
-            definitionName: 'ShiftRegister_W${dataIn.width}'
-                '_D$depth') {
+            definitionName: definitionName ??
+                'ShiftRegister_W${dataIn.width}'
+                    '_D$depth') {
     dataIn = addInput('${dataName}_in', dataIn, width: width);
     clk = addInput('clk', clk);
 

--- a/lib/src/signed_shifter.dart
+++ b/lib/src/signed_shifter.dart
@@ -17,8 +17,10 @@ class SignedShifter extends Module {
   /// Create a [SignedShifter] that treats shift as signed
   /// - [bits] is the input to be shifted
   /// - [shift] is the signed amount to be shifted
-  SignedShifter(Logic bits, Logic shift, {super.name = 'shifter'})
-      : super(definitionName: 'SignedShifter_W${bits.width}') {
+  SignedShifter(Logic bits, Logic shift,
+      {super.name = 'shifter', String? definitionName})
+      : super(
+            definitionName: definitionName ?? 'SignedShifter_W${bits.width}') {
     bits = addInput('bits', bits, width: bits.width);
     shift = addInput('shift', shift, width: shift.width);
 

--- a/lib/src/sort.dart
+++ b/lib/src/sort.dart
@@ -54,10 +54,11 @@ class _CompareSwap extends Module {
   /// be increased by 1 cycle if the signals for [i] and [j] are considered for
   /// swapping.
   _CompareSwap(Logic clk, Logic reset, List<Logic> toSort, int i, int j,
-      {required this.isAscending})
+      {required this.isAscending, String? definitionName})
       : super(
             name: 'compare_swap_${i}_$j',
-            definitionName: '_CompareSwap_W${toSort.length}') {
+            definitionName:
+                definitionName ?? '_CompareSwap_W${toSort.length}') {
     clk = addInput('clk', clk);
     reset = addInput('reset', reset);
 
@@ -109,13 +110,14 @@ class _BitonicMerge extends Module {
   /// [isAscending] given by [BitonicSort] to first created a bitonic sequence.
   /// The final stage will sort the bitonic sequence into sorted order
   /// of [isAscending].
-  _BitonicMerge(
-    Logic clk,
-    Logic reset, {
-    required bool isAscending,
-    required Iterable<Logic> bitonicSequence,
-    super.name = 'bitonic_merge',
-  }) : super(definitionName: '_BitonicMerge_W${bitonicSequence.length}') {
+  _BitonicMerge(Logic clk, Logic reset,
+      {required bool isAscending,
+      required Iterable<Logic> bitonicSequence,
+      super.name = 'bitonic_merge',
+      String? definitionName})
+      : super(
+            definitionName:
+                definitionName ?? '_BitonicMerge_W${bitonicSequence.length}') {
     clk = addInput('clk', clk);
     reset = addInput('reset', reset);
 
@@ -211,8 +213,12 @@ class BitonicSort extends Sort {
   /// await sortMod.build();
   /// ```
   BitonicSort(Logic clk, Logic reset,
-      {required super.toSort, super.isAscending, super.name = 'bitonic_sort'})
-      : super(definitionName: 'BitonicSort_W${toSort.length}') {
+      {required super.toSort,
+      super.isAscending,
+      super.name = 'bitonic_sort',
+      String? definitionName})
+      : super(
+            definitionName: definitionName ?? 'BitonicSort_W${toSort.length}') {
     clk = addInput('clk', clk);
     reset = addInput('reset', reset);
 

--- a/lib/src/summation/counter.dart
+++ b/lib/src/summation/counter.dart
@@ -67,6 +67,7 @@ class Counter extends SummationBase {
     super.width,
     super.saturates,
     super.name = 'counter',
+    super.definitionName,
   }) : super(initialValue: resetValue) {
     this.clk = addInput('clk', clk);
     this.reset = addInput('reset', reset);

--- a/lib/src/summation/gated_counter.dart
+++ b/lib/src/summation/gated_counter.dart
@@ -75,21 +75,21 @@ class GatedCounter extends Counter {
   /// than partitioned. If no [clkGatePartitionIndex] is provided, the counter
   /// will attempt to infer a good partition index based on the interfaces
   /// provided.
-  GatedCounter(
-    super.interfaces, {
-    required super.clk,
-    required super.reset,
-    super.restart,
-    super.resetValue,
-    super.maxValue,
-    super.minValue,
-    super.width,
-    super.saturates,
-    this.gateToggles = true,
-    ClockGateControlInterface? clockGateControlInterface,
-    int? clkGatePartitionIndex,
-    super.name,
-  })  : _providedClkGateParitionIndex = clkGatePartitionIndex,
+  GatedCounter(super.interfaces,
+      {required super.clk,
+      required super.reset,
+      super.restart,
+      super.resetValue,
+      super.maxValue,
+      super.minValue,
+      super.width,
+      super.saturates,
+      this.gateToggles = true,
+      ClockGateControlInterface? clockGateControlInterface,
+      int? clkGatePartitionIndex,
+      super.name,
+      super.definitionName})
+      : _providedClkGateParitionIndex = clkGatePartitionIndex,
         _clockGateControlInterface = clockGateControlInterface == null
             ? null
             : ClockGateControlInterface.clone(clockGateControlInterface) {

--- a/lib/src/summation/sum.dart
+++ b/lib/src/summation/sum.dart
@@ -61,15 +61,15 @@ class Sum extends SummationBase {
   /// and [underflowed] outputs can be used to determine if the sum is at the
   /// maximum, minimum, (would have) overflowed, or  (would have) underflowed,
   /// respectively.
-  Sum(
-    super.interfaces, {
-    dynamic initialValue = 0,
-    super.maxValue,
-    super.minValue,
-    super.width,
-    super.saturates,
-    super.name = 'sum',
-  }) : super(initialValue: initialValue) {
+  Sum(super.interfaces,
+      {dynamic initialValue = 0,
+      super.maxValue,
+      super.minValue,
+      super.width,
+      super.saturates,
+      super.name = 'sum',
+      super.definitionName})
+      : super(initialValue: initialValue) {
     addOutput('sum', width: width);
 
     var maxPosMagnitude = SummationBase.biggestVal(width);

--- a/lib/src/summation/summation_base.dart
+++ b/lib/src/summation/summation_base.dart
@@ -71,16 +71,17 @@ abstract class SummationBase extends Module {
   /// Sums the values across the provided [interfaces] within the bounds of the
   /// [saturates] behavior, [initialValue], [maxValue], and [minValue], with the
   /// specified [width], if provided.
-  SummationBase(
-    List<SumInterface> interfaces, {
-    dynamic initialValue = 0,
-    dynamic maxValue,
-    dynamic minValue = 0,
-    this.saturates = false,
-    int? width,
-    super.name,
-  }) : width =
-            _inferWidth([initialValue, maxValue, minValue], width, interfaces) {
+  SummationBase(List<SumInterface> interfaces,
+      {dynamic initialValue = 0,
+      dynamic maxValue,
+      dynamic minValue = 0,
+      this.saturates = false,
+      int? width,
+      super.name,
+      String? definitionName})
+      : width =
+            _inferWidth([initialValue, maxValue, minValue], width, interfaces),
+        super(definitionName: definitionName ?? 'SummationBase_') {
     if (interfaces.isEmpty) {
       throw RohdHclException('At least one interface must be provided.');
     }

--- a/lib/src/toggle_gate.dart
+++ b/lib/src/toggle_gate.dart
@@ -29,15 +29,16 @@ class ToggleGate extends Module {
   /// If no [clockGateControlIntf] is provided (left `null`), then a default
   /// clock gating implementation will be included for the internal sequential
   /// elements.
-  ToggleGate({
-    required Logic enable,
-    required Logic data,
-    required Logic clk,
-    required Logic reset,
-    dynamic resetValue,
-    ClockGateControlInterface? clockGateControlIntf,
-    super.name = 'toggle_gate',
-  }) : super(definitionName: 'ToggleGate_W${data.width}') {
+  ToggleGate(
+      {required Logic enable,
+      required Logic data,
+      required Logic clk,
+      required Logic reset,
+      dynamic resetValue,
+      ClockGateControlInterface? clockGateControlIntf,
+      super.name = 'toggle_gate',
+      String? definitionName})
+      : super(definitionName: definitionName ?? 'ToggleGate_W${data.width}') {
     enable = addInput('enable', enable);
     data = addInput('data', data, width: data.width);
     clk = addInput('clk', clk);

--- a/test/configurator_test.dart
+++ b/test/configurator_test.dart
@@ -71,7 +71,7 @@ void main() {
     test('should return RotateRight module when generate() with default value',
         () async {
       final rotate = RotateConfigurator();
-      expect(await rotate.generateSV(), contains('Rotate_right'));
+      expect(await rotate.generateSV(), contains('RotateRight'));
     });
 
     test('should return RotateLeft when invoke generate() with default value',
@@ -85,7 +85,7 @@ void main() {
       rotate.rotateWidthKnob.value = rotateAmountWidth;
 
       final sv = await rotate.generateSV();
-      expect(sv, contains('Rotate_left'));
+      expect(sv, contains('RotateLeft'));
       expect(sv, contains('input logic [9:0] original'));
       expect(sv, contains('input logic [4:0] rotate_amount'));
     });
@@ -168,11 +168,11 @@ void main() {
         'different multiplier selections', () async {
       final cfg = MultiplierConfigurator();
       final svDefault = await cfg.generateSV();
-      expect(svDefault, contains('NativeMultiplier'));
+      expect(svDefault, contains('Multiplier'));
       cfg.multiplierSelectKnob.compressionTreeMultiplierKnob.value = true;
 
       var sv = await cfg.generateSV();
-      expect(sv, contains('CompressionTreeMultiplier'));
+      expect(sv, contains('compressor'));
       cfg.multiplierSelectKnob.adderSelectionKnob.parallelPrefixAdderKnob
           .value = true;
       sv = await cfg.generateSV();
@@ -219,7 +219,7 @@ void main() {
 
       final sv = await cfg.generateSV();
 
-      expect(sv, contains('FloatingPointSquareRoot'));
+      expect(sv, contains('FloatingPointSqrtSimple'));
     });
   });
 


### PR DESCRIPTION
… to use plain schematic name

<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

It would be nice to be able to set the definition name of every component.  This PR allows for this by passing in an overriding
definitionName option for each component.

## Related Issue(s)

None

## Testing

Ran all tests.   HTML deployment will need live site testing.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Markdowns link to new plain HTML names.  Otherwise no documentation change is needed as these are additional, optional 
constructor arguments.
