### PR TITLE
Enable `Fifo` to return the same type as was received

### DIFF
--- a/lib/src/fifo.dart
+++ b/lib/src/fifo.dart
@@ -17,7 +17,7 @@ import 'package:rohd_vf/rohd_vf.dart';
 /// A module [Fifo] implementing a simple FIFO (First In, First Out) buffer.
 ///
 /// Supports a bypass if [Fifo] is empty and written & read at the same time.
-class Fifo extends Module {
+class Fifo<LogicType extends Logic> extends Module {
   /// High if the entire FIFO is full and it cannot accept any more new items.
   Logic get full => output('full');
 
@@ -27,7 +27,7 @@ class Fifo extends Module {
   /// Read data for the next item in [Fifo]
   ///
   /// This data is visible even when not actively removing from [Fifo].
-  Logic get readData => output('readData');
+  late final LogicType readData;
 
   /// High if an error condition is reached.
   ///
@@ -88,7 +88,7 @@ class Fifo extends Module {
   /// may be either [Logic]s or constants compatible with [LogicValue.of].
   Fifo(Logic clk, Logic reset,
       {required Logic writeEnable,
-      required Logic writeData,
+      required LogicType writeData,
       required Logic readEnable,
       required this.depth,
       this.generateError = false,
@@ -117,9 +117,10 @@ class Fifo extends Module {
 
     // set up read/write ports
     addInput('writeEnable', writeEnable);
-    addInput('writeData', writeData, width: dataWidth);
+    addTypedInput('writeData', writeData);
     addInput('readEnable', readEnable);
-    addOutput('readData', width: dataWidth);
+    readData = addTypedOutput(
+        'readData', writeData.clone as LogicType Function({String? name}));
 
     // set up info ports
     addOutput('full');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   collection: ^1.18.0
   meta: ^1.9.1
-  rohd: ^0.6.1
+  rohd: ^0.6.6
   rohd_vf: ^0.6.0
 
 dev_dependencies:

--- a/test/fifo_test.dart
+++ b/test/fifo_test.dart
@@ -738,6 +738,31 @@ void main() {
       expect(vals, isEmpty);
     });
   });
+
+  test('typed fifo', () {
+    final fifo = Fifo(
+      Logic(),
+      Logic(),
+      writeEnable: Logic(),
+      readEnable: Logic(),
+      writeData: ExampleStruct(),
+      depth: 4,
+    );
+
+    expect(fifo.readData, isA<ExampleStruct>());
+  });
+}
+
+class ExampleStruct extends LogicStructure {
+  ExampleStruct({super.name})
+      : super([
+          Logic(name: 'a', width: 8),
+          Logic(name: 'b', width: 16),
+          Logic(name: 'c', width: 32)
+        ]);
+
+  @override
+  ExampleStruct clone({String? name}) => ExampleStruct(name: name);
 }
 
 class FifoTest extends Test {


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Adds the ability to pass any arbitrary `Logic` type into a `Fifo` and receive that same type on the output.  This leverages ROHD's `addTypedInput` and `addTypedOutput` capabilities and thus required ROHD v0.6.6 minimum.

## Related Issue(s)

N/A

## Testing

Added a test that the type worked.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

Minimum version of ROHD has increased, but not to a backwards-incompatible version.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
