### PR TITLE
fix just the deprecated Port calls to Logic.port

### DIFF
--- a/example/clock_gating_example.dart
+++ b/example/clock_gating_example.dart
@@ -102,7 +102,7 @@ Future<void> main({bool noPrint = false}) async {
     additionalPorts: [
       // we add an additional override port, for example, which is passed
       // automatically down the hierarchy
-      Port('anotherOverride'),
+      Logic.port('anotherOverride'),
     ],
     gatedClockGenerator: (intf, clk, enable) => CustomClockGateMacro(
       clk: clk,

--- a/lib/src/arithmetic/divider.dart
+++ b/lib/src/arithmetic/divider.dart
@@ -76,19 +76,19 @@ class MultiCycleDividerInterface extends PairInterface {
   /// A constructor for the divider interface.
   MultiCycleDividerInterface({this.dataWidth = 32})
       : super(portsFromProvider: [
-          Port('clk'),
-          Port('reset'),
-          Port('dividend', dataWidth),
-          Port('divisor', dataWidth),
-          Port('isSigned'),
-          Port('validIn'),
-          Port('readyOut'),
+          Logic.port('clk'),
+          Logic.port('reset'),
+          Logic.port('dividend', dataWidth),
+          Logic.port('divisor', dataWidth),
+          Logic.port('isSigned'),
+          Logic.port('validIn'),
+          Logic.port('readyOut'),
         ], portsFromConsumer: [
-          Port('quotient', dataWidth),
-          Port('remainder', dataWidth),
-          Port('divZero'),
-          Port('validOut'),
-          Port('readyIn'),
+          Logic.port('quotient', dataWidth),
+          Logic.port('remainder', dataWidth),
+          Logic.port('divZero'),
+          Logic.port('validOut'),
+          Logic.port('readyIn'),
         ]);
 
   /// A match constructor for the divider interface.
@@ -125,12 +125,14 @@ class MultiCycleDivider extends Module {
   late final int logDataWidth;
 
   /// The Divider module's constructor
-  MultiCycleDivider(MultiCycleDividerInterface interface)
+  MultiCycleDivider(MultiCycleDividerInterface interface,
+      {String? definitionName})
       : dataWidth = interface.dataWidth,
         logDataWidth = log2Ceil(interface.dataWidth),
         super(
             name: 'divider',
-            definitionName: 'MultiCycleDivider_W${interface.dataWidth}') {
+            definitionName:
+                definitionName ?? 'MultiCycleDivider_W${interface.dataWidth}') {
     intf = MultiCycleDividerInterface.match(interface)
       ..pairConnectIO(
         this,
@@ -152,6 +154,7 @@ class MultiCycleDivider extends Module {
     required Logic divisor,
     required Logic isSigned,
     required Logic readyOut,
+    String? definitionName,
   }) {
     assert(dividend.width == divisor.width,
         'Widths of all data signals do not match!');
@@ -164,7 +167,9 @@ class MultiCycleDivider extends Module {
     intf.divisor <= divisor;
     intf.isSigned <= isSigned;
     intf.readyOut <= readyOut;
-    return MultiCycleDivider(intf);
+    return MultiCycleDivider(intf,
+        definitionName:
+            definitionName ?? 'MultiCycleDivider_W${intf.dataWidth}');
   }
 
   void _build() {

--- a/lib/src/clock_gating.dart
+++ b/lib/src/clock_gating.dart
@@ -66,10 +66,10 @@ class ClockGateControlInterface extends PairInterface {
   ClockGateControlInterface({
     this.isPresent = true,
     this.hasEnableOverride = false,
-    List<Port>? additionalPorts,
+    List<Logic>? additionalPorts,
     this.gatedClockGenerator = defaultGenerateGatedClock,
   }) : super(portsFromProvider: [
-          if (hasEnableOverride) Port('en_override'),
+          if (hasEnableOverride) Logic.port('en_override'),
           ...?additionalPorts,
         ]);
 
@@ -205,14 +205,13 @@ class ClockGate extends Module {
   /// that synchronous resets work properly, and the [enable] is extended for an
   /// appropriate duration (if [delayControlledSignals]) to ensure proper
   /// capture of data.
-  ClockGate(
-    Logic freeClk, {
-    required Logic enable,
-    Logic? reset,
-    ClockGateControlInterface? controlIntf,
-    this.delayControlledSignals = false,
-    super.name = 'clock_gate',
-  }) {
+  ClockGate(Logic freeClk,
+      {required Logic enable,
+      Logic? reset,
+      ClockGateControlInterface? controlIntf,
+      this.delayControlledSignals = false,
+      super.name = 'clock_gate',
+      super.definitionName}) {
     // if this clock gating is not intended to be present, then just do nothing
     if (!(controlIntf?.isPresent ?? true)) {
       _controlIntf = null;

--- a/lib/src/interfaces/apb.dart
+++ b/lib/src/interfaces/apb.dart
@@ -208,40 +208,40 @@ class ApbInterface extends Interface<ApbDirection> {
     _validateParameters();
 
     setPorts([
-      Port('PCLK'),
-      Port('PRESETn'),
+      Logic.port('PCLK'),
+      Logic.port('PRESETn'),
     ], [
       ApbDirection.misc
     ]);
 
     setPorts([
-      Port('PADDR', addrWidth),
-      Port('PPROT', 3),
-      Port('PNSE'),
-      Port('PENABLE'),
-      Port('PWRITE'),
-      Port('PWDATA', dataWidth),
-      Port('PSTRB', dataWidth ~/ 8),
-      if (userReqWidth != 0) Port('PAUSER', userReqWidth),
-      if (userDataWidth != 0) Port('PWUSER', userDataWidth),
+      Logic.port('PADDR', addrWidth),
+      Logic.port('PPROT', 3),
+      Logic.port('PNSE'),
+      Logic.port('PENABLE'),
+      Logic.port('PWRITE'),
+      Logic.port('PWDATA', dataWidth),
+      Logic.port('PSTRB', dataWidth ~/ 8),
+      if (userReqWidth != 0) Logic.port('PAUSER', userReqWidth),
+      if (userDataWidth != 0) Logic.port('PWUSER', userDataWidth),
     ], [
       ApbDirection.fromRequester,
       ApbDirection.fromRequesterExceptSelect,
     ]);
 
     setPorts([
-      for (var i = 0; i < numSelects; i++) Port('PSEL$i'),
+      for (var i = 0; i < numSelects; i++) Logic.port('PSEL$i'),
     ], [
       ApbDirection.fromRequester,
     ]);
 
     setPorts([
-      Port('PREADY'),
-      Port('PRDATA', dataWidth),
-      if (includeSlvErr) Port('PSLVERR'),
-      Port('PWAKEUP'),
-      if (userDataWidth != 0) Port('PRUSER', userDataWidth),
-      if (userRespWidth != 0) Port('PBUSER', userRespWidth),
+      Logic.port('PREADY'),
+      Logic.port('PRDATA', dataWidth),
+      if (includeSlvErr) Logic.port('PSLVERR'),
+      Logic.port('PWAKEUP'),
+      if (userDataWidth != 0) Logic.port('PRUSER', userDataWidth),
+      if (userRespWidth != 0) Logic.port('PBUSER', userRespWidth),
     ], [
       ApbDirection.fromCompleter
     ]);

--- a/lib/src/interfaces/axi4.dart
+++ b/lib/src/interfaces/axi4.dart
@@ -40,8 +40,8 @@ class Axi4SystemInterface extends Interface<Axi4Direction> {
   /// Construct a new instance of an AXI4 interface.
   Axi4SystemInterface() {
     setPorts([
-      Port('ACLK'),
-      Port('ARESETn'),
+      Logic.port('ACLK'),
+      Logic.port('ARESETn'),
     ], [
       Axi4Direction.misc,
     ]);
@@ -212,31 +212,31 @@ class Axi4ReadInterface extends Interface<Axi4Direction> {
     _validateParameters();
 
     setPorts([
-      if (idWidth > 0) Port('ARID', idWidth),
-      Port('ARADDR', addrWidth),
-      if (lenWidth > 0) Port('ARLEN', lenWidth),
-      if (sizeWidth > 0) Port('ARSIZE', sizeWidth),
-      if (burstWidth > 0) Port('ARBURST', burstWidth),
-      if (useLock) Port('ARLOCK'),
-      if (cacheWidth > 0) Port('ARCACHE', cacheWidth),
-      Port('ARPROT', protWidth),
-      if (qosWidth > 0) Port('ARQOS', qosWidth),
-      if (regionWidth > 0) Port('ARREGION', regionWidth),
-      if (aruserWidth > 0) Port('ARUSER', aruserWidth),
-      Port('ARVALID'),
-      Port('RREADY'),
+      if (idWidth > 0) Logic.port('ARID', idWidth),
+      Logic.port('ARADDR', addrWidth),
+      if (lenWidth > 0) Logic.port('ARLEN', lenWidth),
+      if (sizeWidth > 0) Logic.port('ARSIZE', sizeWidth),
+      if (burstWidth > 0) Logic.port('ARBURST', burstWidth),
+      if (useLock) Logic.port('ARLOCK'),
+      if (cacheWidth > 0) Logic.port('ARCACHE', cacheWidth),
+      Logic.port('ARPROT', protWidth),
+      if (qosWidth > 0) Logic.port('ARQOS', qosWidth),
+      if (regionWidth > 0) Logic.port('ARREGION', regionWidth),
+      if (aruserWidth > 0) Logic.port('ARUSER', aruserWidth),
+      Logic.port('ARVALID'),
+      Logic.port('RREADY'),
     ], [
       Axi4Direction.fromMain,
     ]);
 
     setPorts([
-      if (idWidth > 0) Port('RID', idWidth),
-      Port('RDATA', dataWidth),
-      if (rrespWidth > 0) Port('RRESP', rrespWidth),
-      if (useLast) Port('RLAST'),
-      if (ruserWidth > 0) Port('RUSER', ruserWidth),
-      Port('RVALID'),
-      Port('ARREADY'),
+      if (idWidth > 0) Logic.port('RID', idWidth),
+      Logic.port('RDATA', dataWidth),
+      if (rrespWidth > 0) Logic.port('RRESP', rrespWidth),
+      if (useLast) Logic.port('RLAST'),
+      if (ruserWidth > 0) Logic.port('RUSER', ruserWidth),
+      Logic.port('RVALID'),
+      Logic.port('ARREADY'),
     ], [
       Axi4Direction.fromSubordinate,
     ]);
@@ -472,35 +472,35 @@ class Axi4WriteInterface extends Interface<Axi4Direction> {
     _validateParameters();
 
     setPorts([
-      if (idWidth > 0) Port('AWID', idWidth),
-      Port('AWADDR', addrWidth),
-      if (lenWidth > 0) Port('AWLEN', lenWidth),
-      if (sizeWidth > 0) Port('AWSIZE', sizeWidth),
-      if (burstWidth > 0) Port('AWBURST', burstWidth),
-      if (useLock) Port('AWLOCK'),
-      if (cacheWidth > 0) Port('AWCACHE', cacheWidth),
-      Port('AWPROT', protWidth),
-      if (qosWidth > 0) Port('AWQOS', qosWidth),
-      if (regionWidth > 0) Port('AWREGION', regionWidth),
-      if (awuserWidth > 0) Port('AWUSER', awuserWidth),
-      Port('AWVALID'),
-      Port('WDATA', dataWidth),
-      Port('WSTRB', strbWidth),
-      Port('WLAST'),
-      if (wuserWidth > 0) Port('WUSER', wuserWidth),
-      Port('WVALID'),
-      Port('BREADY'),
+      if (idWidth > 0) Logic.port('AWID', idWidth),
+      Logic.port('AWADDR', addrWidth),
+      if (lenWidth > 0) Logic.port('AWLEN', lenWidth),
+      if (sizeWidth > 0) Logic.port('AWSIZE', sizeWidth),
+      if (burstWidth > 0) Logic.port('AWBURST', burstWidth),
+      if (useLock) Logic.port('AWLOCK'),
+      if (cacheWidth > 0) Logic.port('AWCACHE', cacheWidth),
+      Logic.port('AWPROT', protWidth),
+      if (qosWidth > 0) Logic.port('AWQOS', qosWidth),
+      if (regionWidth > 0) Logic.port('AWREGION', regionWidth),
+      if (awuserWidth > 0) Logic.port('AWUSER', awuserWidth),
+      Logic.port('AWVALID'),
+      Logic.port('WDATA', dataWidth),
+      Logic.port('WSTRB', strbWidth),
+      Logic.port('WLAST'),
+      if (wuserWidth > 0) Logic.port('WUSER', wuserWidth),
+      Logic.port('WVALID'),
+      Logic.port('BREADY'),
     ], [
       Axi4Direction.fromMain,
     ]);
 
     setPorts([
-      if (idWidth > 0) Port('BID', idWidth),
-      if (brespWidth > 0) Port('BRESP', brespWidth),
-      if (buserWidth > 0) Port('BUSER', buserWidth),
-      Port('BVALID'),
-      Port('AWREADY'),
-      Port('WREADY'),
+      if (idWidth > 0) Logic.port('BID', idWidth),
+      if (brespWidth > 0) Logic.port('BRESP', brespWidth),
+      if (buserWidth > 0) Logic.port('BUSER', buserWidth),
+      Logic.port('BVALID'),
+      Logic.port('AWREADY'),
+      Logic.port('WREADY'),
     ], [
       Axi4Direction.fromSubordinate,
     ]);

--- a/lib/src/interfaces/spi.dart
+++ b/lib/src/interfaces/spi.dart
@@ -28,9 +28,13 @@ class SpiInterface extends PairInterface {
 
   /// Creates a new [SpiInterface].
   SpiInterface({this.dataLength = 1})
-      : super(
-            portsFromConsumer: [Port('MISO')],
-            portsFromProvider: [Port('MOSI'), Port('CSB'), Port('SCLK')]);
+      : super(portsFromConsumer: [
+          Logic.port('MISO')
+        ], portsFromProvider: [
+          Logic.port('MOSI'),
+          Logic.port('CSB'),
+          Logic.port('SCLK')
+        ]);
 
   /// Clones this [SpiInterface].
   SpiInterface.clone(SpiInterface super.otherInterface)

--- a/lib/src/memory/csr/csr_backdoor.dart
+++ b/lib/src/memory/csr/csr_backdoor.dart
@@ -62,8 +62,8 @@ class CsrBackdoorInterface extends Interface<CsrBackdoorPortGroup> {
 
     if (hasWrite) {
       setPorts([
-        Port('${config.name}_wrEn'),
-        Port('${config.name}_wrData', dataWidth),
+        Logic.port('${config.name}_wrEn'),
+        Logic.port('${config.name}_wrData', dataWidth),
       ], [
         CsrBackdoorPortGroup.write,
       ]);

--- a/lib/src/memory/memory.dart
+++ b/lib/src/memory/memory.dart
@@ -32,7 +32,7 @@ class MaskedDataPortInterface extends DataPortInterface {
       throw RohdHclException('The data width must be byte-granularity');
     }
     setPorts([
-      Port('mask', dataWidth ~/ 8),
+      Logic.port('mask', dataWidth ~/ 8),
     ], [
       DataPortGroup.control
     ]);
@@ -66,14 +66,14 @@ class DataPortInterface extends Interface<DataPortGroup> {
   /// interacting with a memory in either the read or write direction.
   DataPortInterface(this.dataWidth, this.addrWidth) {
     setPorts([
-      Port('en'),
-      Port('addr', addrWidth),
+      Logic.port('en'),
+      Logic.port('addr', addrWidth),
     ], [
       DataPortGroup.control
     ]);
 
     setPorts([
-      Port('data', dataWidth),
+      Logic.port('data', dataWidth),
     ], [
       DataPortGroup.data
     ]);

--- a/lib/src/summation/sum_interface.dart
+++ b/lib/src/summation/sum_interface.dart
@@ -66,8 +66,8 @@ class SumInterface extends PairInterface {
       throw RohdHclException('Width must be positive.');
     }
     setPorts([
-      if (fixedAmount == null) Port('amount', this.width),
-      if (hasEnable) Port('enable'),
+      if (fixedAmount == null) Logic.port('amount', this.width),
+      if (hasEnable) Logic.port('enable'),
     ], [
       PairDirection.fromProvider
     ]);

--- a/test/clock_gating_test.dart
+++ b/test/clock_gating_test.dart
@@ -53,7 +53,7 @@ class CustomClockGateControlInterface extends ClockGateControlInterface {
       : super(
             hasEnableOverride: true,
             additionalPorts: [
-              Port('anotherOverride'),
+              Logic.port('anotherOverride'),
             ],
             gatedClockGenerator: (intf, clk, enable) => CustomClockGateMacro(
                   clk: clk,


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Fix deprecated Port call to Logic.port

## Related Issue(s)

None

## Testing

Ran dart test

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No change needed.
