### PR TITLE
Add AssertiveDataPortInterface

### DIFF
--- a/lib/src/memory/memory.dart
+++ b/lib/src/memory/memory.dart
@@ -17,7 +17,33 @@ enum DataPortGroup {
   control,
 
   /// For data signals to/from memory.
-  data
+  data,
+
+  /// For data signal validation.
+  validation,
+}
+
+/// A [DataPortInterface] that signals the data validation and readiness.
+class AssertiveDataPortInterface extends DataPortInterface {
+  /// On a read port, this indicates that the data is ready to be read.
+  /// On a write port, this indicates that the write has completed.
+  Logic get ready => port('ready');
+
+  /// A signal that indicates the transaction is successful.
+  Logic get valid => port('valid');
+
+  /// Constructs a [DataPortInterface] with ready and valid.
+  AssertiveDataPortInterface(super.dataWidth, super.addrWidth) {
+    setPorts([
+      Logic.port('ready'),
+      Logic.port('valid'),
+    ], [
+      DataPortGroup.validation
+    ]);
+  }
+
+  @override
+  DataPortInterface clone() => AssertiveDataPortInterface(dataWidth, addrWidth);
 }
 
 /// A [DataPortInterface] that supports byte-enabled strobing.

--- a/lib/src/memory/memory.dart
+++ b/lib/src/memory/memory.dart
@@ -208,14 +208,14 @@ abstract class Memory extends Module {
       rdPorts.add(readPorts[i].clone()
         ..connectIO(this, readPorts[i],
             inputTags: {DataPortGroup.control},
-            outputTags: {DataPortGroup.data},
+            outputTags: {DataPortGroup.data, DataPortGroup.validation},
             uniquify: (original) => 'rd_${original}_$i'));
     }
     for (var i = 0; i < numWrites; i++) {
       wrPorts.add(writePorts[i].clone()
         ..connectIO(this, writePorts[i],
             inputTags: {DataPortGroup.control, DataPortGroup.data},
-            outputTags: {},
+            outputTags: {DataPortGroup.validation},
             uniquify: (original) => 'wr_${original}_$i'));
     }
   }

--- a/lib/src/models/memory_model.dart
+++ b/lib/src/models/memory_model.dart
@@ -69,10 +69,17 @@ class MemoryModel extends Memory {
         if (!wrPort.en.previousValue!.isValid && !storage.isEmpty) {
           // storage doesnt have access to `en`, so check ourselves
           storage.invalidWrite();
+
+          if (wrPort is AssertiveDataPortInterface) {
+            wrPort.ready.put(LogicValue.one);
+            wrPort.valid.put(LogicValue.zero);
+          }
           return;
         }
 
-        if (wrPort.en.previousValue == LogicValue.one) {
+        final wrEnHigh = wrPort.en.previousValue == LogicValue.one;
+
+        if (wrEnHigh) {
           final addrValue = wrPort.addr.previousValue!;
 
           if (wrPort is MaskedDataPortInterface) {
@@ -92,6 +99,11 @@ class MemoryModel extends Memory {
             storage.writeData(addrValue, wrPort.data.previousValue!);
           }
         }
+
+        if (wrPort is AssertiveDataPortInterface) {
+          wrPort.ready.put(LogicValue.one);
+          wrPort.valid.put(wrEnHigh ? LogicValue.one : LogicValue.zero);
+        }
       }
 
       for (final rdPort in rdPorts) {
@@ -101,7 +113,8 @@ class MemoryModel extends Memory {
               !rdPort.en.previousValue!.toBool() ||
               !rdPort.addr.previousValue!.isValid) {
             unawaited(_updateRead(
-                rdPort, LogicValue.filled(rdPort.dataWidth, LogicValue.x)));
+                rdPort, LogicValue.filled(rdPort.dataWidth, LogicValue.x),
+                valid: false));
           } else {
             unawaited(_updateRead(
                 rdPort, storage.readData(rdPort.addr.previousValue!)));
@@ -129,16 +142,38 @@ class MemoryModel extends Memory {
         !rdPort.en.value.toBool() ||
         !rdPort.addr.value.isValid) {
       rdPort.data.put(LogicValue.x, fill: true);
+
+      if (rdPort is AssertiveDataPortInterface) {
+        rdPort.ready.put(LogicValue.one);
+        rdPort.valid.put(LogicValue.zero);
+      }
     } else {
       rdPort.data.put(storage.readData(rdPort.addr.value));
+
+      if (rdPort is AssertiveDataPortInterface) {
+        rdPort.ready.put(LogicValue.one);
+        rdPort.valid.put(LogicValue.one);
+      }
     }
   }
 
   /// Updates read data for [rdPort] after [readLatency] time.
-  Future<void> _updateRead(DataPortInterface rdPort, LogicValue data) async {
+  Future<void> _updateRead(DataPortInterface rdPort, LogicValue data,
+      {bool valid = true}) async {
     if (readLatency > 1) {
+      // The transaction is in flight; drop ready/valid until it completes so
+      // downstream consumers don't latch a stale "data ready" indication.
+      if (rdPort is AssertiveDataPortInterface) {
+        rdPort.ready.put(LogicValue.zero);
+        rdPort.valid.put(LogicValue.zero);
+      }
       await clk.waitCycles(readLatency - 1);
     }
     rdPort.data.inject(data);
+
+    if (rdPort is AssertiveDataPortInterface) {
+      rdPort.ready.put(valid ? LogicValue.one : LogicValue.zero);
+      rdPort.valid.put(valid ? LogicValue.one : LogicValue.zero);
+    }
   }
 }

--- a/test/memory/memory_test.dart
+++ b/test/memory/memory_test.dart
@@ -345,4 +345,100 @@ void main() {
   test('non-byte-aligned data widths are legal without masks', () {
     DataPortInterface(1, 1);
   });
+
+  group('AssertiveDataPortInterface', () {
+    const dataWidth = 32;
+    const addrWidth = 5;
+
+    for (final readLatency in [0, 1, 2]) {
+      test(
+          'memory model write and read assert ready/valid (latency '
+          '$readLatency)', () async {
+        final clk = SimpleClockGenerator(10).clk;
+        final reset = Logic();
+
+        final wrPort = AssertiveDataPortInterface(dataWidth, addrWidth)
+          ..en.put(0);
+        final rdPort = AssertiveDataPortInterface(dataWidth, addrWidth)
+          ..en.put(0);
+
+        final mem = MemoryModel(clk, reset, [wrPort], [rdPort],
+            readLatency: readLatency);
+
+        await mem.build();
+
+        unawaited(Simulator.run());
+
+        await clk.nextNegedge;
+        reset.inject(1);
+        await clk.nextNegedge;
+        await clk.nextNegedge;
+        reset.inject(0);
+        await clk.nextNegedge;
+        await clk.nextNegedge;
+
+        // perform a write
+        wrPort.en.put(1);
+        wrPort.addr.put(3);
+        wrPort.data.put(0xdeadbeef);
+
+        await clk.nextPosedge;
+        // after the posedge, write completes; ready/valid should be asserted
+        await clk.nextNegedge;
+        expect(wrPort.ready.value.toInt(), 1,
+            reason: 'wrPort.ready should be high after a write');
+        expect(wrPort.valid.value.toInt(), 1,
+            reason: 'wrPort.valid should be high after a successful write');
+
+        wrPort.en.put(0);
+        await clk.nextPosedge;
+        await clk.nextNegedge;
+        expect(wrPort.valid.value.toInt(), 0,
+            reason: 'wrPort.valid should be low when write is not enabled');
+
+        // perform a read
+        rdPort.en.put(1);
+        rdPort.addr.put(3);
+
+        if (mem.readLatency == 0) {
+          // combinational: data is available immediately
+          expect(rdPort.data.value.toInt(), 0xdeadbeef);
+          expect(rdPort.ready.value.toInt(), 1,
+              reason: 'rdPort.ready should be high when data is available');
+          expect(rdPort.valid.value.toInt(), 1,
+              reason: 'rdPort.valid should be high when data is available');
+        } else {
+          // walk one cycle at a time; valid must stay low while the
+          // transaction is in flight, then assert when data is ready.
+          for (var i = 0; i < mem.readLatency; i++) {
+            await clk.nextNegedge;
+            if (i < mem.readLatency - 1) {
+              expect(rdPort.valid.value.toInt(), 0,
+                  reason: 'rdPort.valid should be low during latency wait '
+                      '(latency $readLatency, cycle $i)');
+              expect(rdPort.ready.value.toInt(), 0,
+                  reason: 'rdPort.ready should be low during latency wait '
+                      '(latency $readLatency, cycle $i)');
+            } else {
+              expect(rdPort.data.value.toInt(), 0xdeadbeef);
+              expect(rdPort.ready.value.toInt(), 1,
+                  reason: 'rdPort.ready should be high when data is available');
+              expect(rdPort.valid.value.toInt(), 1,
+                  reason: 'rdPort.valid should be high when data is available');
+            }
+          }
+        }
+
+        // disable the read port, valid should drop low
+        rdPort.en.put(0);
+        for (var i = 0; i < mem.readLatency; i++) {
+          await clk.nextNegedge;
+        }
+        expect(rdPort.valid.value.toInt(), 0,
+            reason: 'rdPort.valid should be low when read is not enabled');
+
+        await Simulator.endSimulation();
+      });
+    }
+  });
 }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Adds a valid output to `DataPortInterface`. This makes it possible to know whether the read or write has completed successfully.

Adds a done output to `DataPortInterface`. This makes it possible to know whether the read or write has completed.

<!-- Description of changes, and motivation for adding them. -->

## Related Issue(s)

Seems like #146 is somewhat related since this allows for polling if `valid` is set and knowing that marks things are valid.

<!-- If there are any issues related to this PR, please link to the issues here. -->

## Testing

Ensure `test/memory_model.dart` passes

<!-- Please describe how you tested your changes. -->

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

<!-- Answer here. -->

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

<!-- Answer here. -->
