### PR TITLE
Fix register increment amount and larger registers args

### DIFF
--- a/lib/src/memory/csr/csr_block.dart
+++ b/lib/src/memory/csr/csr_block.dart
@@ -24,10 +24,6 @@ class CsrBlock extends CsrContainer {
   /// CSRs in this block.
   final List<Csr> csrs;
 
-  /// What increment value to use when deriving logical addresses
-  /// for registers that are wider than the frontdoor data width.
-  final int logicalRegisterIncrement;
-
   /// Direct access ports for reading and writing individual registers.
   ///
   /// There is a public copy that is exported out of the module
@@ -51,7 +47,7 @@ class CsrBlock extends CsrContainer {
     required super.frontWrite,
     required super.frontRead,
     super.allowLargerRegisters,
-    this.logicalRegisterIncrement = 1,
+    super.logicalRegisterIncrement,
     super.reserveName,
     super.reserveDefinitionName,
     String? definitionName,

--- a/lib/src/memory/csr/csr_container.dart
+++ b/lib/src/memory/csr/csr_container.dart
@@ -54,6 +54,10 @@ abstract class CsrContainer extends Module {
   /// to any register that exceeds the data width of the frontdoor.
   final bool allowLargerRegisters;
 
+  /// What increment value to use when deriving logical addresses
+  /// for registers that are wider than the frontdoor data width.
+  final int logicalRegisterIncrement;
+
   /// Constructs a base container.
   CsrContainer(
       {required Logic clk,
@@ -62,6 +66,7 @@ abstract class CsrContainer extends Module {
       required DataPortInterface? frontRead,
       required this.config,
       this.allowLargerRegisters = false,
+      this.logicalRegisterIncrement = 1,
       super.reserveName,
       super.reserveDefinitionName,
       String? definitionName})

--- a/lib/src/memory/csr/csr_top.dart
+++ b/lib/src/memory/csr/csr_top.dart
@@ -18,10 +18,6 @@ import 'package:rohd_hcl/src/memory/csr/csr_container.dart';
 /// MSBs of the incoming address and registers within the given block
 /// are addressable using the remaining LSBs of the incoming address.
 class CsrTop extends CsrContainer {
-  /// What increment value to use when deriving logical addresses
-  /// for registers that are wider than the frontdoor data width.
-  final int logicalRegisterIncrement;
-
   /// Configuration for the CSR Top module.
   @override
   CsrTopConfig get config => super.config as CsrTopConfig;
@@ -91,7 +87,7 @@ class CsrTop extends CsrContainer {
       required super.frontWrite,
       required super.frontRead,
       super.allowLargerRegisters,
-      this.logicalRegisterIncrement = 1,
+      super.logicalRegisterIncrement,
       super.reserveName,
       super.reserveDefinitionName,
       String? definitionName})
@@ -125,7 +121,8 @@ class CsrTop extends CsrContainer {
           reset: reset,
           frontWrite: blockFdWrite,
           frontRead: blockFdRead,
-          allowLargerRegisters: allowLargerRegisters));
+          allowLargerRegisters: allowLargerRegisters,
+          logicalRegisterIncrement: logicalRegisterIncrement));
     }
 
     for (var i = 0; i < blocks.length; i++) {


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

- Improvement: The `logicalRegisterIncrement` can be made common to the container
- Bug fix: The `logicalRegisterIncrement` was not properly passed down to blocks from top

## Related Issue(s)

N/A

## Testing

Existing tests cover, but there's a gap to close on the bug fix.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

N/A
