### PR TITLE
deprecate fixed-point operators until next release

### DIFF
--- a/lib/src/arithmetic/values/fixed_point_value.dart
+++ b/lib/src/arithmetic/values/fixed_point_value.dart
@@ -123,18 +123,26 @@ class FixedPointValue implements Comparable<FixedPointValue> {
       compareTo(other) != 0 ? LogicValue.one : LogicValue.zero;
 
   /// Less-than operation that returns a [LogicValue].
+  @Deprecated('This operator will be replaced'
+      ' with a boolean return in the future.')
   LogicValue operator <(FixedPointValue other) =>
       compareTo(other) < 0 ? LogicValue.one : LogicValue.zero;
 
   /// Less-than operation that returns a [LogicValue].
+  @Deprecated('This operator will be replaced'
+      ' with a boolean return in the future.')
   LogicValue operator <=(FixedPointValue other) =>
       compareTo(other) <= 0 ? LogicValue.one : LogicValue.zero;
 
   /// Less-than operation that returns a [LogicValue].
+  @Deprecated('This operator will be replaced'
+      ' with a boolean return in the future.')
   LogicValue operator >(FixedPointValue other) =>
       compareTo(other) > 0 ? LogicValue.one : LogicValue.zero;
 
   /// Less-than operation that returns a [LogicValue].
+  @Deprecated('This operator will be replaced'
+      ' with a boolean return in the future.')
   LogicValue operator >=(FixedPointValue other) =>
       compareTo(other) >= 0 ? LogicValue.one : LogicValue.zero;
 

--- a/test/arithmetic/values/fixed_point_value_test.dart
+++ b/test/arithmetic/values/fixed_point_value_test.dart
@@ -8,6 +8,8 @@
 // Authors:
 //  Soner Yaldiz <soner.yaldiz@intel.com>
 
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'dart:math';
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

This PR deprecates the `FixedPointValue`  comparison operators as they currently return `LogicValue` and will soon return `bool`.

## Related Issue(s)

#199 this will prepare for finalizing fixes for this issue.

## Testing

No additional tests needed. 

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No.  This is signalling deprecation of these operators before a breaking change is made.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No.
