### PR TITLE
update Interface classes to include the required clone() method.

### DIFF
--- a/example/clock_gating_example.dart
+++ b/example/clock_gating_example.dart
@@ -30,8 +30,7 @@ class CounterWithSimpleClockGate extends Module {
     reset = addInput('reset', reset);
 
     // We clone the incoming interface, receiving all config information with it
-    cgIntf = ClockGateControlInterface.clone(cgIntf)
-      ..pairConnectIO(this, cgIntf, PairRole.consumer);
+    cgIntf = cgIntf.clone()..pairConnectIO(this, cgIntf, PairRole.consumer);
 
     // In this case, we want to enable the clock any time we're incrementing
     final clkEnable = incr;

--- a/lib/src/arithmetic/divider.dart
+++ b/lib/src/arithmetic/divider.dart
@@ -92,6 +92,7 @@ class MultiCycleDividerInterface extends PairInterface {
         ]);
 
   /// A match constructor for the divider interface.
+  @Deprecated('Use clone() instead.')
   MultiCycleDividerInterface.match(MultiCycleDividerInterface other)
       : this(dataWidth: other.dataWidth);
 

--- a/lib/src/arithmetic/divider.dart
+++ b/lib/src/arithmetic/divider.dart
@@ -94,6 +94,11 @@ class MultiCycleDividerInterface extends PairInterface {
   /// A match constructor for the divider interface.
   MultiCycleDividerInterface.match(MultiCycleDividerInterface other)
       : this(dataWidth: other.dataWidth);
+
+  /// Clones this [MultiCycleDividerInterface].
+  @override
+  MultiCycleDividerInterface clone() =>
+      MultiCycleDividerInterface(dataWidth: dataWidth);
 }
 
 /// The Divider module definition.

--- a/lib/src/arithmetic/divider.dart
+++ b/lib/src/arithmetic/divider.dart
@@ -141,7 +141,7 @@ class MultiCycleDivider extends Module {
         super(
             definitionName:
                 definitionName ?? 'MultiCycleDivider_W${interface.dataWidth}') {
-    intf = MultiCycleDividerInterface.match(interface)
+    intf = interface.clone()
       ..pairConnectIO(
         this,
         interface,

--- a/lib/src/arithmetic/multiplier_components/partial_product_generator.dart
+++ b/lib/src/arithmetic/multiplier_components/partial_product_generator.dart
@@ -19,12 +19,13 @@ class SignBit extends Logic {
   bool inverted = false;
 
   /// Construct a sign bit to store
-  SignBit(Logic inl, {this.inverted = false})
-      : super(name: '${inl.name}_signbit', naming: Naming.mergeable) {
+  SignBit(Logic inl, {this.inverted = false, String? name})
+      : super(name: name ?? inl.name, naming: Naming.mergeable) {
     this <= inl;
   }
   @override
-  SignBit clone({String? name = 'clone'}) => SignBit(this, inverted: inverted);
+  SignBit clone({String? name}) =>
+      SignBit(this, inverted: inverted, name: name);
 }
 
 /// A [PartialProductArray] is a class that holds a set of partial products

--- a/lib/src/arithmetic/multiplier_components/partial_product_generator.dart
+++ b/lib/src/arithmetic/multiplier_components/partial_product_generator.dart
@@ -23,6 +23,8 @@ class SignBit extends Logic {
       : super(name: '${inl.name}_signbit', naming: Naming.mergeable) {
     this <= inl;
   }
+  @override
+  SignBit clone({String? name = 'clone'}) => SignBit(this, inverted: inverted);
 }
 
 /// A [PartialProductArray] is a class that holds a set of partial products

--- a/lib/src/clock_gating.dart
+++ b/lib/src/clock_gating.dart
@@ -29,7 +29,6 @@ class ClockGateControlInterface extends PairInterface {
   final bool isPresent;
 
   /// Capture the additional ports that are part of this interface, if any.
-  @protected
   late final List<Logic>? additionalPorts;
 
   /// A default implementation for clock gating, effectively just an AND of the

--- a/lib/src/clock_gating.dart
+++ b/lib/src/clock_gating.dart
@@ -88,7 +88,7 @@ class ClockGateControlInterface extends PairInterface {
   ///
   /// If a [gatedClockGenerator] is provided, then it will override the
   /// [gatedClockGenerator] function from [`otherInterface`].
-  @Deprecated('Use Instance-based `clone({String name = "clone"})` instead.')
+  @Deprecated('Use Instance-based `clone()` instead.')
   ClockGateControlInterface.clone(
     ClockGateControlInterface super.otherInterface, {
     bool? isPresent,
@@ -108,14 +108,13 @@ class ClockGateControlInterface extends PairInterface {
   /// to replicate interface configuration through hierarchies to carry
   /// configuration information.
   @override
-  ClockGateControlInterface clone({String name = 'clone'}) =>
-      ClockGateControlInterface(
-          isPresent: isPresent,
-          hasEnableOverride: hasEnableOverride,
-          additionalPorts: (additionalPorts != null)
-              ? [for (final p in additionalPorts!) p.clone(name: p.name)]
-              : null,
-          gatedClockGenerator: gatedClockGenerator);
+  ClockGateControlInterface clone() => ClockGateControlInterface(
+      isPresent: isPresent,
+      hasEnableOverride: hasEnableOverride,
+      additionalPorts: (additionalPorts != null)
+          ? [for (final p in additionalPorts!) p.clone(name: p.name)]
+          : null,
+      gatedClockGenerator: gatedClockGenerator);
 }
 
 /// A generic and configurable clock gating block.

--- a/lib/src/clock_gating.dart
+++ b/lib/src/clock_gating.dart
@@ -7,7 +7,6 @@
 // 2024 September 18
 // Author: Max Korbel <max.korbel@intel.com>
 
-import 'package:meta/meta.dart';
 import 'package:rohd/rohd.dart';
 // ignore: implementation_imports
 import 'package:rohd/src/utilities/uniquifier.dart';

--- a/lib/src/gaskets/spi/spi_main.dart
+++ b/lib/src/gaskets/spi/spi_main.dart
@@ -54,8 +54,7 @@ class SpiMain extends Module {
 
     addOutput('done');
 
-    intf = SpiInterface.clone(intf)
-      ..pairConnectIO(this, intf, PairRole.provider);
+    intf = intf.clone()..pairConnectIO(this, intf, PairRole.provider);
 
     final isRunning = Logic(name: 'isRunning');
 

--- a/lib/src/gaskets/spi/spi_sub.dart
+++ b/lib/src/gaskets/spi/spi_sub.dart
@@ -44,8 +44,7 @@ class SpiSub extends Module {
                     '${intf.dataLength}_'
                     '${intf.sclk.width}') {
     // SPI Interface
-    intf = SpiInterface.clone(intf)
-      ..pairConnectIO(this, intf, PairRole.consumer);
+    intf = intf.clone()..pairConnectIO(this, intf, PairRole.consumer);
 
     // Bus Input to sub, if provided.
     if (busIn != null) {

--- a/lib/src/interfaces/apb.dart
+++ b/lib/src/interfaces/apb.dart
@@ -248,6 +248,7 @@ class ApbInterface extends Interface<ApbDirection> {
   }
 
   /// Constructs a new [ApbInterface] with identical parameters to [other].
+  @Deprecated('Use Instance-based `clone()` instead.')
   ApbInterface.clone(ApbInterface other)
       : this(
           addrWidth: other.addrWidth,
@@ -256,6 +257,19 @@ class ApbInterface extends Interface<ApbDirection> {
           userRespWidth: other.userRespWidth,
           includeSlvErr: other.includeSlvErr,
         );
+
+  /// Clone this [ApbInterface].
+  @override
+  ApbInterface clone() => ApbInterface(
+        addrWidth: addrWidth,
+        dataWidth: dataWidth,
+        userReqWidth: userReqWidth,
+        userDataWidth: userDataWidth,
+        userRespWidth: userRespWidth,
+        includeSlvErr: includeSlvErr,
+        includeWakeup: includeWakeup,
+        numSelects: numSelects,
+      );
 
   /// Checks that the values set for parameters follow the specification's
   /// restrictions.

--- a/lib/src/interfaces/axi4.dart
+++ b/lib/src/interfaces/axi4.dart
@@ -49,7 +49,7 @@ class Axi4SystemInterface extends Interface<Axi4Direction> {
 
   /// Constructs a new [Axi4SystemInterface] with identical parameters.
   @override
-  Axi4SystemInterface clone({String name = 'clone'}) => Axi4SystemInterface();
+  Axi4SystemInterface clone() => Axi4SystemInterface();
 }
 
 /// A standard AXI4 read interface.

--- a/lib/src/interfaces/axi4.dart
+++ b/lib/src/interfaces/axi4.dart
@@ -46,6 +46,10 @@ class Axi4SystemInterface extends Interface<Axi4Direction> {
       Axi4Direction.misc,
     ]);
   }
+
+  /// Constructs a new [Axi4SystemInterface] with identical parameters.
+  @override
+  Axi4SystemInterface clone({String name = 'clone'}) => Axi4SystemInterface();
 }
 
 /// A standard AXI4 read interface.
@@ -243,6 +247,7 @@ class Axi4ReadInterface extends Interface<Axi4Direction> {
   }
 
   /// Constructs a new [Axi4ReadInterface] with identical parameters to [other].
+  @Deprecated('Use Instance-based `clone()` instead.')
   Axi4ReadInterface.clone(Axi4ReadInterface other)
       : this(
           idWidth: other.idWidth,
@@ -254,6 +259,18 @@ class Axi4ReadInterface extends Interface<Axi4Direction> {
           useLock: other.useLock,
           useLast: other.useLast,
         );
+
+  /// Constructs a new [Axi4ReadInterface] with identical parameters.
+  @override
+  Axi4ReadInterface clone() => Axi4ReadInterface(
+      idWidth: idWidth,
+      addrWidth: addrWidth,
+      lenWidth: lenWidth,
+      dataWidth: dataWidth,
+      aruserWidth: aruserWidth,
+      ruserWidth: ruserWidth,
+      useLock: useLock,
+      useLast: useLast);
 
   /// Checks that the values set for parameters follow the specification's
   /// restrictions.
@@ -508,6 +525,7 @@ class Axi4WriteInterface extends Interface<Axi4Direction> {
 
   /// Constructs a new [Axi4WriteInterface] with
   /// identical parameters to [other].
+  @Deprecated('Use Instance-based `clone()` instead.')
   Axi4WriteInterface.clone(Axi4WriteInterface other)
       : this(
           idWidth: other.idWidth,
@@ -519,6 +537,19 @@ class Axi4WriteInterface extends Interface<Axi4Direction> {
           buserWidth: other.buserWidth,
           useLock: other.useLock,
         );
+
+  /// Constructs a new [Axi4WriteInterface] with identical parameters.
+  @override
+  Axi4WriteInterface clone() => Axi4WriteInterface(
+        idWidth: idWidth,
+        addrWidth: addrWidth,
+        lenWidth: lenWidth,
+        dataWidth: dataWidth,
+        awuserWidth: awuserWidth,
+        wuserWidth: wuserWidth,
+        buserWidth: buserWidth,
+        useLock: useLock,
+      );
 
   /// Checks that the values set for parameters follow the specification's
   /// restrictions.

--- a/lib/src/interfaces/spi.dart
+++ b/lib/src/interfaces/spi.dart
@@ -37,7 +37,12 @@ class SpiInterface extends PairInterface {
         ]);
 
   /// Clones this [SpiInterface].
+  @Deprecated('Use Instance-based `clone({String name})` instead.')
   SpiInterface.clone(SpiInterface super.otherInterface)
       : dataLength = otherInterface.dataLength,
         super.clone();
+
+  @override
+  SpiInterface clone({String name = 'clone'}) =>
+      SpiInterface(dataLength: dataLength);
 }

--- a/lib/src/interfaces/spi.dart
+++ b/lib/src/interfaces/spi.dart
@@ -37,12 +37,11 @@ class SpiInterface extends PairInterface {
         ]);
 
   /// Clones this [SpiInterface].
-  @Deprecated('Use Instance-based `clone({String name})` instead.')
+  @Deprecated('Use Instance-based `clone()` instead.')
   SpiInterface.clone(SpiInterface super.otherInterface)
       : dataLength = otherInterface.dataLength,
         super.clone();
 
   @override
-  SpiInterface clone({String name = 'clone'}) =>
-      SpiInterface(dataLength: dataLength);
+  SpiInterface clone() => SpiInterface(dataLength: dataLength);
 }

--- a/lib/src/memory/csr/csr_backdoor.dart
+++ b/lib/src/memory/csr/csr_backdoor.dart
@@ -71,5 +71,6 @@ class CsrBackdoorInterface extends Interface<CsrBackdoorPortGroup> {
   }
 
   /// Makes a copy of this [Interface] with matching configuration.
+  @override
   CsrBackdoorInterface clone() => CsrBackdoorInterface(config: config);
 }

--- a/lib/src/memory/memory.dart
+++ b/lib/src/memory/memory.dart
@@ -80,6 +80,7 @@ class DataPortInterface extends Interface<DataPortGroup> {
   }
 
   /// Makes a copy of this [Interface] with matching configuration.
+  @override
   DataPortInterface clone() => DataPortInterface(dataWidth, addrWidth);
 }
 

--- a/lib/src/summation/gated_counter.dart
+++ b/lib/src/summation/gated_counter.dart
@@ -28,7 +28,7 @@ class GatedCounter extends Counter {
   List<SumInterface> get interfaces => _interfaces;
   late final _interfaces = gateToggles
       ? super.interfaces.map((e) {
-          final intf = SumInterface.clone(e);
+          final intf = e.clone();
 
           intf.enable?.gets(e.enable!);
 
@@ -92,9 +92,7 @@ class GatedCounter extends Counter {
       super.reserveDefinitionName,
       String? definitionName})
       : _providedClkGateParitionIndex = clkGatePartitionIndex,
-        _clockGateControlInterface = clockGateControlInterface == null
-            ? null
-            : ClockGateControlInterface.clone(clockGateControlInterface),
+        _clockGateControlInterface = clockGateControlInterface?.clone(),
         super(
             definitionName: definitionName ??
                 'GatedCounter_W${width}_m${minValue}_M$maxValue') {

--- a/lib/src/summation/sum_interface.dart
+++ b/lib/src/summation/sum_interface.dart
@@ -74,7 +74,7 @@ class SumInterface extends PairInterface {
   }
 
   /// Creates a clone of this [SumInterface] for things like [pairConnectIO].
-  @Deprecated('Use Instance-based `clone({String name})` instead.')
+  @Deprecated('Use Instance-based `clone()` instead.')
   SumInterface.clone(SumInterface other)
       : this(
           fixedAmount: other.fixedAmount,
@@ -86,7 +86,7 @@ class SumInterface extends PairInterface {
   /// Create a clone of the [SumInterface] with the same configuration,
   /// including any `fixedAmount`, `increments`, and `hasEnable` properties.
   @override
-  SumInterface clone({String name = 'clone'}) => SumInterface(
+  SumInterface clone() => SumInterface(
         fixedAmount: fixedAmount,
         increments: increments,
         width: width,

--- a/lib/src/summation/sum_interface.dart
+++ b/lib/src/summation/sum_interface.dart
@@ -74,6 +74,7 @@ class SumInterface extends PairInterface {
   }
 
   /// Creates a clone of this [SumInterface] for things like [pairConnectIO].
+  @Deprecated('Use Instance-based `clone({String name})` instead.')
   SumInterface.clone(SumInterface other)
       : this(
           fixedAmount: other.fixedAmount,
@@ -81,6 +82,16 @@ class SumInterface extends PairInterface {
           width: other.width,
           hasEnable: other.hasEnable,
         );
+
+  /// Create a clone of the [SumInterface] with the same configuration,
+  /// including any `fixedAmount`, `increments`, and `hasEnable` properties.
+  @override
+  SumInterface clone({String name = 'clone'}) => SumInterface(
+        fixedAmount: fixedAmount,
+        increments: increments,
+        width: width,
+        hasEnable: hasEnable,
+      );
 
   @override
   String toString() => [

--- a/lib/src/summation/summation_base.dart
+++ b/lib/src/summation/summation_base.dart
@@ -91,7 +91,7 @@ abstract class SummationBase extends Module {
     }
 
     this.interfaces = interfaces
-        .mapIndexed((i, e) => SumInterface.clone(e)
+        .mapIndexed((i, e) => e.clone()
           ..pairConnectIO(this, e, PairRole.consumer,
               uniquify: (original) => '${original}_$i'))
         .toList();

--- a/lib/src/toggle_gate.dart
+++ b/lib/src/toggle_gate.dart
@@ -51,9 +51,8 @@ class ToggleGate extends Module {
     }
 
     if (clockGateControlIntf != null) {
-      clockGateControlIntf =
-          ClockGateControlInterface.clone(clockGateControlIntf)
-            ..pairConnectIO(this, clockGateControlIntf, PairRole.consumer);
+      clockGateControlIntf = clockGateControlIntf.clone()
+        ..pairConnectIO(this, clockGateControlIntf, PairRole.consumer);
     }
 
     addOutput('gatedData', width: data.width);

--- a/test/apb_test.dart
+++ b/test/apb_test.dart
@@ -13,7 +13,7 @@ import 'package:test/test.dart';
 
 class ApbCompleter extends Module {
   ApbCompleter(ApbInterface intf) {
-    intf = ApbInterface.clone(intf)
+    intf = intf.clone()
       ..connectIO(this, intf,
           inputTags: {ApbDirection.misc, ApbDirection.fromRequester},
           outputTags: {ApbDirection.fromCompleter});
@@ -22,7 +22,7 @@ class ApbCompleter extends Module {
 
 class ApbRequester extends Module {
   ApbRequester(ApbInterface intf) {
-    intf = ApbInterface.clone(intf)
+    intf = intf.clone()
       ..connectIO(this, intf,
           inputTags: {ApbDirection.misc, ApbDirection.fromCompleter},
           outputTags: {ApbDirection.fromRequester});

--- a/test/axi4_test.dart
+++ b/test/axi4_test.dart
@@ -23,13 +23,13 @@ class Axi4Subordinate extends Module {
       channelsL.add(Axi4Channel(
           channelId: channels[i].channelId,
           rIntf: channels[i].hasRead
-              ? (Axi4ReadInterface.clone(channels[i].rIntf!)
+              ? (channels[i].rIntf!.clone()
                 ..connectIO(this, channels[i].rIntf!,
                     inputTags: {Axi4Direction.fromMain},
                     outputTags: {Axi4Direction.fromSubordinate}))
               : null,
           wIntf: channels[i].hasWrite
-              ? (Axi4WriteInterface.clone(channels[i].wIntf!)
+              ? (channels[i].wIntf!.clone()
                 ..connectIO(this, channels[i].wIntf!,
                     inputTags: {Axi4Direction.fromMain},
                     outputTags: {Axi4Direction.fromSubordinate}))
@@ -48,13 +48,13 @@ class Axi4Main extends Module {
       channelsL.add(Axi4Channel(
           channelId: channels[i].channelId,
           rIntf: channels[i].hasRead
-              ? (Axi4ReadInterface.clone(channels[i].rIntf!)
+              ? (channels[i].rIntf!.clone()
                 ..connectIO(this, channels[i].rIntf!,
                     inputTags: {Axi4Direction.fromSubordinate},
                     outputTags: {Axi4Direction.fromMain}))
               : null,
           wIntf: channels[i].hasWrite
-              ? (Axi4WriteInterface.clone(channels[i].wIntf!)
+              ? (channels[i].wIntf!.clone()
                 ..connectIO(this, channels[i].wIntf!,
                     inputTags: {Axi4Direction.fromSubordinate},
                     outputTags: {Axi4Direction.fromMain}))

--- a/test/clock_gating_test.dart
+++ b/test/clock_gating_test.dart
@@ -63,7 +63,7 @@ class CustomClockGateControlInterface extends ClockGateControlInterface {
                 ).gatedClk);
 
   @override
-  CustomClockGateControlInterface clone({String name = 'clone'}) =>
+  CustomClockGateControlInterface clone() =>
       CustomClockGateControlInterface(isPresent: isPresent);
 }
 

--- a/test/clock_gating_test.dart
+++ b/test/clock_gating_test.dart
@@ -61,6 +61,10 @@ class CustomClockGateControlInterface extends ClockGateControlInterface {
                   override: intf.enableOverride!,
                   anotherOverride: intf.port('anotherOverride'),
                 ).gatedClk);
+
+  @override
+  CustomClockGateControlInterface clone({String name = 'clone'}) =>
+      CustomClockGateControlInterface(isPresent: isPresent);
 }
 
 class CounterWithSimpleClockGate extends Module {
@@ -73,8 +77,7 @@ class CounterWithSimpleClockGate extends Module {
       {bool withDelay = true, ClockGateControlInterface? cgIntf})
       : super(name: 'clk_gated_counter') {
     if (cgIntf != null) {
-      cgIntf = ClockGateControlInterface.clone(cgIntf)
-        ..pairConnectIO(this, cgIntf, PairRole.consumer);
+      cgIntf = cgIntf.clone()..pairConnectIO(this, cgIntf, PairRole.consumer);
     }
 
     clk = addInput('clk', clk);

--- a/test/spi/spi_bfm_test.dart
+++ b/test/spi/spi_bfm_test.dart
@@ -17,7 +17,7 @@ import 'package:test/test.dart';
 
 class SpiMod extends Module {
   SpiMod(SpiInterface intf, {super.name = 'SpiModIntf'}) {
-    intf = SpiInterface.clone(intf)
+    intf = intf.clone()
       ..connectIO(this, intf,
           inputTags: [PairDirection.fromProvider, PairDirection.fromConsumer]);
   }

--- a/test/spi/spi_test.dart
+++ b/test/spi/spi_test.dart
@@ -13,15 +13,13 @@ import 'package:test/test.dart';
 
 class SpiMainIntf extends Module {
   SpiMainIntf(SpiInterface intf, {super.name = 'SpiMainIntf'}) {
-    intf = SpiInterface.clone(intf)
-      ..pairConnectIO(this, intf, PairRole.provider);
+    intf = intf.clone()..pairConnectIO(this, intf, PairRole.provider);
   }
 }
 
 class SpiSubIntf extends Module {
   SpiSubIntf(SpiInterface intf, {super.name = 'SpiSubIntf'}) {
-    intf = SpiInterface.clone(intf)
-      ..pairConnectIO(this, intf, PairRole.consumer);
+    intf = intf.clone()..pairConnectIO(this, intf, PairRole.consumer);
   }
 }
 


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Updated our interface classes in use in ROHD-HCL to deprecate any former static clone routines and add in the 
clone() overrides on instance classes that inherit from Interface.

## Related Issue(s)

None

## Testing

Ran dart test.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Not required.
