### PR TITLE
Support for Heterogenous Block Sizes within CsrTop

### DIFF
--- a/doc/components/csr.md
+++ b/doc/components/csr.md
@@ -206,7 +206,7 @@ A CSR top is a `Module` that wraps a collection of `CsrBlock` objects, making th
 The `CsrTopConfig` defines the contents of the top module. As such, it is constructed by passing a list of `CsrBlockConfig`s which defines the blocks contained within the top module. In addition to the register block configurations, the top configuration offers the following functionality:
 
 - A name for the module (called `name`).
-- An offset width that is used to slice the main address signal to address registers within a given block (called `blockOffsetWidth`).
+- A block size that defines how many addresses of space live in each block (called `blockSize`).
 - Methods to retrieve a given register block's configuration by name or base address (`getBlockByName` and `getBlockByAddr`).
 - Validation to check for configuration correctness and consistency.
 - A method `minAddrBits()` that returns the minimum number of address bits required to uniquely address every register instance in every block. The return value is based on both the largest block `baseAddr` and its largest `minAddrBits`.
@@ -220,7 +220,7 @@ The following checks are run:
 - No two register blocks in the module have the same `name`.
 - No two register blocks in the module have the same `baseAddr`.
 - No two register blocks in the module have `baseAddr`s that are too close together such there would be an address collision. This is based on the `minAddrBits` of each block to determine how much room that block needs before the next `baseAddr`.
-- The `blockOffsetWidth` must be wide enough to cover the largest `minAddrBits` across all blocks.
+- The `blockSize` must be large enough to cover the largest register address in each block.
 
 ### Frontdoor CSR Access - Top
 
@@ -228,7 +228,7 @@ Similar to `CsrBlock`, the `CsrTop` module provides frontdoor read/write access 
 
 To access a particular register in a particular block, drive the address of the appropriate `DataPortInterface` to the block's `baseAddr` + the register's `addr`.
 
-In the hardware's construction, each `CsrBlock`'s `DataPortInterface` is driven by the `CsrTop`'s associated `DataPortInterface`. For the address signal, the LSBs of the `CsrTop`'s `DataPortInterface` are used per the value of `blockOffsetWidth`. All other signals are direct pass-throughs.
+In the hardware's construction, each `CsrBlock`'s `DataPortInterface` is driven by the `CsrTop`'s associated `DataPortInterface`. For the address signal, the LSBs of the `CsrTop`'s `DataPortInterface` are used per the offset width derived from `blockSize`. All other signals are direct pass-throughs.
 
 If an access drives an address that doesn't map to any block, writes are NOPs and reads return 0x0.
 

--- a/lib/src/memory/csr/config/csr_block_config.dart
+++ b/lib/src/memory/csr/config/csr_block_config.dart
@@ -26,11 +26,21 @@ class CsrBlockConfig extends CsrContainerConfig {
   /// Registers in this block.
   final List<CsrInstanceConfig> registers;
 
+  /// Optional override for the number of address bits dedicated to registers
+  /// within this block.
+  ///
+  /// When set, this value takes precedence over the uniform
+  /// [CsrTopConfig.blockOffsetWidth] for this specific block, enabling
+  /// heterogeneous block sizes within the same top-level module. When `null`
+  /// (the default), the top-level [CsrTopConfig.blockOffsetWidth] is used.
+  final int? blockOffsetWidth;
+
   /// Construct a new block configuration.
   CsrBlockConfig({
     required super.name,
     required this.baseAddr,
     required List<CsrInstanceConfig> registers,
+    this.blockOffsetWidth,
   }) : registers = List.unmodifiable(registers) {
     // validate the block
     _validate();
@@ -74,6 +84,13 @@ class CsrBlockConfig extends CsrContainerConfig {
     if (issues.isNotEmpty) {
       throw CsrValidationException(issues.join('\n'));
     }
+
+    // if a blockOffsetWidth override is provided, validate it is large enough
+    if (blockOffsetWidth != null && blockOffsetWidth! < minAddrBits()) {
+      throw CsrValidationException(
+          'Block $name has a blockOffsetWidth of $blockOffsetWidth which is '
+          'too small to address all registers. The minimum is ${minAddrBits()}.');
+    }
   }
 
   /// Method to determine the minimum number of address bits
@@ -109,6 +126,7 @@ class CsrBlockConfig extends CsrContainerConfig {
         name: name,
         baseAddr: baseAddr,
         registers: registers,
+        blockOffsetWidth: blockOffsetWidth,
       );
 
   @override
@@ -120,6 +138,7 @@ class CsrBlockConfig extends CsrContainerConfig {
     return other is CsrBlockConfig &&
         super == other &&
         other.baseAddr == baseAddr &&
+        other.blockOffsetWidth == blockOffsetWidth &&
         const ListEquality<CsrInstanceConfig>()
             .equals(other.registers, registers);
   }
@@ -128,5 +147,6 @@ class CsrBlockConfig extends CsrContainerConfig {
   int get hashCode =>
       super.hashCode ^
       baseAddr.hashCode ^
+      blockOffsetWidth.hashCode ^
       const ListEquality<CsrInstanceConfig>().hash(registers);
 }

--- a/lib/src/memory/csr/config/csr_block_config.dart
+++ b/lib/src/memory/csr/config/csr_block_config.dart
@@ -26,21 +26,21 @@ class CsrBlockConfig extends CsrContainerConfig {
   /// Registers in this block.
   final List<CsrInstanceConfig> registers;
 
-  /// Optional override for the number of address bits dedicated to registers
-  /// within this block.
+  /// Optional override for the number of addresses in this block's
+  /// address space.
   ///
   /// When set, this value takes precedence over the uniform
-  /// [CsrTopConfig.blockOffsetWidth] for this specific block, enabling
+  /// [CsrTopConfig.blockSize] for this specific block, enabling
   /// heterogeneous block sizes within the same top-level module. When `null`
-  /// (the default), the top-level [CsrTopConfig.blockOffsetWidth] is used.
-  final int? blockOffsetWidth;
+  /// (the default), the top-level [CsrTopConfig.blockSize] is used.
+  final int? blockSize;
 
   /// Construct a new block configuration.
   CsrBlockConfig({
     required super.name,
     required this.baseAddr,
     required List<CsrInstanceConfig> registers,
-    this.blockOffsetWidth,
+    this.blockSize,
   }) : registers = List.unmodifiable(registers) {
     // validate the block
     _validate();
@@ -85,27 +85,32 @@ class CsrBlockConfig extends CsrContainerConfig {
       throw CsrValidationException(issues.join('\n'));
     }
 
-    // if a blockOffsetWidth override is provided, validate it is large enough
-    if (blockOffsetWidth != null && blockOffsetWidth! < minAddrBits()) {
+    // if a blockSize override is provided, validate it is large enough
+    if (blockSize != null && blockSize! < minBlockSize()) {
       throw CsrValidationException(
-          'Block $name has a blockOffsetWidth of $blockOffsetWidth which is '
-          'too small to address all registers. The minimum is ${minAddrBits()}.');
+          'Block $name has a blockSize of $blockSize which is '
+          'too small to address all registers. '
+          'The minimum block size is ${minBlockSize()}.');
     }
   }
 
-  /// Method to determine the minimum number of address bits
-  /// needed to address all registers in the block. This is
-  /// based on the maximum register address offset.
-  @override
-  int minAddrBits() {
+  /// Returns the minimum block size (number of addresses) needed to
+  /// cover all registers in this block.
+  int minBlockSize() {
     var maxAddr = 0;
     for (final reg in registers) {
       if (reg.addr > maxAddr) {
         maxAddr = reg.addr;
       }
     }
-    return maxAddr.bitLength;
+    return maxAddr + 1;
   }
+
+  /// Method to determine the minimum number of address bits
+  /// needed to address all registers in the block. This is
+  /// based on the maximum register address offset.
+  @override
+  int minAddrBits() => (minBlockSize() - 1).bitLength;
 
   /// Method to determine the maximum register size.
   /// This is important for interface data width validation.
@@ -126,7 +131,7 @@ class CsrBlockConfig extends CsrContainerConfig {
         name: name,
         baseAddr: baseAddr,
         registers: registers,
-        blockOffsetWidth: blockOffsetWidth,
+        blockSize: blockSize,
       );
 
   @override
@@ -138,7 +143,7 @@ class CsrBlockConfig extends CsrContainerConfig {
     return other is CsrBlockConfig &&
         super == other &&
         other.baseAddr == baseAddr &&
-        other.blockOffsetWidth == blockOffsetWidth &&
+        other.blockSize == blockSize &&
         const ListEquality<CsrInstanceConfig>()
             .equals(other.registers, registers);
   }
@@ -147,6 +152,6 @@ class CsrBlockConfig extends CsrContainerConfig {
   int get hashCode =>
       super.hashCode ^
       baseAddr.hashCode ^
-      blockOffsetWidth.hashCode ^
+      blockSize.hashCode ^
       const ListEquality<CsrInstanceConfig>().hash(registers);
 }

--- a/lib/src/memory/csr/config/csr_top_config.dart
+++ b/lib/src/memory/csr/config/csr_top_config.dart
@@ -18,10 +18,12 @@ import 'package:rohd_hcl/src/memory/csr/config/csr_container_config.dart';
 /// any conditional blocks should take place.
 @immutable
 class CsrTopConfig extends CsrContainerConfig {
-  /// Address bits dedicated to the individual registers.
+  /// Default number of address bits dedicated to registers within each block.
   ///
   /// This is effectively the number of LSBs in an incoming address
-  /// to ignore when assessing the address of a block.
+  /// to ignore when assessing the address of a block. Individual blocks may
+  /// override this value via [CsrBlockConfig.blockOffsetWidth] to support
+  /// heterogeneous block sizes.
   final int blockOffsetWidth;
 
   /// Blocks in this module.
@@ -35,6 +37,14 @@ class CsrTopConfig extends CsrContainerConfig {
   }) : blocks = List.unmodifiable(blocks) {
     _validate();
   }
+
+  /// Returns the effective block offset width for [block].
+  ///
+  /// If the block has its own [CsrBlockConfig.blockOffsetWidth] set, that
+  /// value is returned; otherwise the top-level [blockOffsetWidth] default
+  /// is used.
+  int blockOffsetWidthForBlock(CsrBlockConfig block) =>
+      block.blockOffsetWidth ?? blockOffsetWidth;
 
   /// Accessor to the config of a particular register block
   /// within the module by name [name].
@@ -63,13 +73,21 @@ class CsrTopConfig extends CsrContainerConfig {
     // no two blocks with the same name
     // no two blocks with the same base address
     // no two blocks with base addresses that are too close together
-    // also compute the max min address bits across the blocks
+    // also check that each block's effective offset width is large enough
     final issues = <String>[];
-    var maxMinAddrBits = 0;
     for (var i = 0; i < blocks.length; i++) {
-      final currMaxMin = blocks[i].minAddrBits();
-      if (currMaxMin > maxMinAddrBits) {
-        maxMinAddrBits = currMaxMin;
+      final effectiveWidthI = blockOffsetWidthForBlock(blocks[i]);
+
+      // verify that the effective offset width can address all registers
+      // in this block (only needs to be checked here for blocks that use the
+      // top-level default; blocks with their own override are validated in
+      // CsrBlockConfig directly)
+      if (blocks[i].blockOffsetWidth == null &&
+          effectiveWidthI < blocks[i].minAddrBits()) {
+        issues.add(
+            'Block offset width $effectiveWidthI is too small to address all '
+            'registers in block ${blocks[i].name}. The minimum offset width '
+            'for this block is ${blocks[i].minAddrBits()}.');
       }
 
       for (var j = i + 1; j < blocks.length; j++) {
@@ -80,24 +98,25 @@ class CsrTopConfig extends CsrContainerConfig {
         if (blocks[i].baseAddr == blocks[j].baseAddr) {
           issues.add(
               'Register block ${blocks[i].name} has a duplicate base address.');
-        } else if ((blocks[i].baseAddr - blocks[j].baseAddr).abs().bitLength <
-            blockOffsetWidth) {
-          issues.add(
-              'Register blocks ${blocks[i].name} and ${blocks[j].name} are '
-              'too close together per the block offset width.');
+        } else {
+          // two blocks must be spaced far enough apart that neither block's
+          // address range overlaps the other; use the larger of the two
+          // effective offset widths as the required minimum separation
+          final effectiveWidthJ = blockOffsetWidthForBlock(blocks[j]);
+          final minSeparation = effectiveWidthI > effectiveWidthJ
+              ? effectiveWidthI
+              : effectiveWidthJ;
+          if ((blocks[i].baseAddr - blocks[j].baseAddr).abs().bitLength <
+              minSeparation) {
+            issues.add(
+                'Register blocks ${blocks[i].name} and ${blocks[j].name} are '
+                'too close together per their block offset widths.');
+          }
         }
       }
     }
     if (issues.isNotEmpty) {
       throw CsrValidationException(issues.join('\n'));
-    }
-
-    // is the block offset width big enough to address
-    // every register in every block
-    if (blockOffsetWidth < maxMinAddrBits) {
-      throw CsrValidationException(
-          'Block offset width is too small to address all register in all '
-          'blocks in the module. The minimum offset width is $maxMinAddrBits.');
     }
   }
 

--- a/lib/src/memory/csr/config/csr_top_config.dart
+++ b/lib/src/memory/csr/config/csr_top_config.dart
@@ -18,13 +18,11 @@ import 'package:rohd_hcl/src/memory/csr/config/csr_container_config.dart';
 /// any conditional blocks should take place.
 @immutable
 class CsrTopConfig extends CsrContainerConfig {
-  /// Default number of address bits dedicated to registers within each block.
+  /// Default number of addresses in each block's address space.
   ///
-  /// This is effectively the number of LSBs in an incoming address
-  /// to ignore when assessing the address of a block. Individual blocks may
-  /// override this value via [CsrBlockConfig.blockOffsetWidth] to support
-  /// heterogeneous block sizes.
-  final int blockOffsetWidth;
+  /// Individual blocks may override this value via
+  /// [CsrBlockConfig.blockSize] to support heterogeneous block sizes.
+  final int blockSize;
 
   /// Blocks in this module.
   final List<CsrBlockConfig> blocks;
@@ -32,19 +30,23 @@ class CsrTopConfig extends CsrContainerConfig {
   /// Construct a new top level configuration.
   CsrTopConfig({
     required super.name,
-    required this.blockOffsetWidth,
+    required this.blockSize,
     required List<CsrBlockConfig> blocks,
   }) : blocks = List.unmodifiable(blocks) {
     _validate();
   }
 
-  /// Returns the effective block offset width for [block].
+  /// Returns the effective block size for [block].
   ///
-  /// If the block has its own [CsrBlockConfig.blockOffsetWidth] set, that
-  /// value is returned; otherwise the top-level [blockOffsetWidth] default
+  /// If the block has its own [CsrBlockConfig.blockSize] set, that
+  /// value is returned; otherwise the top-level [blockSize] default
   /// is used.
+  int blockSizeForBlock(CsrBlockConfig block) => block.blockSize ?? blockSize;
+
+  /// Returns the number of address offset bits needed to index within
+  /// [block], derived from the effective block size.
   int blockOffsetWidthForBlock(CsrBlockConfig block) =>
-      block.blockOffsetWidth ?? blockOffsetWidth;
+      (blockSizeForBlock(block) - 1).bitLength;
 
   /// Accessor to the config of a particular register block
   /// within the module by name [name].
@@ -73,21 +75,20 @@ class CsrTopConfig extends CsrContainerConfig {
     // no two blocks with the same name
     // no two blocks with the same base address
     // no two blocks with base addresses that are too close together
-    // also check that each block's effective offset width is large enough
+    // also check that each block's effective size is large enough
     final issues = <String>[];
     for (var i = 0; i < blocks.length; i++) {
-      final effectiveWidthI = blockOffsetWidthForBlock(blocks[i]);
+      final effectiveSizeI = blockSizeForBlock(blocks[i]);
 
-      // verify that the effective offset width can address all registers
+      // verify that the effective block size can address all registers
       // in this block (only needs to be checked here for blocks that use the
       // top-level default; blocks with their own override are validated in
       // CsrBlockConfig directly)
-      if (blocks[i].blockOffsetWidth == null &&
-          effectiveWidthI < blocks[i].minAddrBits()) {
-        issues.add(
-            'Block offset width $effectiveWidthI is too small to address all '
-            'registers in block ${blocks[i].name}. The minimum offset width '
-            'for this block is ${blocks[i].minAddrBits()}.');
+      if (blocks[i].blockSize == null &&
+          effectiveSizeI < blocks[i].minBlockSize()) {
+        issues.add('Block size $effectiveSizeI is too small to address all '
+            'registers in block ${blocks[i].name}. The minimum block size '
+            'for this block is ${blocks[i].minBlockSize()}.');
       }
 
       for (var j = i + 1; j < blocks.length; j++) {
@@ -101,21 +102,21 @@ class CsrTopConfig extends CsrContainerConfig {
         } else {
           // the block whose base address comes first in the address space
           // must not bleed into the block that comes second, based on
-          // the first block's effective offset width (i.e., size)
-          final effectiveWidthJ = blockOffsetWidthForBlock(blocks[j]);
+          // the first block's effective size
+          final effectiveSizeJ = blockSizeForBlock(blocks[j]);
           final int separation;
-          final int firstBlockWidth;
+          final int firstBlockSize;
           if (blocks[i].baseAddr < blocks[j].baseAddr) {
             separation = blocks[j].baseAddr - blocks[i].baseAddr;
-            firstBlockWidth = effectiveWidthI;
+            firstBlockSize = effectiveSizeI;
           } else {
             separation = blocks[i].baseAddr - blocks[j].baseAddr;
-            firstBlockWidth = effectiveWidthJ;
+            firstBlockSize = effectiveSizeJ;
           }
-          if (separation.bitLength <= firstBlockWidth) {
+          if (separation < firstBlockSize) {
             issues.add(
                 'Register blocks ${blocks[i].name} and ${blocks[j].name} are '
-                'too close together per their block offset widths.');
+                'too close together per their block sizes.');
           }
         }
       }
@@ -128,7 +129,7 @@ class CsrTopConfig extends CsrContainerConfig {
   /// Method to determine the minimum number of address bits
   /// needed to address all registers across all blocks. This is
   /// based on the maximum block base address. Note that we independently
-  /// validate the block offset width relative to the base addresses
+  /// validate the block size relative to the base addresses
   /// so we can trust the simpler analysis here.
   @override
   int minAddrBits() {
@@ -158,12 +159,12 @@ class CsrTopConfig extends CsrContainerConfig {
   @override
   CsrTopConfig clone({
     String? name,
-    int? blockOffsetWidth,
+    int? blockSize,
     List<CsrBlockConfig>? blocks,
   }) =>
       CsrTopConfig(
         name: name ?? this.name,
-        blockOffsetWidth: blockOffsetWidth ?? this.blockOffsetWidth,
+        blockSize: blockSize ?? this.blockSize,
         blocks: blocks ?? this.blocks,
       );
 
@@ -175,7 +176,7 @@ class CsrTopConfig extends CsrContainerConfig {
 
     return other is CsrTopConfig &&
         super == other &&
-        blockOffsetWidth == other.blockOffsetWidth &&
+        blockSize == other.blockSize &&
         blocks.length == other.blocks.length &&
         const ListEquality<CsrBlockConfig>().equals(blocks, other.blocks);
   }
@@ -183,6 +184,6 @@ class CsrTopConfig extends CsrContainerConfig {
   @override
   int get hashCode =>
       super.hashCode ^
-      blockOffsetWidth.hashCode ^
+      blockSize.hashCode ^
       const ListEquality<CsrBlockConfig>().hash(blocks);
 }

--- a/lib/src/memory/csr/config/csr_top_config.dart
+++ b/lib/src/memory/csr/config/csr_top_config.dart
@@ -99,15 +99,20 @@ class CsrTopConfig extends CsrContainerConfig {
           issues.add(
               'Register block ${blocks[i].name} has a duplicate base address.');
         } else {
-          // two blocks must be spaced far enough apart that neither block's
-          // address range overlaps the other; use the larger of the two
-          // effective offset widths as the required minimum separation
+          // the block whose base address comes first in the address space
+          // must not bleed into the block that comes second, based on
+          // the first block's effective offset width (i.e., size)
           final effectiveWidthJ = blockOffsetWidthForBlock(blocks[j]);
-          final minSeparation = effectiveWidthI > effectiveWidthJ
-              ? effectiveWidthI
-              : effectiveWidthJ;
-          if ((blocks[i].baseAddr - blocks[j].baseAddr).abs().bitLength <
-              minSeparation) {
+          final int separation;
+          final int firstBlockWidth;
+          if (blocks[i].baseAddr < blocks[j].baseAddr) {
+            separation = blocks[j].baseAddr - blocks[i].baseAddr;
+            firstBlockWidth = effectiveWidthI;
+          } else {
+            separation = blocks[i].baseAddr - blocks[j].baseAddr;
+            firstBlockWidth = effectiveWidthJ;
+          }
+          if (separation.bitLength <= firstBlockWidth) {
             issues.add(
                 'Register blocks ${blocks[i].name} and ${blocks[j].name} are '
                 'too close together per their block offset widths.');

--- a/lib/src/memory/csr/csr_top.dart
+++ b/lib/src/memory/csr/csr_top.dart
@@ -108,14 +108,15 @@ class CsrTop extends CsrContainer {
       DataPortInterface? blockFdWrite;
       DataPortInterface? blockFdRead;
 
+      final blockOffsetW = config.blockOffsetWidthForBlock(block);
+
       if (frontWritePresent) {
-        blockFdWrite =
-            DataPortInterface(frontWrite!.dataWidth, blockOffsetWidth);
+        blockFdWrite = DataPortInterface(frontWrite!.dataWidth, blockOffsetW);
         _fdWrites.add(blockFdWrite);
       }
 
       if (frontReadPresent) {
-        blockFdRead = DataPortInterface(frontRead!.dataWidth, blockOffsetWidth);
+        blockFdRead = DataPortInterface(frontRead!.dataWidth, blockOffsetW);
         _fdReads.add(blockFdRead);
       }
 
@@ -168,34 +169,41 @@ class CsrTop extends CsrContainer {
     // address width must be at least wide enough
     // to address all registers in all blocks
 
+    // compute the maximum effective block offset width across all blocks
+    final maxBlockOffsetWidth = config.blocks
+        .map(config.blockOffsetWidthForBlock)
+        .fold(0, (a, b) => a > b ? a : b);
+
     if (frontReadPresent) {
-      if (frontRead!.addrWidth < blockOffsetWidth) {
+      if (frontRead!.addrWidth < maxBlockOffsetWidth) {
         throw CsrValidationException(
             'Frontdoor read interface address width must be '
-            'at least $blockOffsetWidth.');
+            'at least $maxBlockOffsetWidth.');
       }
     }
 
     if (frontWritePresent) {
-      if (frontWrite!.addrWidth < blockOffsetWidth) {
+      if (frontWrite!.addrWidth < maxBlockOffsetWidth) {
         throw CsrValidationException(
             'Frontdoor write interface address width must be '
-            'at least $blockOffsetWidth.');
+            'at least $maxBlockOffsetWidth.');
       }
     }
   }
 
   void _buildLogic() {
     if (frontWritePresent) {
-      // mask out LSBs to perform a match on block
-      final maskedFrontWrAddr = frontWrite!.addr &
-          ~Const((1 << blockOffsetWidth) - 1, width: addrWidth);
-
-      // shift out MSBs to pass the appropriate address into the blocks
-      final shiftedFrontWrAddr = frontWrite!.addr.getRange(0, blockOffsetWidth);
-
-      // drive frontdoor write and read inputs
+      // drive frontdoor write inputs per block using each block's own mask
       for (var i = 0; i < _blocks.length; i++) {
+        final offsetWidth = config.blockOffsetWidthForBlock(config.blocks[i]);
+
+        // mask out LSBs to perform a match on block
+        final maskedFrontWrAddr =
+            frontWrite!.addr & ~Const((1 << offsetWidth) - 1, width: addrWidth);
+
+        // extract the in-block register address
+        final shiftedFrontWrAddr = frontWrite!.addr.getRange(0, offsetWidth);
+
         _fdWrites[i].en <=
             frontWrite!.en &
                 maskedFrontWrAddr
@@ -207,42 +215,31 @@ class CsrTop extends CsrContainer {
     }
 
     if (frontReadPresent) {
-      // mask out LSBs to perform a match on block
-      final maskedFrontRdAddr = (frontRead!.addr &
-              ~Const((1 << blockOffsetWidth) - 1, width: addrWidth))
-          .named('maskFrontRdAddr');
+      // per-block address match signals
+      final blockReadMatches = List.generate(_blocks.length, (i) {
+        final offsetWidth = config.blockOffsetWidthForBlock(config.blocks[i]);
+        return (frontRead!.addr &
+                ~Const((1 << offsetWidth) - 1, width: addrWidth))
+            .named('maskedFrontRdAddr_$i')
+            .eq(Const(_blocks[i].baseAddr, width: addrWidth));
+      });
 
-      // shift out MSBs to pass the appropriate address into the blocks
-      final shiftedFrontRdAddr = frontRead!.addr.getRange(0, blockOffsetWidth);
-
-      // drive frontdoor write and read inputs
+      // drive frontdoor read enable and address per block
       for (var i = 0; i < _blocks.length; i++) {
-        _fdReads[i].en <=
-            frontRead!.en &
-                maskedFrontRdAddr
-                    .eq(Const(_blocks[i].baseAddr, width: addrWidth));
-
-        _fdReads[i].addr <= shiftedFrontRdAddr;
+        final offsetWidth = config.blockOffsetWidthForBlock(config.blocks[i]);
+        _fdReads[i].en <= frontRead!.en & blockReadMatches[i];
+        _fdReads[i].addr <= frontRead!.addr.getRange(0, offsetWidth);
       }
 
-      // capture frontdoor read output
+      // capture frontdoor read output via Iff/ElseIf/Else on per-block matches
       final rdData = Logic(name: 'internalRdData', width: frontRead!.dataWidth);
-      final rdCases = _blocks
-          .asMap()
-          .entries
-          .map((block) =>
-              CaseItem(Const(block.value.baseAddr, width: addrWidth), [
-                rdData < _fdReads[block.key].data,
-              ]))
-          .toList();
       Combinational([
-        Case(
-            maskedFrontRdAddr,
-            conditionalType: ConditionalType.unique,
-            rdCases,
-            defaultItem: [
-              rdData < Const(0, width: frontRead!.dataWidth),
-            ]),
+        If.block([
+          Iff(blockReadMatches[0], [rdData < _fdReads[0].data]),
+          for (var i = 1; i < _blocks.length; i++)
+            ElseIf(blockReadMatches[i], [rdData < _fdReads[i].data]),
+          Else([rdData < Const(0, width: frontRead!.dataWidth)]),
+        ]),
       ]);
       frontRead!.data <= rdData;
     }

--- a/lib/src/memory/csr/csr_top.dart
+++ b/lib/src/memory/csr/csr_top.dart
@@ -42,8 +42,8 @@ class CsrTop extends CsrContainer {
   final List<List<CsrBackdoorInterface>> _backdoorInterfaces = [];
   final List<Map<int, int>> _backdoorIndexMaps = [];
 
-  /// Getter for the block offset width.
-  int get blockOffsetWidth => config.blockOffsetWidth;
+  /// Getter for the block size.
+  int get blockSize => config.blockSize;
 
   /// Getter for the block configurations of the CSR.
   List<CsrBlockConfig> get blocks => config.blocks;
@@ -99,7 +99,7 @@ class CsrTop extends CsrContainer {
             definitionName: definitionName ??
                 'CsrTop_A${config.minAddrBits()}_'
                     'W${config.maxRegWidth()}_'
-                    'BO${config.blockOffsetWidth}_'
+                    'BS${config.blockSize}_'
                     'LR${allowLargerRegisters}_'
                     'RI$logicalRegisterIncrement') {
     _validate();

--- a/test/memory/csr_test.dart
+++ b/test/memory/csr_test.dart
@@ -128,6 +128,54 @@ class MyCsrModule extends CsrTopConfig {
         ]);
 }
 
+/// A CSR module with heterogeneous block offset widths for testing.
+///
+/// - block_large: uses the default [blockOffsetWidth] of 8.
+/// - block_small: overrides to a smaller [blockOffsetWidth] of 4.
+class MyHeterogeneousCsrModule extends CsrTopConfig {
+  MyHeterogeneousCsrModule()
+      : super(
+          name: 'myHeterogeneousCsrModule',
+          blockOffsetWidth: 8, // default for blocks without their own override
+          blocks: [
+            // block_large uses the default blockOffsetWidth = 8
+            MyRegisterBlock(
+              baseAddr: 0x000,
+              name: 'block_large',
+              csrWidth: 32,
+              numNoFieldCsrs: 2,
+            ),
+            // block_small overrides to a smaller blockOffsetWidth = 4
+            CsrBlockConfig(
+              name: 'block_small',
+              baseAddr: 0x100,
+              blockOffsetWidth: 4,
+              registers: [
+                CsrInstanceConfig(
+                  arch: CsrConfig(
+                    access: CsrAccess.readWrite,
+                    name: 'sReg0',
+                    fields: const [],
+                  ),
+                  addr: 0x0,
+                  width: 32,
+                ),
+                CsrInstanceConfig(
+                  arch: CsrConfig(
+                    access: CsrAccess.readOnly,
+                    name: 'sReg1',
+                    fields: const [],
+                  ),
+                  addr: 0x1,
+                  width: 32,
+                  resetValue: 0xABCD1234,
+                ),
+              ],
+            ),
+          ],
+        );
+}
+
 // to test potentially issues with CsrTop port propagation
 class DummyCsrTopModule extends Module {
   late final Logic _clk;
@@ -474,6 +522,132 @@ void main() {
     await mod.build();
   });
 
+  test('CSR top with heterogeneous block offset widths', () async {
+    const csrWidth = 32;
+
+    final csrTopCfg = MyHeterogeneousCsrModule();
+
+    final clk = SimpleClockGenerator(10).clk;
+    final reset = Logic()..inject(0);
+    final wIntf = DataPortInterface(csrWidth, 32);
+    final rIntf = DataPortInterface(csrWidth, 32);
+    final csrTop = CsrTop(
+        config: csrTopCfg,
+        clk: clk,
+        reset: reset,
+        frontWrite: wIntf,
+        frontRead: rIntf,
+        allowLargerRegisters: true);
+
+    wIntf.en.inject(0);
+    wIntf.addr.inject(0);
+    wIntf.data.inject(0);
+    rIntf.en.inject(0);
+    rIntf.addr.inject(0);
+
+    await csrTop.build();
+
+    for (var i = 0; i < csrTop.backdoorInterfaces.length; i++) {
+      for (var j = 0; j < csrTop.backdoorInterfaces[i].length; j++) {
+        if (csrTop.backdoorInterfaces[i][j].hasWrite) {
+          csrTop.backdoorInterfaces[i][j].wrEn!.put(0);
+          csrTop.backdoorInterfaces[i][j].wrData!.put(0);
+        }
+      }
+    }
+
+    Simulator.setMaxSimTime(10000);
+    unawaited(Simulator.run());
+
+    final blockLarge = csrTop.getBlockByName('block_large');
+    final blockSmall = csrTop.getBlockByName('block_small');
+    final largeCsr1 = blockLarge.getRegisterByName('csr1');
+    final smallSReg0 = blockSmall.getRegisterByName('sReg0');
+    final smallSReg1 = blockSmall.getRegisterByName('sReg1');
+
+    // check that block offset widths are as configured
+    expect(csrTopCfg.blockOffsetWidthForBlock(blockLarge), 8);
+    expect(csrTopCfg.blockOffsetWidthForBlock(blockSmall), 4);
+
+    // perform a reset
+    reset.inject(1);
+    await clk.waitCycles(10);
+    reset.inject(0);
+    await clk.waitCycles(10);
+
+    // read small block's read-only register (has reset value 0xABCD1234)
+    final addrSmall1 = blockSmall.baseAddr + smallSReg1.addr;
+    await clk.nextNegedge;
+    rIntf.en.inject(1);
+    rIntf.addr.inject(addrSmall1);
+    await clk.nextNegedge;
+    rIntf.en.inject(0);
+    expect(rIntf.data.value,
+        LogicValue.ofInt(smallSReg1.resetValue, rIntf.dataWidth));
+    await clk.waitCycles(10);
+
+    // attempt a write to small block's read-only register (sReg1) and verify
+    // it has no effect
+    await clk.nextNegedge;
+    wIntf.en.inject(1);
+    wIntf.addr.inject(addrSmall1);
+    wIntf.data.inject(0xDEADBEEF);
+    await clk.nextNegedge;
+    wIntf.en.inject(0);
+    rIntf.en.inject(1);
+    rIntf.addr.inject(addrSmall1);
+    await clk.nextNegedge;
+    rIntf.en.inject(0);
+    // read-only, so value should remain the reset value
+    expect(rIntf.data.value,
+        LogicValue.ofInt(smallSReg1.resetValue, rIntf.dataWidth));
+    await clk.waitCycles(10);
+
+    // write to small block's read-write register (sReg0) and verify
+    final addrSmall0 = blockSmall.baseAddr + smallSReg0.addr;
+    await clk.nextNegedge;
+    wIntf.en.inject(1);
+    wIntf.addr.inject(addrSmall0);
+    wIntf.data.inject(0x12345678);
+    await clk.nextNegedge;
+    wIntf.en.inject(0);
+    rIntf.en.inject(1);
+    rIntf.addr.inject(addrSmall0);
+    await clk.nextNegedge;
+    rIntf.en.inject(0);
+    expect(rIntf.data.value, LogicValue.ofInt(0x12345678, rIntf.dataWidth));
+    await clk.waitCycles(10);
+
+    // write to large block's csr1 and verify: fields restrict the written value
+    final addrLarge1 = blockLarge.baseAddr + largeCsr1.addr;
+    await clk.nextNegedge;
+    wIntf.en.inject(1);
+    wIntf.addr.inject(addrLarge1);
+    wIntf.data.inject(0xbeefdead);
+    await clk.nextNegedge;
+    wIntf.en.inject(0);
+    rIntf.en.inject(1);
+    rIntf.addr.inject(addrLarge1);
+    await clk.nextNegedge;
+    rIntf.en.inject(0);
+    // same field-masked result as in the uniform test
+    expect(rIntf.data.value, LogicValue.ofInt(0xef00f3, rIntf.dataWidth));
+    await clk.waitCycles(10);
+
+    // confirm small block sReg0 still holds its written value
+    // (write to large block must not corrupt small block)
+    await clk.nextNegedge;
+    rIntf.en.inject(1);
+    rIntf.addr.inject(addrSmall0);
+    await clk.nextNegedge;
+    rIntf.en.inject(0);
+    expect(rIntf.data.value, LogicValue.ofInt(0x12345678, rIntf.dataWidth));
+    await clk.waitCycles(10);
+
+    await Simulator.endSimulation();
+    await Simulator.simulationEnded;
+  });
+
   group('omitted front-door interfaces', () {
     test('no front write', () {
       CsrTop(
@@ -656,6 +830,59 @@ void main() {
                     width: 4)
               ])
             ]),
+        throwsA(isA<CsrValidationException>()));
+
+    // illegal block-level blockOffsetWidth override: too small for its registers
+    expect(
+        () => CsrBlockConfig(
+              name: 'block',
+              baseAddr: 0x0,
+              blockOffsetWidth: 2, // too small: reg at addr=0x4 needs 3 bits
+              registers: [
+                CsrInstanceConfig(
+                    arch: CsrConfig(
+                        access: CsrAccess.readWrite,
+                        name: 'reg',
+                        fields: const []),
+                    addr: 0x4,
+                    width: 4)
+              ],
+            ),
+        throwsA(isA<CsrValidationException>()));
+
+    // illegal top - blocks too close considering larger per-block offset override
+    expect(
+        () => CsrTopConfig(
+              name: 'top',
+              blockOffsetWidth: 4, // default
+              blocks: [
+                CsrBlockConfig(
+                    name: 'block0',
+                    baseAddr: 0x0,
+                    blockOffsetWidth: 8, // override: needs 256-address space
+                    registers: [
+                      CsrInstanceConfig(
+                          arch: CsrConfig(
+                              access: CsrAccess.readWrite,
+                              name: 'reg',
+                              fields: const []),
+                          addr: 0x0,
+                          width: 4)
+                    ]),
+                CsrBlockConfig(
+                    name: 'block1',
+                    baseAddr: 0x10, // only 16 away from block0 - too close
+                    registers: [
+                      CsrInstanceConfig(
+                          arch: CsrConfig(
+                              access: CsrAccess.readWrite,
+                              name: 'reg',
+                              fields: const []),
+                          addr: 0x0,
+                          width: 4)
+                    ]),
+              ],
+            ),
         throwsA(isA<CsrValidationException>()));
   });
 }

--- a/test/memory/csr_test.dart
+++ b/test/memory/csr_test.dart
@@ -116,7 +116,7 @@ class MyCsrModule extends CsrTopConfig {
   MyCsrModule({
     this.numBlocks = 1,
     super.name = 'myCsrModule',
-    super.blockOffsetWidth = 8,
+    super.blockSize = 256,
   }) : super(blocks: [
           // example of dynamic block instantiation
           for (var i = 0; i < numBlocks; i++)
@@ -128,28 +128,28 @@ class MyCsrModule extends CsrTopConfig {
         ]);
 }
 
-/// A CSR module with heterogeneous block offset widths for testing.
+/// A CSR module with heterogeneous block sizes for testing.
 ///
-/// - block_large: uses the default [blockOffsetWidth] of 8.
-/// - block_small: overrides to a smaller [blockOffsetWidth] of 4.
+/// - block_large: uses the default [blockSize] of 256.
+/// - block_small: overrides to a smaller [blockSize] of 16.
 class MyHeterogeneousCsrModule extends CsrTopConfig {
   MyHeterogeneousCsrModule()
       : super(
           name: 'myHeterogeneousCsrModule',
-          blockOffsetWidth: 8, // default for blocks without their own override
+          blockSize: 256, // default for blocks without their own override
           blocks: [
-            // block_large uses the default blockOffsetWidth = 8
+            // block_large uses the default blockSize = 256
             MyRegisterBlock(
               baseAddr: 0x000,
               name: 'block_large',
               csrWidth: 32,
               numNoFieldCsrs: 2,
             ),
-            // block_small overrides to a smaller blockOffsetWidth = 4
+            // block_small overrides to a smaller blockSize = 16
             CsrBlockConfig(
               name: 'block_small',
               baseAddr: 0x100,
-              blockOffsetWidth: 4,
+              blockSize: 16,
               registers: [
                 CsrInstanceConfig(
                   arch: CsrConfig(
@@ -565,9 +565,9 @@ void main() {
     final smallSReg0 = blockSmall.getRegisterByName('sReg0');
     final smallSReg1 = blockSmall.getRegisterByName('sReg1');
 
-    // check that block offset widths are as configured
-    expect(csrTopCfg.blockOffsetWidthForBlock(blockLarge), 8);
-    expect(csrTopCfg.blockOffsetWidthForBlock(blockSmall), 4);
+    // check that block sizes are as configured
+    expect(csrTopCfg.blockSizeForBlock(blockLarge), 256);
+    expect(csrTopCfg.blockSizeForBlock(blockSmall), 16);
 
     // perform a reset
     reset.inject(1);
@@ -804,13 +804,12 @@ void main() {
         throwsA(isA<CsrValidationException>()));
 
     // illegal top - empty
-    expect(
-        () => CsrTopConfig(name: 'top', blockOffsetWidth: 8, blocks: const []),
+    expect(() => CsrTopConfig(name: 'top', blockSize: 256, blocks: const []),
         throwsA(isA<CsrValidationException>()));
 
     // illegal top - duplication and closeness
     expect(
-        () => CsrTopConfig(name: 'top', blockOffsetWidth: 8, blocks: [
+        () => CsrTopConfig(name: 'top', blockSize: 256, blocks: [
               CsrBlockConfig(name: 'block', baseAddr: 0x0, registers: const []),
               CsrBlockConfig(name: 'block', baseAddr: 0x1, registers: const []),
               CsrBlockConfig(name: 'block1', baseAddr: 0x1, registers: const [])
@@ -819,7 +818,7 @@ void main() {
 
     // illegal top - bad block offset width
     expect(
-        () => CsrTopConfig(name: 'top', blockOffsetWidth: 1, blocks: [
+        () => CsrTopConfig(name: 'top', blockSize: 2, blocks: [
               CsrBlockConfig(name: 'block', baseAddr: 0x0, registers: [
                 CsrInstanceConfig(
                     arch: CsrConfig(
@@ -832,12 +831,12 @@ void main() {
             ]),
         throwsA(isA<CsrValidationException>()));
 
-    // illegal block-level blockOffsetWidth override: too small for its registers
+    // illegal block-level blockSize override: too small for its registers
     expect(
         () => CsrBlockConfig(
               name: 'block',
               baseAddr: 0x0,
-              blockOffsetWidth: 2, // too small: reg at addr=0x4 needs 3 bits
+              blockSize: 4, // too small: reg at addr=0x4 needs size >= 5
               registers: [
                 CsrInstanceConfig(
                     arch: CsrConfig(
@@ -854,12 +853,12 @@ void main() {
     expect(
         () => CsrTopConfig(
               name: 'top',
-              blockOffsetWidth: 4, // default
+              blockSize: 16, // default
               blocks: [
                 CsrBlockConfig(
                     name: 'block0',
                     baseAddr: 0x0,
-                    blockOffsetWidth: 8, // override: needs 256-address space
+                    blockSize: 256, // override: needs 256-address space
                     registers: [
                       CsrInstanceConfig(
                           arch: CsrConfig(


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

In some cases, it is desirable within a `CsrTop` to have blocks that have different sizes. Currently, there is one universal block size that is applied to every block. This PR aims to relax that restriction.

## Related Issue(s)

N/A

## Testing

Added explicit unit tests to the Csr unit testing covering the case of heterogeneous block sizes within a `CsrTop`.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

This change is fully backwards compatible because to exercise this new behavior there is a new optional member attribute on `CsrBlockConfig`. By default, we fall back on the original behavior of a block size defined in `CsrTop`.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Csr documentation will be updated as needed.
