### PR TITLE
fix count internal naming

### DIFF
--- a/lib/src/count.dart
+++ b/lib/src/count.dart
@@ -39,7 +39,7 @@ class Count extends Module {
     bus = addInput('bus', bus, width: bus.width);
     Logic count = Const(0, width: max(1, log2Ceil(bus.width + 1)));
     for (var i = 0; i < bus.width; i++) {
-      count += (countOne ? bus[i] : ~bus[i]).zeroExtend(count.width);
+      count = (count + (countOne ? bus[i] : ~bus[i]).zeroExtend(count.width)).named('count_$i');
     }
     _output =
         addOutput('count${countOne ? "One" : "Zero"}', width: count.width);


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

The module `Count` was creating ever longer names internally because of the use of `+=`.  By reverting to  using `= count +incr`, we can name the RHS and get clean internal naming.  This only happens because we cannot use a two-input add, due to the need for handling the carry (lint issue).

## Related Issue(s)

None.

## Testing

Tested Verilog output to make sure it was clean visually.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No need for documentation update.
