### PR TITLE
bug in DAZ computing effectiveSubtraction incorrectly

### DIFF
--- a/lib/src/arithmetic/floating_point/floating_point_adder_dualpath.dart
+++ b/lib/src/arithmetic/floating_point/floating_point_adder_dualpath.dart
@@ -62,12 +62,6 @@ class FloatingPointAdderDualPath<FpTypeIn extends FloatingPoint,
     }
 
     // Seidel: S.EFF = effectiveSubtraction.
-    final effectiveSubtraction =
-        (a.sign ^ b.sign ^ (subtract ?? Const(0))).named('effSubtraction');
-    final isNaN = (a.isNaN |
-            b.isNaN |
-            (a.isAnInfinity & b.isAnInfinity & effectiveSubtraction))
-        .named('isNaN');
     final isInf = (a.isAnInfinity | b.isAnInfinity).named('isInf');
 
     final exponentSubtractor = OnesComplementAdder(
@@ -80,6 +74,12 @@ class FloatingPointAdderDualPath<FpTypeIn extends FloatingPoint,
     final fa = a.resolveSubNormalAsZero();
     final fb = b.resolveSubNormalAsZero();
 
+    final effectiveSubtraction =
+        (fa.sign ^ fb.sign ^ (subtract ?? Const(0))).named('effSubtraction');
+    final isNaN = (a.isNaN |
+            b.isNaN |
+            (a.isAnInfinity & b.isAnInfinity & effectiveSubtraction))
+        .named('isNaN');
     // Seidel: (sl, el, fl) = larger; (ss, es, fs) = smaller.
     final swapper = FloatingPointConditionalSwap(fa, fb, signDelta);
     final larger = swapper.outA;

--- a/lib/src/arithmetic/floating_point/floating_point_adder_singlepath.dart
+++ b/lib/src/arithmetic/floating_point/floating_point_adder_singlepath.dart
@@ -74,7 +74,7 @@ class FloatingPointAdderSinglePath<FpTypeIn extends FloatingPoint,
     final largerExplicit = swapper.outMetaA!;
     final smallerExplicit = swapper.outMetaB!;
 
-    final effectiveSubtraction = (a.sign ^ b.sign).named('effSubtraction');
+    final effectiveSubtraction = (fa.sign ^ fb.sign).named('effSubtraction');
 
     final isInf = (larger.isAnInfinity | smaller.isAnInfinity).named('isInf');
     final isNaN = (larger.isNaN |

--- a/test/arithmetic/floating_point/floating_point_adder_dualpath_test.dart
+++ b/test/arithmetic/floating_point/floating_point_adder_dualpath_test.dart
@@ -29,7 +29,7 @@ void main() {
     FloatingPointValuePopulator fpvPopulator() => FloatingPointValue.populator(
         exponentWidth: exponentWidth, mantissaWidth: mantissaWidth);
     test('FP: dual-path adder N path singleton', () async {
-      final fv1 = fpvPopulator().ofInts(0, 0);
+      final fv1 = fpvPopulator().ofInts(0, 0, sign: true);
       final fv2 = fpvPopulator().ofInts(0, 1, sign: true);
 
       fp1.put(fv1);
@@ -59,20 +59,24 @@ void main() {
       final largestMantissa = pow(2, mantissaWidth).toInt() - 1;
       for (var e1 = 0; e1 <= largestExponent; e1++) {
         for (var e2 = 0; e2 <= largestExponent; e2++) {
-          if ((e1 - e2).abs() < 2) {
-            for (var m1 = 0; m1 <= largestMantissa; m1++) {
-              final fv1 = fpvPopulator().ofInts(e1, m1);
-              for (var m2 = 0; m2 <= largestMantissa; m2++) {
-                final fv2 = fpvPopulator().ofInts(e2, m2, sign: true);
+          for (final sign1 in [false, true]) {
+            for (final sign2 in [false, true]) {
+              if ((sign1 ^ sign2) && (e1 - e2).abs() < 2) {
+                for (var m1 = 0; m1 <= largestMantissa; m1++) {
+                  final fv1 = fpvPopulator().ofInts(e1, m1, sign: sign1);
+                  for (var m2 = 0; m2 <= largestMantissa; m2++) {
+                    final fv2 = fpvPopulator().ofInts(e2, m2, sign: sign2);
 
-                fp1.put(fv1);
-                fp2.put(fv2);
-                // No rounding
-                final expected = fpvPopulator()
-                    .ofDoubleUnrounded(fv1.toDouble() + fv2.toDouble());
+                    fp1.put(fv1);
+                    fp2.put(fv2);
+                    // No rounding
+                    final expected = fpvPopulator()
+                        .ofDoubleUnrounded(fv1.toDouble() + fv2.toDouble());
 
-                final computed = adder.sum.floatingPointValue;
-                expect(computed, equals(expected));
+                    final computed = adder.sum.floatingPointValue;
+                    expect(computed, equals(expected));
+                  }
+                }
               }
             }
           }
@@ -125,25 +129,27 @@ void main() {
       fp2.put(0);
       final adder = FloatingPointAdderDualPath(fp1, fp2);
 
-      for (final sign in [false, true]) {
-        for (var e1 = 0; e1 < expLimit; e1++) {
-          for (var e2 = 0; e2 < expLimit; e2++) {
-            if (!sign || (e1 - e2).abs() >= 2) {
-              for (var m1 = 0; m1 < mantLimit; m1++) {
-                final fv1 = fpvPopulator().ofInts(e1, m1);
-                for (var m2 = 0; m2 < mantLimit; m2++) {
-                  final fv2 = fpvPopulator().ofInts(e2, m2, sign: sign);
+      for (var e1 = 0; e1 < expLimit; e1++) {
+        for (var e2 = 0; e2 < expLimit; e2++) {
+          for (final sign1 in [false, true]) {
+            for (final sign2 in [false, true]) {
+              if ((sign1 == sign2) || (e1 - e2).abs() >= 2) {
+                for (var m1 = 0; m1 < mantLimit; m1++) {
+                  final fv1 = fpvPopulator().ofInts(e1, m1, sign: sign1);
+                  for (var m2 = 0; m2 < mantLimit; m2++) {
+                    final fv2 = fpvPopulator().ofInts(e2, m2, sign: sign2);
 
-                  fp1.put(fv1);
-                  fp2.put(fv2);
-                  final expected = fv1 + fv2;
-                  final computed = adder.sum.floatingPointValue;
-                  expect(computed, equals(expected), reason: '''
+                    fp1.put(fv1);
+                    fp2.put(fv2);
+                    final expected = fv1 + fv2;
+                    final computed = adder.sum.floatingPointValue;
+                    expect(computed, equals(expected), reason: '''
       $fv1 (${fv1.toDouble()})\t+
       $fv2 (${fv2.toDouble()})\t=
       $computed (${computed.toDouble()})\tcomputed
       $expected (${expected.toDouble()})\texpected
 ''');
+                  }
                 }
               }
             }
@@ -320,54 +326,58 @@ void main() {
             subNormalAsZero: subNormalAsZero);
 
     test('FP: dual-path adder DAZ/FTZ test singleton', () {
-      for (final subtract in [0, 1]) {
-        for (final daz1 in [false, true]) {
-          for (final daz2 in [false, true]) {
-            for (final ftz in [false, true]) {
-              final fp1 = fpConstructor(subNormalAsZero: daz1);
-              final fp2 = fpConstructor(subNormalAsZero: daz2);
-              final fpOut = fpConstructor(subNormalAsZero: ftz);
+      for (final daz1 in [false]) {
+        for (final daz2 in [true]) {
+          for (final ftz in [false]) {
+            final fp1 = fpConstructor(subNormalAsZero: daz1);
+            final fp2 = fpConstructor(subNormalAsZero: daz2);
+            final fpOut = fpConstructor(subNormalAsZero: ftz);
 
-              fp1.put(0);
-              fp2.put(0);
-              final adder = FloatingPointAdderDualPath(fp1, fp2, outSum: fpOut);
-              const e1 = 0;
-              const m1 = 6;
-              const e2 = 0;
-              const m2 = 7;
+            fp1.put(0);
+            fp2.put(0);
+            const e1 = 0;
+            const m1 = 1;
+            const e2 = 0;
+            const m2 = 0;
 
-              final fv1 = fpvPopulator(subNormalAsZero: daz1).ofInts(e1, m1);
-              final fv2 = fpvPopulator(subNormalAsZero: daz2)
-                  .ofInts(e2, m2, sign: subtract == 1);
+            for (final sign1 in [true]) {
+              final fv1 = fpvPopulator(subNormalAsZero: daz1)
+                  .ofInts(e1, m1, sign: sign1);
+              for (final sign2 in [true]) {
+                final fv2 = fpvPopulator(subNormalAsZero: daz2)
+                    .ofInts(e2, m2, sign: sign2);
 
-              fp1.put(fv1.value);
-              fp2.put(fv2.value);
-              // This will interpret the adder.sum value as
-              // a FloatingPointValue without the sumNormalAsZero
-              // property set, so we can validate it is indeed zero.
-              final computed = fpvPopulator()
-                  .ofFloatingPointValue(adder.sum.floatingPointValue);
+                fp1.put(fv1.value);
+                fp2.put(fv2.value);
+                final adder =
+                    FloatingPointAdderDualPath(fp1, fp2, outSum: fpOut);
+                // This will interpret the adder.sum value as
+                // a FloatingPointValue without the sumNormalAsZero
+                // property set, so we can validate it is indeed zero.
+                final computed = fpvPopulator()
+                    .ofFloatingPointValue(adder.sum.floatingPointValue);
 
-              final dbl = fv1.toDouble() + fv2.toDouble();
+                final dbl = fv1.toDouble() + fv2.toDouble();
 
-              final expectedNoRound =
-                  fpvPopulator(subNormalAsZero: ftz).ofDoubleUnrounded(dbl);
-              final expectedRound =
-                  fpvPopulator(subNormalAsZero: ftz).ofDouble(dbl);
+                final expectedNoRound =
+                    fpvPopulator(subNormalAsZero: ftz).ofDoubleUnrounded(dbl);
+                final expectedRound =
+                    fpvPopulator(subNormalAsZero: ftz).ofDouble(dbl);
 
-              final expected =
-                  (((fv1.exponent.toInt() - fv2.exponent.toInt()).abs() < 2) &
-                          (fv1.sign.toInt() != fv2.sign.toInt()))
-                      ? expectedNoRound
-                      : expectedRound;
-              expect(computed.isNaN, equals(expected.isNaN));
-              expect(computed, equals(expected), reason: '''
+                final expected =
+                    (((fv1.exponent.toInt() - fv2.exponent.toInt()).abs() < 2) &
+                            (fv1.sign.toInt() != fv2.sign.toInt()))
+                        ? expectedNoRound
+                        : expectedRound;
+                expect(computed.isNaN, equals(expected.isNaN));
+                expect(computed, equals(expected), reason: '''
       daz1: $daz1, daz2: $daz2    ftz: $ftz
       $fv1 (${fv1.toDouble()})\t+
       $fv2 (${fv2.toDouble()})\t=
       $computed (${computed.toDouble()})\tcomputed
       $expected (${expected.toDouble()})\texpected
 ''');
+              }
             }
           }
         }
@@ -375,56 +385,58 @@ void main() {
     });
 
     test('FP: dual-path adder DAZ/FTZ test exhaustive', () {
-      for (final subtract in [0, 1]) {
-        for (final daz1 in [false, true]) {
-          for (final daz2 in [false, true]) {
-            for (final ftz in [false, true]) {
-              final fp1 = fpConstructor(subNormalAsZero: daz1);
-              final fp2 = fpConstructor(subNormalAsZero: daz2);
-              final fpOut = fpConstructor(subNormalAsZero: ftz);
+      for (final daz1 in [false, true]) {
+        for (final daz2 in [false, true]) {
+          for (final ftz in [false, true]) {
+            final fp1 = fpConstructor(subNormalAsZero: daz1);
+            final fp2 = fpConstructor(subNormalAsZero: daz2);
+            final fpOut = fpConstructor(subNormalAsZero: ftz);
 
-              fp1.put(0);
-              fp2.put(0);
-              final adder = FloatingPointAdderDualPath(fp1, fp2, outSum: fpOut);
-              for (var e1 = 0; e1 < expLimit; e1++) {
-                for (var m1 = 0; m1 < mantLimit; m1++) {
-                  final fv1 =
-                      fpvPopulator(subNormalAsZero: daz1).ofInts(e1, m1);
+            fp1.put(0);
+            fp2.put(0);
+            final adder = FloatingPointAdderDualPath(fp1, fp2, outSum: fpOut);
+            for (var e1 = 0; e1 < expLimit; e1++) {
+              for (var m1 = 0; m1 < mantLimit; m1++) {
+                for (final sign1 in [false, true]) {
+                  final fv1 = fpvPopulator(subNormalAsZero: daz1)
+                      .ofInts(e1, m1, sign: sign1);
                   for (var e2 = 0; e2 < expLimit; e2++) {
                     for (var m2 = 0; m2 < mantLimit; m2++) {
-                      final fv2 = fpvPopulator(subNormalAsZero: daz2)
-                          .ofInts(e2, m2, sign: subtract == 1);
+                      for (final sign2 in [false, true]) {
+                        final fv2 = fpvPopulator(subNormalAsZero: daz2)
+                            .ofInts(e2, m2, sign: sign2);
 
-                      fp1.put(fv1.value);
-                      fp2.put(fv2.value);
-                      // This will interpret the adder.sum value as
-                      // a FloatingPointValue without the sumNormalAsZero
-                      // property set, so we can validate it is indeed zero.
-                      final computed = fpvPopulator()
-                          .ofFloatingPointValue(adder.sum.floatingPointValue);
+                        fp1.put(fv1.value);
+                        fp2.put(fv2.value);
+                        // This will interpret the adder.sum value as
+                        // a FloatingPointValue without the sumNormalAsZero
+                        // property set, so we can validate it is indeed zero.
+                        final computed = fpvPopulator()
+                            .ofFloatingPointValue(adder.sum.floatingPointValue);
 
-                      final dbl = fv1.toDouble() + fv2.toDouble();
+                        final dbl = fv1.toDouble() + fv2.toDouble();
 
-                      final expectedNoRound = fpvPopulator(subNormalAsZero: ftz)
-                          .ofDoubleUnrounded(dbl);
-                      final expectedRound =
-                          fpvPopulator(subNormalAsZero: ftz).ofDouble(dbl);
-
-                      final expected =
-                          (((fv1.exponent.toInt() - fv2.exponent.toInt())
-                                          .abs() <
-                                      2) &
-                                  (fv1.sign.toInt() != fv2.sign.toInt()))
-                              ? expectedNoRound
-                              : expectedRound;
-                      expect(computed.isNaN, equals(expected.isNaN));
-                      expect(computed, equals(expected), reason: '''
+                        final expectedNoRound =
+                            fpvPopulator(subNormalAsZero: ftz)
+                                .ofDoubleUnrounded(dbl);
+                        final expectedRound =
+                            fpvPopulator(subNormalAsZero: ftz).ofDouble(dbl);
+                        final expected =
+                            (((fv1.exponent.toInt() - fv2.exponent.toInt())
+                                            .abs() <
+                                        2) &
+                                    (fv1.sign.toInt() != fv2.sign.toInt()))
+                                ? expectedNoRound
+                                : expectedRound;
+                        expect(computed.isNaN, equals(expected.isNaN));
+                        expect(computed, equals(expected), reason: '''
       daz1: $daz1, daz2: $daz2, ftz: $ftz
       $fv1 (${fv1.toDouble()})\t+
       $fv2 (${fv2.toDouble()})\t=
       $computed (${computed.toDouble()})\tcomputed
       $expected (${expected.toDouble()})\texpected
 ''');
+                      }
                     }
                   }
                 }

--- a/test/arithmetic/floating_point/floating_point_adder_singlepath_test.dart
+++ b/test/arithmetic/floating_point/floating_point_adder_singlepath_test.dart
@@ -157,7 +157,7 @@ void main() {
             mantissaWidth: mantissaWidth,
             subNormalAsZero: subNormalAsZero);
 
-    test('FP: dual-path adder DAZ/FTZ test singleton', () {
+    test('FP: single-path adder DAZ/FTZ test singleton', () {
       for (final subtract in [0, 1]) {
         for (final daz1 in [false, true]) {
           for (final daz2 in [false, true]) {
@@ -189,10 +189,8 @@ void main() {
 
               final dbl = fv1.toDouble() + fv2.toDouble();
 
-              final expectedRound =
-                  fpvPopulator(subNormalAsZero: ftz).ofDouble(dbl);
+              final expected = fpvPopulator(subNormalAsZero: ftz).ofDouble(dbl);
 
-              final expected = expectedRound;
               expect(computed.isNaN, equals(expected.isNaN));
               expect(computed, equals(expected), reason: '''
       daz1: $daz1, daz2: $daz2    ftz: $ftz
@@ -239,10 +237,9 @@ void main() {
 
                       final dbl = fv1.toDouble() + fv2.toDouble();
 
-                      final expectedRound =
+                      final expected =
                           fpvPopulator(subNormalAsZero: ftz).ofDouble(dbl);
 
-                      final expected = expectedRound;
                       expect(computed.isNaN, equals(expected.isNaN));
                       expect(computed, equals(expected), reason: '''
       daz1: $daz1, daz2: $daz2, ftz: $ftz
@@ -1115,5 +1112,75 @@ void main() {
 ''');
       }
     }
+  });
+
+  group('FP: single-path adder DAZ/FTZ tests', () {
+    const exponentWidth = 3;
+    const mantissaWidth = 3;
+    final expLimit = pow(2, exponentWidth).toInt();
+    final mantLimit = pow(2, mantissaWidth).toInt();
+    FloatingPoint fpConstructor({bool subNormalAsZero = false}) =>
+        FloatingPoint(
+            exponentWidth: exponentWidth,
+            mantissaWidth: mantissaWidth,
+            subNormalAsZero: subNormalAsZero);
+    FloatingPointValuePopulator fpvPopulator({bool subNormalAsZero = false}) =>
+        FloatingPointValue.populator(
+            exponentWidth: exponentWidth,
+            mantissaWidth: mantissaWidth,
+            subNormalAsZero: subNormalAsZero);
+    test('FP: single-path adder DAZ/FTZ test exhaustive', () {
+      for (final daz1 in [false, true]) {
+        for (final daz2 in [false, true]) {
+          for (final ftz in [false, true]) {
+            final fp1 = fpConstructor(subNormalAsZero: daz1);
+            final fp2 = fpConstructor(subNormalAsZero: daz2);
+            final fpOut = fpConstructor(subNormalAsZero: ftz);
+
+            fp1.put(0);
+            fp2.put(0);
+            final adder = FloatingPointAdderSinglePath(fp1, fp2, outSum: fpOut);
+            for (var e1 = 0; e1 < expLimit; e1++) {
+              for (var m1 = 0; m1 < mantLimit; m1++) {
+                for (final sign1 in [false, true]) {
+                  final fv1 = fpvPopulator(subNormalAsZero: daz1)
+                      .ofInts(e1, m1, sign: sign1);
+                  for (var e2 = 0; e2 < expLimit; e2++) {
+                    for (var m2 = 0; m2 < mantLimit; m2++) {
+                      for (final sign2 in [false, true]) {
+                        final fv2 = fpvPopulator(subNormalAsZero: daz2)
+                            .ofInts(e2, m2, sign: sign2);
+
+                        fp1.put(fv1.value);
+                        fp2.put(fv2.value);
+                        // This will interpret the adder.sum value as
+                        // a FloatingPointValue without the sumNormalAsZero
+                        // property set, so we can validate it is indeed zero.
+                        final computed = fpvPopulator()
+                            .ofFloatingPointValue(adder.sum.floatingPointValue);
+
+                        final dbl = fv1.toDouble() + fv2.toDouble();
+
+                        final expectedRound =
+                            fpvPopulator(subNormalAsZero: ftz).ofDouble(dbl);
+                        final expected = expectedRound;
+                        expect(computed.isNaN, equals(expected.isNaN));
+                        expect(computed, equals(expected), reason: '''
+      daz1: $daz1, daz2: $daz2, ftz: $ftz
+      $fv1 (${fv1.toDouble()})\t+
+      $fv2 (${fv2.toDouble()})\t=
+      $computed (${computed.toDouble()})\tcomputed
+      $expected (${expected.toDouble()})\texpected
+''');
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    });
   });
 }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Fixed a bug in the FloatingPoint Adders regarding DAZ of negative subnormals being converted to zero, but sign treated as 1.

## Related Issue(s)

Fix #238.

## Testing

Improved tests to sweep signs on both operands and added DAZ/FTZ tests for FloatingPointSinglePathAdder as well.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No.
