### PR TITLE
Refactoring AXI to support protocol variants (AXI-Lite, AXI-S, ACE, ACE-Lite)

### DIFF
--- a/lib/src/interfaces/amba4/ace4.dart
+++ b/lib/src/interfaces/amba4/ace4.dart
@@ -1,0 +1,143 @@
+// Copyright (C) 2024-2025 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// ace4.dart
+// Definitions for the ACE extension on the AXI interface.
+//
+// 2025 August
+// Author: Josh Kimmel <joshua1.kimmel@intel.com>
+
+import 'package:rohd/rohd.dart';
+import 'package:rohd_hcl/rohd_hcl.dart';
+
+/// ACE read interface.
+///
+/// This is mostly the same as AXI-4 but with some coherency additions.
+class Ace4ReadInterface extends Axi4BaseReadInterface {
+  /// Width of the coherency domain signal.
+  final int domainWidth;
+
+  /// Should the ARBAR signal be present.
+  final bool useBar;
+
+  /// Coherency domain.
+  ///
+  /// Width is equal to [domainWidth].
+  Logic? get arDomain => tryPort('ARDOMAIN');
+
+  /// Coherency barrier.
+  ///
+  /// Width is always 1.
+  Logic? get arBar => tryPort('ARBAR');
+
+  /// Constructor.
+  ///
+  /// Should match regular AXI4 but with DOMAIN and BAR.
+  Ace4ReadInterface({
+    super.idWidth = 4,
+    super.addrWidth = 32,
+    super.lenWidth = 8,
+    super.dataWidth = 64,
+    super.aruserWidth = 32,
+    super.ruserWidth = 32,
+    super.useLock = true,
+    super.useLast = true,
+    this.domainWidth = 1,
+    this.useBar = true,
+  }) : super(
+          sizeWidth: 3,
+          burstWidth: 2,
+          cacheWidth: 4,
+          protWidth: 3,
+          qosWidth: 4,
+          regionWidth: 4,
+          rrespWidth: 2,
+        ) {
+    setPorts([
+      if (domainWidth > 0) Logic.port('ARDOMAIN', domainWidth),
+      if (useBar) Logic.port('ARBAR'),
+    ], [
+      Axi4Direction.fromMain,
+    ]);
+  }
+
+  /// Copy constructor.
+  Ace4ReadInterface clone() => Ace4ReadInterface(
+      idWidth: idWidth,
+      addrWidth: addrWidth,
+      lenWidth: lenWidth,
+      dataWidth: dataWidth,
+      aruserWidth: aruserWidth,
+      ruserWidth: ruserWidth,
+      useLock: useLock,
+      useLast: useLast,
+      domainWidth: domainWidth,
+      useBar: useBar);
+}
+
+/// ACE write interface.
+///
+/// This is mostly the same as AXI-4 but with some coherency additions.
+class Ace4WriteInterface extends Axi4BaseWriteInterface {
+  /// Width of the coherency domain signal.
+  final int domainWidth;
+
+  /// Should the ARBAR signal be present.
+  final bool useBar;
+
+  /// Coherency domain.
+  ///
+  /// Width is equal to [domainWidth].
+  Logic? get arDomain => tryPort('AWDOMAIN');
+
+  /// Coherency barrier.
+  ///
+  /// Width is always 1.
+  Logic? get arBar => tryPort('AWBAR');
+
+  /// Constructor.
+  ///
+  /// Should match regular AXI4 but with DOMAIN and BAR.
+  Ace4WriteInterface({
+    super.idWidth = 4,
+    super.addrWidth = 32,
+    super.lenWidth = 8,
+    super.dataWidth = 64,
+    super.awuserWidth = 32,
+    super.wuserWidth = 32,
+    super.buserWidth = 16,
+    super.useLock = true,
+    this.domainWidth = 1,
+    this.useBar = true,
+  }) : super(
+          sizeWidth: 3,
+          burstWidth: 2,
+          cacheWidth: 4,
+          protWidth: 3,
+          qosWidth: 4,
+          regionWidth: 4,
+          brespWidth: 2,
+        ) {
+    setPorts([
+      if (domainWidth > 0) Logic.port('AWDOMAIN', domainWidth),
+      if (useBar) Logic.port('AWBAR'),
+    ], [
+      Axi4Direction.fromMain,
+    ]);
+  }
+
+  /// Copy constructor.
+  Ace4WriteInterface clone() => Ace4WriteInterface(
+      idWidth: idWidth,
+      addrWidth: addrWidth,
+      lenWidth: lenWidth,
+      dataWidth: dataWidth,
+      awuserWidth: awuserWidth,
+      wuserWidth: wuserWidth,
+      buserWidth: buserWidth,
+      useLock: useLock,
+      domainWidth: domainWidth,
+      useBar: useBar);
+}
+
+// TODO: add Ace4SnoopInterface with the 3 new channels...

--- a/lib/src/interfaces/amba4/ace4_lite.dart
+++ b/lib/src/interfaces/amba4/ace4_lite.dart
@@ -1,0 +1,141 @@
+// Copyright (C) 2024-2025 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// ace4_lite.dart
+// Definitions for the ACE-Lite extension on the AXI interface.
+//
+// 2025 August
+// Author: Josh Kimmel <joshua1.kimmel@intel.com>
+
+import 'package:rohd/rohd.dart';
+import 'package:rohd_hcl/rohd_hcl.dart';
+
+/// ACE-Lite read interface.
+///
+/// This is mostly the same as AXI-4 but with some coherency additions.
+class Ace4LiteReadInterface extends Axi4BaseReadInterface {
+  /// Width of the coherency domain signal.
+  final int domainWidth;
+
+  /// Should the ARBAR signal be present.
+  final bool useBar;
+
+  /// Coherency domain.
+  ///
+  /// Width is equal to [domainWidth].
+  Logic? get arDomain => tryPort('ARDOMAIN');
+
+  /// Coherency barrier.
+  ///
+  /// Width is always 1.
+  Logic? get arBar => tryPort('ARBAR');
+
+  /// Constructor.
+  ///
+  /// Should match regular AXI4 but with DOMAIN and BAR.
+  Ace4LiteReadInterface({
+    super.idWidth = 4,
+    super.addrWidth = 32,
+    super.lenWidth = 8,
+    super.dataWidth = 64,
+    super.aruserWidth = 32,
+    super.ruserWidth = 32,
+    super.useLock = true,
+    super.useLast = true,
+    this.domainWidth = 1,
+    this.useBar = true,
+  }) : super(
+          sizeWidth: 3,
+          burstWidth: 2,
+          cacheWidth: 4,
+          protWidth: 3,
+          qosWidth: 4,
+          regionWidth: 4,
+          rrespWidth: 2,
+        ) {
+    setPorts([
+      if (domainWidth > 0) Logic.port('ARDOMAIN', domainWidth),
+      if (useBar) Logic.port('ARBAR'),
+    ], [
+      Axi4Direction.fromMain,
+    ]);
+  }
+
+  /// Copy constructor.
+  Ace4LiteReadInterface clone() => Ace4LiteReadInterface(
+      idWidth: idWidth,
+      addrWidth: addrWidth,
+      lenWidth: lenWidth,
+      dataWidth: dataWidth,
+      aruserWidth: aruserWidth,
+      ruserWidth: ruserWidth,
+      useLock: useLock,
+      useLast: useLast,
+      domainWidth: domainWidth,
+      useBar: useBar);
+}
+
+/// ACE-Lite write interface.
+///
+/// This is mostly the same as AXI-4 but with some coherency additions.
+class Ace4LiteWriteInterface extends Axi4BaseWriteInterface {
+  /// Width of the coherency domain signal.
+  final int domainWidth;
+
+  /// Should the ARBAR signal be present.
+  final bool useBar;
+
+  /// Coherency domain.
+  ///
+  /// Width is equal to [domainWidth].
+  Logic? get arDomain => tryPort('AWDOMAIN');
+
+  /// Coherency barrier.
+  ///
+  /// Width is always 1.
+  Logic? get arBar => tryPort('AWBAR');
+
+  /// Constructor.
+  ///
+  /// Should match regular AXI4 but with DOMAIN and BAR.
+  Ace4LiteWriteInterface({
+    super.idWidth = 4,
+    super.addrWidth = 32,
+    super.lenWidth = 8,
+    super.dataWidth = 64,
+    super.awuserWidth = 32,
+    super.wuserWidth = 32,
+    super.buserWidth = 16,
+    super.useLock = true,
+    this.domainWidth = 1,
+    this.useBar = true,
+  }) : super(
+          sizeWidth: 3,
+          burstWidth: 2,
+          cacheWidth: 4,
+          protWidth: 3,
+          qosWidth: 4,
+          regionWidth: 4,
+          brespWidth: 2,
+        ) {
+    setPorts([
+      if (domainWidth > 0) Logic.port('AWDOMAIN', domainWidth),
+      if (useBar) Logic.port('AWBAR'),
+    ], [
+      Axi4Direction.fromMain,
+    ]);
+  }
+
+  /// Copy constructor.
+  Ace4LiteWriteInterface clone() => Ace4LiteWriteInterface(
+      idWidth: idWidth,
+      addrWidth: addrWidth,
+      lenWidth: lenWidth,
+      dataWidth: dataWidth,
+      awuserWidth: awuserWidth,
+      wuserWidth: wuserWidth,
+      buserWidth: buserWidth,
+      useLock: useLock,
+      domainWidth: domainWidth,
+      useBar: useBar);
+}

--- a/lib/src/interfaces/amba4/axi4.dart
+++ b/lib/src/interfaces/amba4/axi4.dart
@@ -48,12 +48,11 @@ class Axi4SystemInterface extends Interface<Axi4Direction> {
   }
 
   /// Constructs a new [Axi4SystemInterface] with identical parameters.
-  @override
   Axi4SystemInterface clone() => Axi4SystemInterface();
 }
 
 /// A standard AXI4 read interface.
-class Axi4ReadInterface extends Interface<Axi4Direction> {
+abstract class Axi4BaseReadInterface extends Interface<Axi4Direction> {
   /// Number of channel ID bits.
   final int idWidth;
 
@@ -73,25 +72,25 @@ class Axi4ReadInterface extends Interface<Axi4Direction> {
   final int ruserWidth;
 
   /// Width of the size field is fixed for AXI4.
-  final int sizeWidth = 3;
+  final int sizeWidth;
 
   /// Width of the burst field is fixed for AXI4.
-  final int burstWidth = 2;
+  final int burstWidth;
 
   /// Width of the cache field is fixed for AXI4.
-  final int cacheWidth = 4;
+  final int cacheWidth;
 
   /// Width of the prot field is fixed for AXI4.
-  final int protWidth = 3;
+  final int protWidth;
 
   /// Width of the QoS field is fixed for AXI4.
-  final int qosWidth = 4;
+  final int qosWidth;
 
   /// Width of the region field is fixed for AXI4.
-  final int regionWidth = 4;
+  final int regionWidth;
 
   /// Width of the RRESP field is fixed for AXI4.
-  final int rrespWidth = 2;
+  final int rrespWidth;
 
   /// Controls the presence of [arLock] which is an optional port.
   final bool useLock;
@@ -203,7 +202,7 @@ class Axi4ReadInterface extends Interface<Axi4Direction> {
   /// Construct a new instance of an AXI4 interface.
   ///
   /// Default values in constructor are from official spec.
-  Axi4ReadInterface({
+  Axi4BaseReadInterface({
     this.idWidth = 4,
     this.addrWidth = 32,
     this.lenWidth = 8,
@@ -212,6 +211,13 @@ class Axi4ReadInterface extends Interface<Axi4Direction> {
     this.ruserWidth = 32,
     this.useLock = true,
     this.useLast = true,
+    this.sizeWidth = 3,
+    this.burstWidth = 2,
+    this.cacheWidth = 4,
+    this.protWidth = 3,
+    this.qosWidth = 4,
+    this.regionWidth = 4,
+    this.rrespWidth = 2,
   }) {
     _validateParameters();
 
@@ -246,32 +252,6 @@ class Axi4ReadInterface extends Interface<Axi4Direction> {
     ]);
   }
 
-  /// Constructs a new [Axi4ReadInterface] with identical parameters to [other].
-  @Deprecated('Use Instance-based `clone()` instead.')
-  Axi4ReadInterface.clone(Axi4ReadInterface other)
-      : this(
-          idWidth: other.idWidth,
-          addrWidth: other.addrWidth,
-          lenWidth: other.lenWidth,
-          dataWidth: other.dataWidth,
-          aruserWidth: other.aruserWidth,
-          ruserWidth: other.ruserWidth,
-          useLock: other.useLock,
-          useLast: other.useLast,
-        );
-
-  /// Constructs a new [Axi4ReadInterface] with identical parameters.
-  @override
-  Axi4ReadInterface clone() => Axi4ReadInterface(
-      idWidth: idWidth,
-      addrWidth: addrWidth,
-      lenWidth: lenWidth,
-      dataWidth: dataWidth,
-      aruserWidth: aruserWidth,
-      ruserWidth: ruserWidth,
-      useLock: useLock,
-      useLast: useLast);
-
   /// Checks that the values set for parameters follow the specification's
   /// restrictions.
   void _validateParameters() {
@@ -303,8 +283,42 @@ class Axi4ReadInterface extends Interface<Axi4Direction> {
   }
 }
 
+/// Thin wrapper around abstract class to enforce certain paramater values.
+class Axi4ReadInterface extends Axi4BaseReadInterface {
+  /// Constructor.
+  Axi4ReadInterface({
+    super.idWidth = 4,
+    super.addrWidth = 32,
+    super.lenWidth = 8,
+    super.dataWidth = 64,
+    super.aruserWidth = 32,
+    super.ruserWidth = 32,
+    super.useLock = true,
+    super.useLast = true,
+  }) : super(
+          sizeWidth: 3,
+          burstWidth: 2,
+          cacheWidth: 4,
+          protWidth: 3,
+          qosWidth: 4,
+          regionWidth: 4,
+          rrespWidth: 2,
+        );
+
+  /// Copy constructor.
+  Axi4ReadInterface clone() => Axi4ReadInterface(
+      idWidth: idWidth,
+      addrWidth: addrWidth,
+      lenWidth: lenWidth,
+      dataWidth: dataWidth,
+      aruserWidth: aruserWidth,
+      ruserWidth: ruserWidth,
+      useLock: useLock,
+      useLast: useLast);
+}
+
 /// A standard AXI4 write interface.
-class Axi4WriteInterface extends Interface<Axi4Direction> {
+abstract class Axi4BaseWriteInterface extends Interface<Axi4Direction> {
   /// Number of channel ID bits.
   final int idWidth;
 
@@ -330,25 +344,25 @@ class Axi4WriteInterface extends Interface<Axi4Direction> {
   final int buserWidth;
 
   /// Width of the size field is fixed for AXI4.
-  final int sizeWidth = 3;
+  final int sizeWidth;
 
   /// Width of the burst field is fixed for AXI4.
-  final int burstWidth = 2;
+  final int burstWidth;
 
   /// Width of the cache field is fixed for AXI4.
-  final int cacheWidth = 4;
+  final int cacheWidth;
 
   /// Width of the prot field is fixed for AXI4.
-  final int protWidth = 3;
+  final int protWidth;
 
   /// Width of the QoS field is fixed for AXI4.
-  final int qosWidth = 4;
+  final int qosWidth;
 
   /// Width of the region field is fixed for AXI4.
-  final int regionWidth = 4;
+  final int regionWidth;
 
   /// Width of the BRESP field is fixed for AXI4.
-  final int brespWidth = 2;
+  final int brespWidth;
 
   /// Controls the presence of [awLock] which is an optional port.
   final bool useLock;
@@ -476,7 +490,7 @@ class Axi4WriteInterface extends Interface<Axi4Direction> {
   /// Construct a new instance of an AXI4 interface.
   ///
   /// Default values in constructor are from official spec.
-  Axi4WriteInterface({
+  Axi4BaseWriteInterface({
     this.idWidth = 4,
     this.addrWidth = 32,
     this.lenWidth = 8,
@@ -485,6 +499,13 @@ class Axi4WriteInterface extends Interface<Axi4Direction> {
     this.wuserWidth = 32,
     this.buserWidth = 16,
     this.useLock = true,
+    this.sizeWidth = 3,
+    this.burstWidth = 2,
+    this.cacheWidth = 4,
+    this.protWidth = 3,
+    this.qosWidth = 4,
+    this.regionWidth = 4,
+    this.brespWidth = 2,
   }) : strbWidth = dataWidth ~/ 8 {
     _validateParameters();
 
@@ -523,34 +544,6 @@ class Axi4WriteInterface extends Interface<Axi4Direction> {
     ]);
   }
 
-  /// Constructs a new [Axi4WriteInterface] with
-  /// identical parameters to [other].
-  @Deprecated('Use Instance-based `clone()` instead.')
-  Axi4WriteInterface.clone(Axi4WriteInterface other)
-      : this(
-          idWidth: other.idWidth,
-          addrWidth: other.addrWidth,
-          lenWidth: other.lenWidth,
-          dataWidth: other.dataWidth,
-          awuserWidth: other.awuserWidth,
-          wuserWidth: other.wuserWidth,
-          buserWidth: other.buserWidth,
-          useLock: other.useLock,
-        );
-
-  /// Constructs a new [Axi4WriteInterface] with identical parameters.
-  @override
-  Axi4WriteInterface clone() => Axi4WriteInterface(
-        idWidth: idWidth,
-        addrWidth: addrWidth,
-        lenWidth: lenWidth,
-        dataWidth: dataWidth,
-        awuserWidth: awuserWidth,
-        wuserWidth: wuserWidth,
-        buserWidth: buserWidth,
-        useLock: useLock,
-      );
-
   /// Checks that the values set for parameters follow the specification's
   /// restrictions.
   void _validateParameters() {
@@ -584,6 +577,41 @@ class Axi4WriteInterface extends Interface<Axi4Direction> {
       throw RohdHclException('buserWidth must be >= 0 and <= 128');
     }
   }
+}
+
+/// Thin wrapper around abstract class to enforce certain paramater values.
+class Axi4WriteInterface extends Axi4BaseWriteInterface {
+  /// Constructor.
+  Axi4WriteInterface({
+    super.idWidth = 4,
+    super.addrWidth = 32,
+    super.lenWidth = 8,
+    super.dataWidth = 64,
+    super.awuserWidth = 32,
+    super.wuserWidth = 32,
+    super.buserWidth = 16,
+    super.useLock = true,
+  }) : super(
+          sizeWidth: 3,
+          burstWidth: 2,
+          cacheWidth: 4,
+          protWidth: 3,
+          qosWidth: 4,
+          regionWidth: 4,
+          brespWidth: 2,
+        );
+
+  /// Copy constructor.
+  Axi4WriteInterface clone() => Axi4WriteInterface(
+        idWidth: idWidth,
+        addrWidth: addrWidth,
+        lenWidth: lenWidth,
+        dataWidth: dataWidth,
+        awuserWidth: awuserWidth,
+        wuserWidth: wuserWidth,
+        buserWidth: buserWidth,
+        useLock: useLock,
+      );
 }
 
 /// Helper to enumerate the encodings of the xBURST signal.

--- a/lib/src/interfaces/amba4/axi4_lite.dart
+++ b/lib/src/interfaces/amba4/axi4_lite.dart
@@ -1,0 +1,60 @@
+// Copyright (C) 2024-2025 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// axi4_lite.dart
+// Definitions for the AXI-Lite interface.
+//
+// 2025 August
+// Author: Josh Kimmel <joshua1.kimmel@intel.com>
+
+import 'package:rohd_hcl/rohd_hcl.dart';
+
+/// A standard AXI4-Lite read interface.
+class Axi4LiteReadInterface extends Axi4BaseReadInterface {
+  /// Construct a new instance of an AXI4 interface.
+  ///
+  /// Default values in constructor are from official spec.
+  Axi4LiteReadInterface({
+    super.addrWidth = 32,
+    super.dataWidth = 64,
+    super.useLast = true,
+  }) : super(
+          aruserWidth: 0,
+          idWidth: 0,
+          lenWidth: 0,
+          ruserWidth: 0,
+          useLock: false,
+          sizeWidth: 0,
+          burstWidth: 0,
+          cacheWidth: 0,
+          protWidth: 3,
+          qosWidth: 0,
+          regionWidth: 0,
+          rrespWidth: 2,
+        );
+}
+
+/// A standard AXI4-Lite read interface.
+class Axi4LiteWriteInterface extends Axi4BaseWriteInterface {
+  /// Construct a new instance of an AXI4 interface.
+  ///
+  /// Default values in constructor are from official spec.
+  Axi4LiteWriteInterface({
+    super.addrWidth = 32,
+    super.dataWidth = 64,
+  }) : super(
+          awuserWidth: 0,
+          idWidth: 0,
+          lenWidth: 0,
+          wuserWidth: 0,
+          buserWidth: 0,
+          useLock: false,
+          sizeWidth: 0,
+          burstWidth: 0,
+          cacheWidth: 0,
+          protWidth: 3,
+          qosWidth: 0,
+          regionWidth: 0,
+          brespWidth: 2,
+        );
+}

--- a/lib/src/interfaces/amba4/axi4_s.dart
+++ b/lib/src/interfaces/amba4/axi4_s.dart
@@ -1,0 +1,134 @@
+// Copyright (C) 2024-2025 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// axi4_s.dart
+// Definitions for the AXI-S interface.
+//
+// 2025 August
+// Author: Josh Kimmel <joshua1.kimmel@intel.com>
+
+import 'package:rohd/rohd.dart';
+import 'package:rohd_hcl/rohd_hcl.dart';
+
+/// A standard AXI4 read interface.
+class Axi4StreamInterface extends Interface<Axi4Direction> {
+  /// Width of the TID sideband field.
+  final int idWidth;
+
+  /// Width of the TUSER sideband field.
+  final int userWidth;
+
+  /// Width of the TDEST sideband field.
+  final int destWidth;
+
+  /// Width of the stream data bus.
+  final int dataWidth;
+
+  /// Width of the strobe/keep signals.
+  final int strbWidth;
+
+  /// Identification tag for a stream transaction.
+  ///
+  /// Width is equal to [idWidth].
+  Logic? get tId => tryPort('TID');
+
+  /// User-defined extension for the stream address channel.
+  ///
+  /// Width is equal to [userWidth].
+  Logic? get tUser => tryPort('TUSER');
+
+  /// Destination hint for the stream channel (user-defined).
+  ///
+  /// Width is equal to [destWidth].
+  Logic? get tDest => tryPort('TDEST');
+
+  /// Indicates that the stream channel signals are valid.
+  ///
+  /// Width is always 1.
+  Logic get tValid => port('TVALID');
+
+  /// Indicates that a transfer on the stream channel can be accepted.
+  ///
+  /// Width is always 1.
+  Logic get tReady => port('TREADY');
+
+  /// Stream data.
+  ///
+  /// Width is equal to [dataWidth].
+  Logic get tData => port('TDATA');
+
+  /// Data strobes, indicate which byte lanes hold valid data.
+  ///
+  /// Width is equal to [strbWidth].
+  Logic get tStrb => port('WSTRB');
+
+  /// Keeps, which byte lanes of data shouldn't be ignored at the destination.
+  ///
+  /// Width is equal to [strbWidth].
+  Logic get tKeep => port('TKEEP');
+
+  /// Indicates whether this is the last data transfer in a stream.
+  ///
+  /// Width is always 1.
+  Logic get tLast => port('TLAST');
+
+  /// Construct a new instance of an AXI4 interface.
+  ///
+  /// Default values in constructor are from official spec.
+  Axi4StreamInterface({
+    this.idWidth = 4,
+    this.dataWidth = 64,
+    this.userWidth = 0,
+    this.destWidth = 0,
+  }) : strbWidth = dataWidth ~/ 8 {
+    _validateParameters();
+
+    setPorts([
+      if (idWidth > 0) Logic.port('TID', idWidth),
+      if (userWidth > 0) Logic.port('TUSER', userWidth),
+      if (destWidth > 0) Logic.port('TDEST', destWidth),
+      Logic.port('TVALID'),
+      Logic.port('TDATA', dataWidth),
+      Logic.port('TSTRB', strbWidth),
+      Logic.port('TKEEP', strbWidth),
+      Logic.port('TVALID'),
+      Logic.port('TLAST'),
+    ], [
+      Axi4Direction.fromMain,
+    ]);
+
+    setPorts([
+      Logic.port('TREADY'),
+    ], [
+      Axi4Direction.fromSubordinate,
+    ]);
+  }
+
+  /// Constructs a new [Axi4StreamInterface] with identical parameters.
+  Axi4StreamInterface clone() => Axi4StreamInterface(
+      idWidth: idWidth,
+      dataWidth: dataWidth,
+      userWidth: userWidth,
+      destWidth: destWidth);
+
+  /// Checks that the values set for parameters follow the specification's
+  /// restrictions.
+  void _validateParameters() {
+    const legalDataWidths = [8, 16, 32, 64, 128, 256, 512, 1024];
+    if (!legalDataWidths.contains(dataWidth)) {
+      throw RohdHclException('dataWidth must be one of $legalDataWidths');
+    }
+
+    if (idWidth < 0 || idWidth > 32) {
+      throw RohdHclException('idWidth must be >= 0 and <= 32');
+    }
+
+    if (userWidth < 0 || userWidth > 128) {
+      throw RohdHclException('userWidth must be >= 0 and <= 128');
+    }
+
+    if (destWidth < 0 || destWidth > 128) {
+      throw RohdHclException('destWidth must be >= 0 and <= 128');
+    }
+  }
+}

--- a/lib/src/interfaces/interfaces.dart
+++ b/lib/src/interfaces/interfaces.dart
@@ -1,6 +1,8 @@
 // Copyright (C) 2024-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 
+export 'amba4/axi4.dart';
+export 'amba4/axi4_lite.dart';
+export 'amba4/axi4_s.dart';
 export 'apb.dart';
-export 'axi4.dart';
 export 'spi.dart';


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Adding support for other common AMBA interfaces that are mostly derivatives of AXI. In some cases (ACE), this involves enhancing the BFM.

## Related Issue(s)

N/A

## Testing

Adding unit tests using both existing and new BFMs.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

The changes to AXI itself should be fully backwards compatible.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Yes, included.
