### PR TITLE
Expose name argument on round robin arbiters

### DIFF
--- a/lib/src/arbiters/mask_round_robin_arbiter.dart
+++ b/lib/src/arbiters/mask_round_robin_arbiter.dart
@@ -36,6 +36,7 @@ class MaskRoundRobinArbiter extends StatefulArbiter
   MaskRoundRobinArbiter(super.requests,
       {required super.clk,
       required super.reset,
+      super.name = 'mask_round_robin_arbiter',
       super.reserveName,
       super.reserveDefinitionName,
       String? definitionName})

--- a/lib/src/arbiters/rotate_round_robin_arbiter.dart
+++ b/lib/src/arbiters/rotate_round_robin_arbiter.dart
@@ -17,6 +17,7 @@ class RotateRoundRobinArbiter extends StatefulArbiter
   RotateRoundRobinArbiter(super.requests,
       {required super.clk,
       required super.reset,
+      super.name = 'rotate_round_robin_arbiter',
       super.reserveName,
       super.reserveDefinitionName,
       String? definitionName})

--- a/lib/src/arbiters/round_robin_arbiter.dart
+++ b/lib/src/arbiters/round_robin_arbiter.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // round_robin_arbiter.dart
@@ -16,12 +16,14 @@ abstract class RoundRobinArbiter extends StatefulArbiter {
   factory RoundRobinArbiter(List<Logic> requests,
           {required Logic clk,
           required Logic reset,
+          String name = 'round_robin_arbiter',
           bool reserveName = false,
           bool reserveDefinitionName = false,
           String? definitionName}) =>
       MaskRoundRobinArbiter(requests,
           clk: clk,
           reset: reset,
+          name: name,
           reserveName: reserveName,
           reserveDefinitionName: reserveDefinitionName,
           definitionName: definitionName);

--- a/lib/src/arbiters/stateful_arbiter.dart
+++ b/lib/src/arbiters/stateful_arbiter.dart
@@ -29,6 +29,7 @@ abstract class StatefulArbiter extends Arbiter {
   StatefulArbiter(super.requests,
       {required Logic clk,
       required Logic reset,
+      super.name = 'stateful_arbiter',
       super.reserveName,
       super.reserveDefinitionName,
       String? definitionName})


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

The `name` argument was not exposed for some arbiters, including round robin.  This PR exposes it.

## Related Issue(s)

N/A

## Testing

Static checks and review

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No