### PR TITLE
Minimum width on serializer's counter - Fix for issue 166

### DIFF
--- a/lib/src/count.dart
+++ b/lib/src/count.dart
@@ -7,7 +7,6 @@
 // 2023 July 11
 // Author: Rahul Gautham Putcha <rahul.gautham.putcha@intel.com>
 
-import 'dart:math';
 
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/src/utils.dart';
@@ -37,7 +36,7 @@ class Count extends Module {
       String? definitionName})
       : super(definitionName: definitionName ?? 'Count_W${bus.width}') {
     bus = addInput('bus', bus, width: bus.width);
-    Logic count = Const(0, width: max(1, log2Ceil(bus.width + 1)));
+    Logic count = Const(0, width: widthFor(bus.width + 1));
     for (var i = 0; i < bus.width; i++) {
       count = (count + (countOne ? bus[i] : ~bus[i]).zeroExtend(count.width))
           .named('count_$i');

--- a/lib/src/count.dart
+++ b/lib/src/count.dart
@@ -7,7 +7,6 @@
 // 2023 July 11
 // Author: Rahul Gautham Putcha <rahul.gautham.putcha@intel.com>
 
-
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/src/utils.dart';
 

--- a/lib/src/encodings/one_hot_to_binary.dart
+++ b/lib/src/encodings/one_hot_to_binary.dart
@@ -7,7 +7,6 @@
 // 2023 February 24
 // Author: Desmond Kirkpatrick
 
-import 'dart:math';
 
 import 'package:meta/meta.dart';
 import 'package:rohd/rohd.dart';
@@ -63,7 +62,7 @@ abstract class OneHotToBinary extends Module {
             definitionName:
                 definitionName ?? 'OneHotToBinary_W${onehot.width}') {
     onehot = addInput('onehot', onehot, width: onehot.width);
-    addOutput('binary', width: max(log2Ceil(onehot.width), 1));
+    addOutput('binary', width: widthFor(onehot.width));
 
     if (generateError) {
       addOutput('error');

--- a/lib/src/encodings/one_hot_to_binary.dart
+++ b/lib/src/encodings/one_hot_to_binary.dart
@@ -7,7 +7,6 @@
 // 2023 February 24
 // Author: Desmond Kirkpatrick
 
-
 import 'package:meta/meta.dart';
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';

--- a/lib/src/memory/fifo.dart
+++ b/lib/src/memory/fifo.dart
@@ -7,7 +7,6 @@
 // 2023 March 13
 // Author: Max Korbel <max.korbel@intel.com>
 
-import 'dart:math';
 
 import 'package:collection/collection.dart';
 import 'package:rohd/rohd.dart';
@@ -100,7 +99,7 @@ class Fifo<LogicType extends Logic> extends Module {
       String? definitionName,
       List<dynamic>? initialValues})
       : dataWidth = writeData.width,
-        _addrWidth = max(1, log2Ceil(depth)),
+        _addrWidth = widthFor(depth),
         super(
             definitionName:
                 definitionName ?? 'Fifo_D${depth}_W${writeData.width}') {

--- a/lib/src/memory/fifo.dart
+++ b/lib/src/memory/fifo.dart
@@ -7,7 +7,6 @@
 // 2023 March 13
 // Author: Max Korbel <max.korbel@intel.com>
 
-
 import 'package:collection/collection.dart';
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';

--- a/lib/src/serialization/serializer.dart
+++ b/lib/src/serialization/serializer.dart
@@ -9,6 +9,7 @@
 
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
+import 'dart:math' show max;
 
 /// Serializes wide aggregated data onto a narrower serialization stream.
 class Serializer extends Module {
@@ -63,7 +64,7 @@ class Serializer extends Module {
         dimensions: deserialized.dimensions,
         elementWidth: deserialized.elementWidth);
 
-    addOutput('count', width: log2Ceil(deserialized.dimensions[0]));
+    addOutput('count', width: max(1, log2Ceil(deserialized.dimensions[0])));
     addOutput('done');
 
     final reducedDimensions = List<int>.from(deserialized.dimensions)

--- a/lib/src/serialization/serializer.dart
+++ b/lib/src/serialization/serializer.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // serializer.dart

--- a/lib/src/serialization/serializer.dart
+++ b/lib/src/serialization/serializer.dart
@@ -6,7 +6,6 @@
 //
 // 2024 August 27
 // Author: desmond Kirkpatrick <desmond.a.kirkpatrick@intel.com>
-import 'dart:math' show max;
 
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
@@ -64,7 +63,7 @@ class Serializer extends Module {
         dimensions: deserialized.dimensions,
         elementWidth: deserialized.elementWidth);
 
-    addOutput('count', width: max(1, log2Ceil(deserialized.dimensions[0])));
+    addOutput('count', width: widthFor(deserialized.dimensions[0]));
     addOutput('done');
 
     final reducedDimensions = List<int>.from(deserialized.dimensions)

--- a/lib/src/serialization/serializer.dart
+++ b/lib/src/serialization/serializer.dart
@@ -6,10 +6,10 @@
 //
 // 2024 August 27
 // Author: desmond Kirkpatrick <desmond.a.kirkpatrick@intel.com>
+import 'dart:math' show max;
 
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
-import 'dart:math' show max;
 
 /// Serializes wide aggregated data onto a narrower serialization stream.
 class Serializer extends Module {

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -10,6 +10,13 @@ import 'package:rohd/rohd.dart';
 /// Computes the bit width needed to store [w] addresses.
 int log2Ceil(int w) => (log(w) / log(2)).ceil();
 
+/// Returns the minimum number of bits needed to represent [val] distinct
+/// values, with a minimum of 1 (since 0-width signals are not valid in
+/// hardware).
+///
+/// Equivalent to `max(1, log2Ceil(val))`.
+int widthFor(int val) => max(1, log2Ceil(val));
+
 /// Returns whether [n] is a power of two.
 bool isPowerOfTwo(int n) => n != 0 && (n & (n - 1) == 0);
 

--- a/test/serialization_test.dart
+++ b/test/serialization_test.dart
@@ -510,4 +510,37 @@ void main() {
     await clk.nextPosedge;
     await Simulator.endSimulation();
   });
+
+  // Regression test: a 1-element array previously produced a 0-wide count
+  // output (log2Ceil(1)==0), causing a build failure. Verify it builds and
+  // outputs the single element with done asserted on the first cycle.
+  test('serializer single element array', () async {
+    const width = 8;
+    final dataIn = LogicArray([1], width);
+    final clk = SimpleClockGenerator(10).clk;
+    final reset = Logic();
+
+    final mod = Serializer(dataIn, clk: clk, reset: reset);
+
+    dataIn.elements[0].put(42);
+
+    await mod.build();
+
+    // count must be at least 1 bit wide
+    expect(mod.count.width, greaterThanOrEqualTo(1));
+
+    unawaited(Simulator.run());
+
+    reset.inject(1);
+    await clk.nextPosedge;
+    reset.inject(0);
+    await clk.nextPosedge;
+
+    // With only 1 element, done and the correct value should appear immediately
+    await clk.nextNegedge;
+    expect(mod.serialized.value.toInt(), equals(42));
+    expect(mod.done.value.toBool(), isTrue);
+
+    await Simulator.endSimulation();
+  });
 }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

<!-- Description of changes, and motivation for adding them. -->
Ensuring a minimum width on serializer's counter.

## Related Issue(s)

<!-- If there are any issues related to this PR, please link to the issues here. -->
#166 

## Testing

<!-- Please describe how you tested your changes. -->
The test creates a Serializer with a 1-element LogicArray([1], 8) and asserts count.width >= 1 (the invariant fixed by max(1, ...)).
Then verifies the module builds and drives serialized = 42 with done = true on the first active clock cycle.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

<!-- Answer here. -->
No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

<!-- Answer here. -->
No