### PR TITLE
Multi-cycle divider improvements: FSM enum, 1's complement, and quotient-only mode

### DIFF
--- a/doc/components/divider.md
+++ b/doc/components/divider.md
@@ -1,10 +1,22 @@
 # Divider
 
-ROHD HCL provides an integer divider module to get the quotient and the remainder of dividend and divisor operands. The divider implementation is not pipelined and has a minimum latency of 3 cycles. The maximum latency is dependent on the width of the operands (upper bound of `O(WIDTH**2)`). Note that latency increases exponentially as the absolute difference between the dividend and the divisor increases (worst case: largest possible dividend and divisor of 1).
+ROHD HCL provides two multi-cycle integer divider modules that share a common interface:
+
+* `MultiCycleDivider` — uses **two's complement** signed arithmetic.
+* `OnesComplementDivider` — uses **one's complement** signed arithmetic.
+
+Both modules compute an integer quotient and, optionally, a remainder. The dividers are not pipelined and have a minimum latency of 3 cycles. The maximum latency depends on the width of the operands and the selected mode:
+
+| Mode | Algorithm | Latency upper bound |
+|------|-----------|---------------------|
+| `computeRemainder: true` (default) | O(n²) greedy | `O(WIDTH²)` |
+| `computeRemainder: false` | O(n) binary long-division | `O(WIDTH)` |
+
+In both modes, latency increases as the absolute difference between dividend and divisor increases (worst case: largest possible dividend, divisor of 1).
 
 ## Interface
 
-The inputs to the divider module are:
+Both modules share `MultiCycleDividerInterface`. The inputs are:
 
 * `clock` => clock for synchronous logic
 * `reset` => reset for synchronous logic (active high, synchronous to `clock`)
@@ -14,37 +26,74 @@ The inputs to the divider module are:
 * `validIn` => indication that a new division operation is being requested
 * `readyOut` => indication that the result of the current division can be consumed
 
-The outputs of the divider module are:
+The outputs are:
 
 * `quotient` => the result of the division
-* `remainder` => the remainder of the division
+* `remainder` => the remainder of the division (always 0 when `computeRemainder: false`)
 * `divZero` => divide by zero error indication
 * `validOut` => the result of the current division operation is ready
 * `readyIn` => the divider is ready to accept a new operation
 
 The numerical inputs (`dividend`, `divisor`, `quotient`, `remainder`) are parametrized by a constructor parameter called `dataWidth`. All other signals have a width of 1.
 
+## Constructor Parameters
+
+Both `MultiCycleDivider` and `OnesComplementDivider` accept:
+
+* `dataWidth` (via the interface) — bit width of all data operands and results (default: 32).
+* `computeRemainder` — when `true` (default), the remainder output is computed using the full O(n²) greedy algorithm. When `false`, the remainder output is always 0 and the divider uses an O(n) binary long-division algorithm with significantly lower worst-case latency.
+
+Both modules also provide an `ofLogics` factory constructor to instantiate directly from individual `Logic` signals instead of a pre-built interface.
+
 ## Protocol Description
 
-To initiate a new request, it is expected that the requestor drive `validIn` to high along with the numerical values for `dividend`, `divisor` and the `isSigned` indicator. The first cycle in which `readyIn` is high where the above occurs is the cycle in which the operation is accepted by the divider.
+To initiate a new request, drive `validIn` high along with `dividend`, `divisor`, and `isSigned`. The first cycle in which `readyIn` is high and these conditions hold is the cycle in which the operation is accepted.
 
-When the division is complete, the module will assert the `validOut` signal along with the numerical values of `quotient` and `remainder` representing the division result and the signal `divZero` to indicate whether or not a division by zero occurred. The module will hold these signal values until `readyOut` is driven high by the integrating environment. The integrating environment must assume that `quotient` and `remainder` are meaningless if `divZero` is asserted.
+When division completes, the module asserts `validOut` along with `quotient`, `remainder`, and `divZero`. These values are held until the integrating environment drives `readyOut` high. If `divZero` is asserted, `quotient` and `remainder` are meaningless.
 
 ## Mathematical Properties
 
-For the division, implicit rounding towards 0 is always performed. I.e., a negative quotient will always be rounded up if the dividend is not evenly divisible by the divisor. Note that this behavior is not uniform across all programming languages (for example, Python rounds towards negative infinity).
+Implicit rounding towards 0 is always performed (truncated division). A negative quotient is always rounded towards zero if the dividend is not evenly divisible by the divisor. Note that this differs from Python, which rounds towards negative infinity.
 
-For the remainder, the following equation will always precisely hold true: `dividend = divisor * quotient + remainder`. Note that this differs from the Euclidean modulo operator where the sign of the remainder is always positive.
+The remainder always satisfies: `dividend = divisor * quotient + remainder`. This differs from the Euclidean modulo operator, where the remainder is always non-negative.
 
-Overflow can only occur when `dividend=<max negative number>`, `divisor=-1` and `isSigned=1`. In this case, the hardware will return `quotient=<max negative number>` and `remainder=0`. This is by design as the mathematically correct quotient cannot be represented in the fixed number of bits available.
+### Two's Complement Overflow
+
+Overflow can only occur in `MultiCycleDivider` when `dividend = MIN_INT`, `divisor = -1`, and `isSigned = 1`. In this case the hardware returns `quotient = MIN_INT` and `remainder = 0`, since the mathematically correct result cannot be represented in the available bit width.
+
+### One's Complement Notes
+
+`OnesComplementDivider` uses one's complement signed representation, where both `+0` (`000…0`) and `-0` (`111…1`) exist. The value range is symmetric: `[-(2^(n-1)-1), +(2^(n-1)-1)]`, so the MIN_INT overflow case does not arise.
+
+A divisor of all-ones (`111…1`, i.e., negative zero) with `isSigned = 1` triggers the `divZero` output, in addition to the normal all-zeros check.
+
+The hardware benefit of one's complement is that sign correction in the convert stage requires only a bitwise invert (`~x`) rather than a full carry-propagate add (`~x + 1`), reducing the critical path in synthesized logic.
 
 ## Code Example
 
 ```dart
-
-final width = 32; // width of operands and result
+// Two's complement, with remainder (default)
+final width = 32;
 final divIntf = MultiCycleDividerInterface(dataWidth: width);
-final MultiCycleDivider divider = MultiCycleDivider(divIntf);
+final divider = MultiCycleDivider(divIntf);
+
+// Two's complement, quotient only (O(n) algorithm, no remainder)
+final dividerQOnly = MultiCycleDivider(divIntf, computeRemainder: false);
+
+// One's complement, with remainder
+final onesIntf = MultiCycleDividerInterface(dataWidth: width);
+final onesDiv = OnesComplementDivider(onesIntf);
+
+// Factory constructor from individual Logic signals
+final dividerFromLogics = MultiCycleDivider.ofLogics(
+    clk: clk,
+    reset: reset,
+    validIn: validIn,
+    dividend: dividend,
+    divisor: divisor,
+    isSigned: isSigned,
+    readyOut: readyOut,
+    computeRemainder: false); // quotient only
 
 // ... assume some clock generator and reset flow occur ... //
 
@@ -63,9 +112,4 @@ if (divIntf.validOut.value.toBool()) {
     expect(divIntf.divZero.value.toBool(), false);
     divIntf.readyOut.put(1);
 }
-
 ```
-
-## Future Considerations
-
-In the future, an optimization might be added in which the `remainder` output is optional and controlled by a build time constructor parameter. If the remainder does not need to be computed, the implementation's upper bound latency can be significantly improved (`O(WIDTH**2)` => `O(WIDTH)`).

--- a/lib/src/arithmetic/arithmetic.dart
+++ b/lib/src/arithmetic/arithmetic.dart
@@ -16,6 +16,7 @@ export 'multiplier.dart';
 export 'multiplier_components/mulitiplier_components.dart';
 export 'multiply_accumulate.dart';
 export 'ones_complement_adder.dart';
+export 'ones_complement_divider.dart';
 export 'parallel_prefix_operations.dart';
 export 'ripple_carry_adder.dart';
 export 'sign_magnitude_adder.dart';

--- a/lib/src/arithmetic/divider.dart
+++ b/lib/src/arithmetic/divider.dart
@@ -127,8 +127,8 @@ class MultiCycleDivider extends Module {
   /// the number of bits required to store that number.
   late final int logDataWidth;
 
-  /// When [true] (default), the [remainder] output is computed using the full
-  /// O(n²) greedy algorithm. When [false], [remainder] is always 0 and the
+  /// When `true` (default), the [remainder] output is computed using the full
+  /// O(n²) greedy algorithm. When `false`, [remainder] is always 0 and the
   /// divider uses an O(n) binary long-division algorithm instead.
   final bool computeRemainder;
 
@@ -315,7 +315,7 @@ class MultiCycleDivider extends Module {
 
     // Helper to build a state-equality Logic for use in Sequential blocks.
     Logic inState(MultiCycleDividerStates s) => fsm.currentState
-        .eq(Const(fsm.getStateIndex(s)!, width: fsm.currentState.width));
+        .eq(Const(fsm.getStateIndex(s), width: fsm.currentState.width));
 
     // ready/busy signals are based on internal state
     intf.validOut <= inState(MultiCycleDividerStates.done);
@@ -539,7 +539,7 @@ class MultiCycleDivider extends Module {
     );
 
     Logic inState(MultiCycleDividerStates s) => fsm.currentState
-        .eq(Const(fsm.getStateIndex(s)!, width: fsm.currentState.width));
+        .eq(Const(fsm.getStateIndex(s), width: fsm.currentState.width));
 
     intf.validOut <= inState(MultiCycleDividerStates.done);
     intf.readyIn <= inState(MultiCycleDividerStates.ready);

--- a/lib/src/arithmetic/divider.dart
+++ b/lib/src/arithmetic/divider.dart
@@ -248,8 +248,7 @@ class MultiCycleDivider extends Module {
           MultiCycleDividerStates.ready,
           events: {
             // divide-by-zero: jump straight to done
-            intf.validIn & ~intf.divisor.or():
-                MultiCycleDividerStates.done,
+            intf.validIn & ~intf.divisor.or(): MultiCycleDividerStates.done,
             // normal: start processing
             intf.validIn: MultiCycleDividerStates.process,
           },
@@ -408,10 +407,8 @@ class MultiCycleDivider extends Module {
         ElseIf(inState(MultiCycleDividerStates.ready) & intf.validIn, [
           lastSuccess < 0,
           lastDifference <
-              mux(
-                  extDividendIn[dataWidth - 1] & intf.isSigned,
-                  ~extDividendIn + 1,
-                  extDividendIn), // start by matching aBuf
+              mux(extDividendIn[dataWidth - 1] & intf.isSigned,
+                  ~extDividendIn + 1, extDividendIn), // start by matching aBuf
         ]),
         ElseIf(
           inState(MultiCycleDividerStates.process),
@@ -500,8 +497,7 @@ class MultiCycleDivider extends Module {
         State<MultiCycleDividerStates>(
           MultiCycleDividerStates.ready,
           events: {
-            intf.validIn & ~intf.divisor.or():
-                MultiCycleDividerStates.done,
+            intf.validIn & ~intf.divisor.or(): MultiCycleDividerStates.done,
             intf.validIn: MultiCycleDividerStates.process,
           },
           actions: [],

--- a/lib/src/arithmetic/divider.dart
+++ b/lib/src/arithmetic/divider.dart
@@ -283,8 +283,8 @@ class MultiCycleDivider extends Module {
           MultiCycleDividerStates.accumulate,
           events: {
             // done when remainder is zero or divisor exceeds what's left
-            ~lastDifference.or() |
-                (bBuf > aBuf): MultiCycleDividerStates.convert,
+            ~lastDifference.or() | (bBuf > aBuf):
+                MultiCycleDividerStates.convert,
             // otherwise keep processing more bits
             Const(1): MultiCycleDividerStates.process,
           },
@@ -314,8 +314,8 @@ class MultiCycleDivider extends Module {
     );
 
     // Helper to build a state-equality Logic for use in Sequential blocks.
-    Logic inState(MultiCycleDividerStates s) => fsm.currentState.eq(
-        Const(fsm.getStateIndex(s)!, width: fsm.currentState.width));
+    Logic inState(MultiCycleDividerStates s) => fsm.currentState
+        .eq(Const(fsm.getStateIndex(s)!, width: fsm.currentState.width));
 
     // ready/busy signals are based on internal state
     intf.validOut <= inState(MultiCycleDividerStates.done);
@@ -418,8 +418,7 @@ class MultiCycleDivider extends Module {
           [
             If(~tmpDifference[-1], then: [
               lastSuccess <
-                  (Const(1, width: dataWidth + 1) <<
-                      currIndex), // capture 2^i
+                  (Const(1, width: dataWidth + 1) << currIndex), // capture 2^i
               lastDifference < tmpDifference
             ], orElse: [
               // failure so maintain
@@ -466,7 +465,7 @@ class MultiCycleDivider extends Module {
     // Registers.
     final aBuf = Logic(name: 'aBuf', width: dataWidth + 1); // |dividend|
     final bBuf = Logic(name: 'bBuf', width: dataWidth + 1); // |divisor|
-    final signOut = Logic(name: 'signOut');                  // output sign
+    final signOut = Logic(name: 'signOut'); // output sign
     final outBuffer =
         Logic(name: 'outBuffer', width: dataWidth + 1); // quotient
     final partialRem = Logic(name: 'partialRem', width: dataWidth + 1);
@@ -581,8 +580,7 @@ class MultiCycleDivider extends Module {
           // Accept quotient bit; update partial remainder.
           partialRem < mux(quotBit, trialDiff, shiftedRem),
           // Shift quotient accumulator left and insert new bit at LSB.
-          outBuffer <
-              ((outBuffer << 1) | quotBit.zeroExtend(dataWidth + 1)),
+          outBuffer < ((outBuffer << 1) | quotBit.zeroExtend(dataWidth + 1)),
           // Count down toward 0.
           bitIdx < (bitIdx - Const(1, width: widthFor(dataWidth))),
         ]),

--- a/lib/src/arithmetic/divider.dart
+++ b/lib/src/arithmetic/divider.dart
@@ -11,25 +11,22 @@ import 'package:meta/meta.dart';
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
 
-/// State object for Divider processing.
-class _MultiCycleDividerState {
-  /// Width of state in bits.
-  static int width = 3;
-
+/// States for the [MultiCycleDivider] FSM.
+enum MultiCycleDividerStates {
   /// Ready for a new division.
-  static Const ready = Const(0, width: width);
+  ready,
 
   /// Processing a current step in the algorithm.
-  static Const process = Const(1, width: width);
+  process,
 
   /// Accumulating the result of a current step in the algorithm.
-  static Const accumulate = Const(2, width: width);
+  accumulate,
 
   /// Converting the final result of the algorithm.
-  static Const convert = Const(3, width: width);
+  convert,
 
   /// Division complete.
-  static Const done = Const(4, width: width);
+  done,
 }
 
 /// Internal interface to the Divider.
@@ -130,9 +127,15 @@ class MultiCycleDivider extends Module {
   /// the number of bits required to store that number.
   late final int logDataWidth;
 
+  /// When [true] (default), the [remainder] output is computed using the full
+  /// O(n²) greedy algorithm. When [false], [remainder] is always 0 and the
+  /// divider uses an O(n) binary long-division algorithm instead.
+  final bool computeRemainder;
+
   /// The Divider module's constructor
   MultiCycleDivider(MultiCycleDividerInterface interface,
-      {super.name = 'multi_cycle_divider',
+      {this.computeRemainder = true,
+      super.name = 'multi_cycle_divider',
       super.reserveName,
       super.reserveDefinitionName,
       String? definitionName})
@@ -162,6 +165,7 @@ class MultiCycleDivider extends Module {
     required Logic divisor,
     required Logic isSigned,
     required Logic readyOut,
+    bool computeRemainder = true,
     bool reserveName = false,
     bool reserveDefinitionName = false,
     String? definitionName,
@@ -178,13 +182,24 @@ class MultiCycleDivider extends Module {
     intf.isSigned <= isSigned;
     intf.readyOut <= readyOut;
     return MultiCycleDivider(intf,
+        computeRemainder: computeRemainder,
         reserveName: reserveName,
         reserveDefinitionName: reserveDefinitionName,
         definitionName:
             definitionName ?? 'MultiCycleDivider_W${intf.dataWidth}');
   }
 
+  /// Routes to the appropriate build method based on [computeRemainder].
   void _build() {
+    if (computeRemainder) {
+      _buildWithRemainder();
+    } else {
+      _buildQuotientOnly();
+    }
+  }
+
+  /// Full O(n²) greedy algorithm that computes both quotient and remainder.
+  void _buildWithRemainder() {
     // To capture current inputs
     // as this operation takes multiple cycles.
     final aBuf = Logic(name: 'aBuf', width: dataWidth + 1);
@@ -192,13 +207,6 @@ class MultiCycleDivider extends Module {
     final bBuf = Logic(name: 'bBuf', width: dataWidth + 1);
     final signOut = Logic(name: 'signOut');
     final signNum = Logic(name: 'signNum');
-
-    // to manage FSM
-    // # of states is fixed
-    final currentState =
-        Logic(name: 'currentState', width: _MultiCycleDividerState.width);
-    final nextState =
-        Logic(name: 'nextState', width: _MultiCycleDividerState.width);
 
     // internal buffers for computation
     // accumulator that contains dividend
@@ -223,77 +231,95 @@ class MultiCycleDivider extends Module {
     intf.remainder <=
         rBuf.getRange(0, dataWidth); // synonymous with the remainder
 
+    // special case: b is the most negative number;
+    // XOR of signOut and signNum is high iff signed AND denominator is negative
+    final specialCase = bBuf[dataWidth - 1] &
+        ~bBuf.getRange(0, dataWidth - 2).or() &
+        (signOut ^ signNum);
+
+    // Build the FSM using ROHD's FiniteStateMachine.
+    // setupActions provide combinational defaults before state-specific logic.
+    // Each state's actions run before its events are evaluated, so tmpShift
+    // and tmpDifference computed in process actions are visible to its events.
+    final fsm = FiniteStateMachine<MultiCycleDividerStates>(
+      intf.clk,
+      intf.reset,
+      MultiCycleDividerStates.ready,
+      [
+        State<MultiCycleDividerStates>(
+          MultiCycleDividerStates.ready,
+          events: {
+            // divide-by-zero: jump straight to done
+            intf.validIn & ~intf.divisor.or(): MultiCycleDividerStates.done,
+            // normal: start processing
+            intf.validIn: MultiCycleDividerStates.process,
+          },
+          actions: [],
+        ),
+        State<MultiCycleDividerStates>(
+          MultiCycleDividerStates.process,
+          events: {
+            // go to accumulate when:
+            //   - special case (b is most-negative), or
+            //   - shift would be zero, or
+            //   - difference went negative or exactly zero
+            specialCase |
+                ~tmpShift.or() |
+                tmpDifference[-1] |
+                ~tmpDifference.or(): MultiCycleDividerStates.accumulate,
+          },
+          actions: [
+            // compute shift; for special case set difference to -1,
+            // otherwise compute (a - b*2^i)
+            tmpShift < (bBuf << currIndex),
+            If(
+              specialCase,
+              then: [tmpDifference < ~Const(0, width: dataWidth + 1)],
+              orElse: [tmpDifference < (aBuf - tmpShift)],
+            ),
+          ],
+        ),
+        State<MultiCycleDividerStates>(
+          MultiCycleDividerStates.accumulate,
+          events: {
+            // done when remainder is zero or divisor exceeds what's left
+            ~lastDifference.or() |
+                (bBuf > aBuf): MultiCycleDividerStates.convert,
+            // otherwise keep processing more bits
+            Const(1): MultiCycleDividerStates.process,
+          },
+          actions: [
+            // expose lastDifference through tmpDifference for consistency
+            tmpDifference < lastDifference,
+          ],
+        ),
+        State<MultiCycleDividerStates>(
+          MultiCycleDividerStates.convert,
+          events: {Const(1): MultiCycleDividerStates.done},
+          actions: [],
+        ),
+        State<MultiCycleDividerStates>(
+          MultiCycleDividerStates.done,
+          events: {
+            // return to ready once the consumer has accepted the result
+            intf.readyOut: MultiCycleDividerStates.ready,
+          },
+          actions: [],
+        ),
+      ],
+      setupActions: [
+        tmpShift < 0,
+        tmpDifference < 0,
+      ],
+    );
+
+    // Helper to build a state-equality Logic for use in Sequential blocks.
+    Logic inState(MultiCycleDividerStates s) => fsm.currentState.eq(
+        Const(fsm.getStateIndex(s)!, width: fsm.currentState.width));
+
     // ready/busy signals are based on internal state
-    intf.validOut <= currentState.eq(_MultiCycleDividerState.done);
-    intf.readyIn <= currentState.eq(_MultiCycleDividerState.ready);
-
-    // update current_state with next_state once per cycle
-    Sequential(intf.clk, [
-      If(intf.reset,
-          then: [currentState < _MultiCycleDividerState.ready],
-          orElse: [currentState < nextState])
-    ]);
-
-    // combinational logic to compute next_state
-    // and intermediate variables that are necessary
-    Combinational([
-      tmpShift < 0,
-      tmpDifference < 0,
-      nextState < _MultiCycleDividerState.ready,
-      Case(currentState, [
-        CaseItem(_MultiCycleDividerState.done, [
-          // can move to ready as long as outside indicates consumption
-          nextState <
-              mux(intf.readyOut, _MultiCycleDividerState.ready,
-                  _MultiCycleDividerState.done)
-        ]),
-        CaseItem(_MultiCycleDividerState.convert,
-            [nextState < _MultiCycleDividerState.done]),
-        CaseItem(_MultiCycleDividerState.accumulate, [
-          tmpDifference < lastDifference,
-          If.block([
-            Iff(~tmpDifference.or() | (bBuf > aBuf), [
-              // we're done (ready to convert) as difference == 0
-              // or we've exceeded the numerator
-              nextState < _MultiCycleDividerState.convert
-            ]),
-            // more processing to do
-            Else([nextState < _MultiCycleDividerState.process])
-          ])
-        ]),
-        CaseItem(_MultiCycleDividerState.process, [
-          tmpShift < (bBuf << currIndex),
-          If(
-              // special case: b is most negative #
-              // XOR of signOut and signNum is high iff
-              // signed AND denominator is negative
-              bBuf[dataWidth - 1] &
-                  ~bBuf.getRange(0, dataWidth - 2).or() &
-                  (signOut ^ signNum),
-              then: [
-                tmpDifference < ~Const(0, width: dataWidth + 1), // -1
-                nextState < _MultiCycleDividerState.accumulate
-              ],
-              orElse: [
-                tmpDifference < (aBuf - tmpShift),
-                // move to accumulate if tmpDifference <= 0
-                If(~tmpShift.or() | tmpDifference[-1] | ~tmpDifference.or(),
-                    then: [nextState < _MultiCycleDividerState.accumulate],
-                    orElse: [nextState < _MultiCycleDividerState.process])
-              ])
-        ]),
-        CaseItem(_MultiCycleDividerState.ready, [
-          If(intf.validIn, then: [
-            nextState <
-                mux(~intf.divisor.or(), _MultiCycleDividerState.done,
-                    _MultiCycleDividerState.process)
-            // move straight to DONE if divide-by-0
-          ], orElse: [
-            nextState < _MultiCycleDividerState.ready
-          ])
-        ])
-      ])
-    ]);
+    intf.validOut <= inState(MultiCycleDividerStates.done);
+    intf.readyIn <= inState(MultiCycleDividerStates.ready);
 
     // capture input arguments a, b into internal buffers
     // so the consumer doesn't have to continually assert them
@@ -312,7 +338,7 @@ class MultiCycleDivider extends Module {
           signOut < 0,
           signNum < 0,
         ]),
-        ElseIf(currentState.eq(_MultiCycleDividerState.ready) & intf.validIn, [
+        ElseIf(inState(MultiCycleDividerStates.ready) & intf.validIn, [
           // conditionally convert negative inputs to positive
           // and compute the output sign
           aBuf <
@@ -326,7 +352,7 @@ class MultiCycleDivider extends Module {
                   intf.isSigned,
           signNum < intf.dividend[dataWidth - 1] & intf.isSigned,
         ]),
-        ElseIf(currentState.eq(_MultiCycleDividerState.accumulate), [
+        ElseIf(inState(MultiCycleDividerStates.accumulate), [
           // reduce a_buf by the portion we've covered, retain others
           aBuf < lastDifference,
           bBuf < bBuf,
@@ -349,9 +375,8 @@ class MultiCycleDivider extends Module {
       If.block([
         Iff(intf.reset, [rBuf < Const(0, width: dataWidth + 1)]),
         ElseIf(
-          currentState.eq(_MultiCycleDividerState
-              .convert), // adjust positive remainder for signs
-          [rBuf < aBufConv],
+          inState(MultiCycleDividerStates.convert),
+          [rBuf < aBufConv], // adjust positive remainder for signs
         ),
         Else(
           [rBuf < rBuf], // retain
@@ -364,9 +389,9 @@ class MultiCycleDivider extends Module {
       If.block([
         Iff(intf.reset, [currIndex < Const(0, width: logDataWidth)]),
         ElseIf(
-          currentState.eq(_MultiCycleDividerState
-              .process), // increment current index each PROCESS cycle
+          inState(MultiCycleDividerStates.process),
           [currIndex < (currIndex + Const(1, width: logDataWidth))],
+          // increment current index each PROCESS cycle
         ),
         Else(
           [currIndex < Const(0, width: logDataWidth)], // reset curr_index
@@ -381,27 +406,28 @@ class MultiCycleDivider extends Module {
           lastSuccess < 0,
           lastDifference < 0,
         ]),
-        ElseIf(currentState.eq(_MultiCycleDividerState.ready) & intf.validIn, [
+        ElseIf(inState(MultiCycleDividerStates.ready) & intf.validIn, [
           lastSuccess < 0,
           lastDifference <
               mux(extDividendIn[dataWidth - 1] & intf.isSigned,
                   ~extDividendIn + 1, extDividendIn), // start by matching aBuf
         ]),
         ElseIf(
-            currentState.eq(_MultiCycleDividerState
-                .process), // didn't exceed a_buf, so count as success
-            [
-              If(~tmpDifference[-1], then: [
-                lastSuccess <
-                    (Const(1, width: dataWidth + 1) <<
-                        currIndex), // capture 2^i
-                lastDifference < tmpDifference
-              ], orElse: [
-                // failure so maintain
-                lastSuccess < lastSuccess,
-                lastDifference < lastDifference
-              ]),
+          inState(MultiCycleDividerStates.process),
+          // didn't exceed a_buf, so count as success
+          [
+            If(~tmpDifference[-1], then: [
+              lastSuccess <
+                  (Const(1, width: dataWidth + 1) <<
+                      currIndex), // capture 2^i
+              lastDifference < tmpDifference
+            ], orElse: [
+              // failure so maintain
+              lastSuccess < lastSuccess,
+              lastDifference < lastDifference
             ]),
+          ],
+        ),
         Else(
           [
             // not needed so reset
@@ -416,17 +442,168 @@ class MultiCycleDivider extends Module {
     Sequential(intf.clk, [
       If.block([
         Iff(intf.reset, [outBuffer < 0]), // reset buffer
-        ElseIf(currentState.eq(_MultiCycleDividerState.done), [
+        ElseIf(inState(MultiCycleDividerStates.done), [
           outBuffer <
               mux(intf.readyOut, Const(0, width: dataWidth + 1), outBuffer),
         ]), // reset buffer if consumed result
-        ElseIf(currentState.eq(_MultiCycleDividerState.convert), [
+        ElseIf(inState(MultiCycleDividerStates.convert), [
           outBuffer < mux(signOut, ~outBuffer + 1, outBuffer),
         ]), // conditionally convert the result to the correct sign
-        ElseIf(currentState.eq(_MultiCycleDividerState.accumulate), [
+        ElseIf(inState(MultiCycleDividerStates.accumulate), [
           outBuffer < (outBuffer + lastSuccess)
         ]), // accumulate last_success into buffer
         Else([outBuffer < outBuffer]), // maintain buffer
+      ])
+    ]);
+  }
+
+  /// O(n) binary long division — one quotient bit per clock cycle.
+  ///
+  /// Processes the dividend MSB-first, shifting a partial remainder left and
+  /// trial-subtracting the divisor each cycle. The [remainder] output is
+  /// always 0 in this mode.
+  void _buildQuotientOnly() {
+    // Registers.
+    final aBuf = Logic(name: 'aBuf', width: dataWidth + 1); // |dividend|
+    final bBuf = Logic(name: 'bBuf', width: dataWidth + 1); // |divisor|
+    final signOut = Logic(name: 'signOut');                  // output sign
+    final outBuffer =
+        Logic(name: 'outBuffer', width: dataWidth + 1); // quotient
+    final partialRem = Logic(name: 'partialRem', width: dataWidth + 1);
+
+    // bitIdx counts DOWN from dataWidth-1 to 0; one bit of dividend per cycle.
+    final bitIdx = Logic(name: 'bitIdx', width: widthFor(dataWidth));
+
+    // Combinational intermediates (reset to 0 by setupActions).
+    final shiftedRem = Logic(name: 'shiftedRem', width: dataWidth + 1);
+    final trialDiff = Logic(name: 'trialDiff', width: dataWidth + 1);
+    final quotBit = Logic(name: 'quotBit');
+
+    // Outputs.
+    intf.quotient <= outBuffer.getRange(0, dataWidth);
+    intf.divZero <= ~bBuf.or();
+    intf.remainder <= Const(0, width: dataWidth); // not computed in this mode
+
+    // Select aBuf[bitIdx]: the dividend bit for this cycle (MSB-first).
+    final dividendBitList = List<Logic>.generate(dataWidth, (i) => aBuf[i]);
+    final currentDividendBit =
+        bitIdx.selectFrom(dividendBitList).named('currentDividendBit');
+
+    final bitIdxInit =
+        Const(dataWidth - 1, width: widthFor(dataWidth)).named('bitIdxInit');
+
+    final fsm = FiniteStateMachine<MultiCycleDividerStates>(
+      intf.clk,
+      intf.reset,
+      MultiCycleDividerStates.ready,
+      [
+        State<MultiCycleDividerStates>(
+          MultiCycleDividerStates.ready,
+          events: {
+            intf.validIn & ~intf.divisor.or(): MultiCycleDividerStates.done,
+            intf.validIn: MultiCycleDividerStates.process,
+          },
+          actions: [],
+        ),
+        State<MultiCycleDividerStates>(
+          MultiCycleDividerStates.process,
+          events: {
+            // Last bit: bitIdx is at 0 this cycle → go to sign-convert.
+            bitIdx.eq(Const(0, width: widthFor(dataWidth))):
+                MultiCycleDividerStates.convert,
+          },
+          actions: [
+            // Shift partial remainder left and bring in the next dividend bit.
+            shiftedRem <
+                ((partialRem << 1) |
+                    currentDividendBit.zeroExtend(dataWidth + 1)),
+            // Trial subtraction: shiftedRem - bBuf.
+            trialDiff < (shiftedRem - bBuf),
+            // Quotient bit = 1 when shiftedRem >= bBuf (MSB of diff = 0).
+            quotBit < ~trialDiff[-1],
+          ],
+        ),
+        State<MultiCycleDividerStates>(
+          MultiCycleDividerStates.convert,
+          events: {Const(1): MultiCycleDividerStates.done},
+          actions: [],
+        ),
+        State<MultiCycleDividerStates>(
+          MultiCycleDividerStates.done,
+          events: {
+            intf.readyOut: MultiCycleDividerStates.ready,
+          },
+          actions: [],
+        ),
+      ],
+      setupActions: [shiftedRem < 0, trialDiff < 0, quotBit < 0],
+    );
+
+    Logic inState(MultiCycleDividerStates s) => fsm.currentState
+        .eq(Const(fsm.getStateIndex(s)!, width: fsm.currentState.width));
+
+    intf.validOut <= inState(MultiCycleDividerStates.done);
+    intf.readyIn <= inState(MultiCycleDividerStates.ready);
+
+    final extDividendIn = Logic(name: 'extDividendIn', width: dataWidth + 1)
+      ..gets(mux(intf.isSigned, intf.dividend.signExtend(dataWidth + 1),
+          intf.dividend.zeroExtend(dataWidth + 1)));
+    final extDivisorIn = Logic(name: 'extDivisorIn', width: dataWidth + 1)
+      ..gets(mux(intf.isSigned, intf.divisor.signExtend(dataWidth + 1),
+          intf.divisor.zeroExtend(dataWidth + 1)));
+
+    Sequential(intf.clk, [
+      If.block([
+        Iff(intf.reset, [
+          aBuf < 0,
+          bBuf < 0,
+          signOut < 0,
+          outBuffer < 0,
+          partialRem < 0,
+          bitIdx < bitIdxInit,
+        ]),
+        ElseIf(inState(MultiCycleDividerStates.ready) & intf.validIn, [
+          // Convert negative inputs to positive and compute the output sign.
+          aBuf <
+              mux(extDividendIn[dataWidth - 1] & intf.isSigned,
+                  ~extDividendIn + 1, extDividendIn),
+          bBuf <
+              mux(extDivisorIn[dataWidth - 1] & intf.isSigned,
+                  ~extDivisorIn + 1, extDivisorIn),
+          signOut <
+              (intf.dividend[dataWidth - 1] ^ intf.divisor[dataWidth - 1]) &
+                  intf.isSigned,
+          outBuffer < 0,
+          partialRem < 0,
+          bitIdx < bitIdxInit,
+        ]),
+        ElseIf(inState(MultiCycleDividerStates.process), [
+          // Accept quotient bit; update partial remainder.
+          partialRem < mux(quotBit, trialDiff, shiftedRem),
+          // Shift quotient accumulator left and insert new bit at LSB.
+          outBuffer <
+              ((outBuffer << 1) | quotBit.zeroExtend(dataWidth + 1)),
+          // Count down toward 0.
+          bitIdx < (bitIdx - Const(1, width: widthFor(dataWidth))),
+        ]),
+        ElseIf(inState(MultiCycleDividerStates.convert), [
+          // Apply sign correction to quotient.
+          outBuffer < mux(signOut, ~outBuffer + 1, outBuffer),
+          bitIdx < bitIdx,
+        ]),
+        ElseIf(inState(MultiCycleDividerStates.done), [
+          // Clear quotient once the consumer accepts the result.
+          outBuffer <
+              mux(intf.readyOut, Const(0, width: dataWidth + 1), outBuffer),
+        ]),
+        Else([
+          aBuf < aBuf,
+          bBuf < bBuf,
+          signOut < signOut,
+          outBuffer < outBuffer,
+          partialRem < partialRem,
+          bitIdx < bitIdx,
+        ]),
       ])
     ]);
   }

--- a/lib/src/arithmetic/ones_complement_divider.dart
+++ b/lib/src/arithmetic/ones_complement_divider.dart
@@ -184,9 +184,8 @@ class OnesComplementDivider extends Module {
         State<MultiCycleDividerStates>(
           MultiCycleDividerStates.process,
           events: {
-            ~tmpShift.or() |
-                tmpDifference[-1] |
-                ~tmpDifference.or(): MultiCycleDividerStates.accumulate,
+            ~tmpShift.or() | tmpDifference[-1] | ~tmpDifference.or():
+                MultiCycleDividerStates.accumulate,
           },
           actions: [
             tmpShift < (bBuf << currIndex),
@@ -242,11 +241,11 @@ class OnesComplementDivider extends Module {
         ElseIf(inState(MultiCycleDividerStates.ready) & intf.validIn, [
           // Negate by ~x only (no carry chain).
           aBuf <
-              mux(extDividendIn[dataWidth - 1] & intf.isSigned,
-                  ~extDividendIn, extDividendIn),
+              mux(extDividendIn[dataWidth - 1] & intf.isSigned, ~extDividendIn,
+                  extDividendIn),
           bBuf <
-              mux(extDivisorIn[dataWidth - 1] & intf.isSigned,
-                  ~extDivisorIn, extDivisorIn),
+              mux(extDivisorIn[dataWidth - 1] & intf.isSigned, ~extDivisorIn,
+                  extDivisorIn),
           signOut <
               (intf.dividend[dataWidth - 1] ^ intf.divisor[dataWidth - 1]) &
                   intf.isSigned,
@@ -292,8 +291,8 @@ class OnesComplementDivider extends Module {
         ElseIf(inState(MultiCycleDividerStates.ready) & intf.validIn, [
           lastSuccess < 0,
           lastDifference <
-              mux(extDividendIn[dataWidth - 1] & intf.isSigned,
-                  ~extDividendIn, extDividendIn),
+              mux(extDividendIn[dataWidth - 1] & intf.isSigned, ~extDividendIn,
+                  extDividendIn),
         ]),
         ElseIf(inState(MultiCycleDividerStates.process), [
           If(~tmpDifference[-1], then: [
@@ -419,11 +418,11 @@ class OnesComplementDivider extends Module {
         ElseIf(inState(MultiCycleDividerStates.ready) & intf.validIn, [
           // Negate by ~x only (no carry chain).
           aBuf <
-              mux(extDividendIn[dataWidth - 1] & intf.isSigned,
-                  ~extDividendIn, extDividendIn),
+              mux(extDividendIn[dataWidth - 1] & intf.isSigned, ~extDividendIn,
+                  extDividendIn),
           bBuf <
-              mux(extDivisorIn[dataWidth - 1] & intf.isSigned,
-                  ~extDivisorIn, extDivisorIn),
+              mux(extDivisorIn[dataWidth - 1] & intf.isSigned, ~extDivisorIn,
+                  extDivisorIn),
           signOut <
               (intf.dividend[dataWidth - 1] ^ intf.divisor[dataWidth - 1]) &
                   intf.isSigned,

--- a/lib/src/arithmetic/ones_complement_divider.dart
+++ b/lib/src/arithmetic/ones_complement_divider.dart
@@ -1,106 +1,43 @@
 // Copyright (C) 2024-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
-// divider.dart
-// Implementation of Integer Divider Module.
+// ones_complement_divider.dart
+// Integer Divider using one's complement signed arithmetic.
 //
-// 2024 August
-// Author: Josh Kimmel <joshua1.kimmel@intel.com>
+// 2025 April
+// Author: Jose Rojas Chaves <jose.rojas.chaves@intel.com>
 
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
 
-/// States for the [MultiCycleDivider] FSM.
-enum MultiCycleDividerStates {
-  /// Ready for a new division.
-  ready,
-
-  /// Processing a current step in the algorithm.
-  process,
-
-  /// Accumulating the result of a current step in the algorithm.
-  accumulate,
-
-  /// Converting the final result of the algorithm.
-  convert,
-
-  /// Division complete.
-  done,
-}
-
-/// Internal interface to the Divider.
-class MultiCycleDividerInterface extends PairInterface {
-  /// Clock for sequential logic.
-  Logic get clk => port('clk');
-
-  /// Reset for sequential logic (active high).
-  Logic get reset => port('reset');
-
-  /// Dividend (numerator) for the division operation.
-  Logic get dividend => port('dividend');
-
-  /// Divisor (denominator) for the division operation.
-  Logic get divisor => port('divisor');
-
-  /// Are the division operands signed.
-  Logic get isSigned => port('isSigned');
-
-  /// The integrating environment is ready to accept the output of the module.
-  Logic get readyOut => port('readyOut');
-
-  /// Request for a new division operation to be performed.
-  Logic get validIn => port('validIn');
-
-  /// Quotient (result) for the division operation.
-  Logic get quotient => port('quotient');
-
-  /// Remainder (modulus) for the division operation.
-  Logic get remainder => port('remainder');
-
-  /// A Division by zero occurred.
-  Logic get divZero => port('divZero');
-
-  /// The result of the current division operation is ready.
-  Logic get validOut => port('validOut');
-
-  /// The module is ready to accept new inputs.
-  Logic get readyIn => port('readyIn');
-
-  /// The width of the data operands and result.
-  final int dataWidth;
-
-  /// A constructor for the divider interface.
-  MultiCycleDividerInterface({this.dataWidth = 32})
-      : super(portsFromProvider: [
-          Logic.port('clk'),
-          Logic.port('reset'),
-          Logic.port('dividend', dataWidth),
-          Logic.port('divisor', dataWidth),
-          Logic.port('isSigned'),
-          Logic.port('validIn'),
-          Logic.port('readyOut'),
-        ], portsFromConsumer: [
-          Logic.port('quotient', dataWidth),
-          Logic.port('remainder', dataWidth),
-          Logic.port('divZero'),
-          Logic.port('validOut'),
-          Logic.port('readyIn'),
-        ]);
-
-  /// A match constructor for the divider interface.
-  @Deprecated('Use clone() instead.')
-  MultiCycleDividerInterface.match(MultiCycleDividerInterface other)
-      : this(dataWidth: other.dataWidth);
-
-  /// Clones this [MultiCycleDividerInterface].
-  @override
-  MultiCycleDividerInterface clone() =>
-      MultiCycleDividerInterface(dataWidth: dataWidth);
-}
-
-/// The Divider module definition.
-class MultiCycleDivider extends Module {
-  /// The Divider's interface declaration.
+/// A multi-cycle integer divider that uses **one's complement** signed
+/// arithmetic.
+///
+/// This is an independent sibling of [MultiCycleDivider] intended for
+/// performance and area comparison.  Both classes share the same
+/// [MultiCycleDividerInterface] and [MultiCycleDividerStates] FSM states,
+/// but differ in their sign-arithmetic primitives and sign-correction
+/// circuit:
+///
+/// | Primitive | 2's complement ([MultiCycleDivider]) | 1's complement |
+/// |-----------|--------------------------------------|----------------|
+/// | Negate    | `~x + 1` (carry chain)  | `~x` (bitwise only)        |
+/// | Zero test | all-zeros               | all-zeros OR all-ones      |
+/// | Overflow  | MIN_INT ÷ −1 overflows  | symmetric range, never     |
+///
+/// The critical-path benefit is in the **convert** FSM state: sign-correcting
+/// the quotient/remainder requires only a bitwise invert (`~x`) rather than a
+/// full carry-propagate add (`~x + 1`), removing an adder from the cycle.
+///
+/// ### One's complement conventions
+///
+/// * Positive zero: `000…0`.  Negative zero: `111…1`.
+/// * The range is symmetric: `[-(2^(n-1)-1), +(2^(n-1)-1)]`; there is no
+///   MIN_INT overflow case.
+/// * A divisor of `111…1` (negative zero) triggers [divZero] when
+///   `isSigned` is asserted.
+class OnesComplementDivider extends Module {
+  /// The divider interface (shared with [MultiCycleDivider]).
   late final MultiCycleDividerInterface intf;
 
   /// Get interface's validOut signal value.
@@ -121,8 +58,7 @@ class MultiCycleDivider extends Module {
   /// The width of the data operands and result.
   late final int dataWidth;
 
-  /// The log of the data width representing
-  /// the number of bits required to store that number.
+  /// The log of the data width (bits needed to represent [dataWidth]).
   late final int logDataWidth;
 
   /// When `true` (default), the [remainder] output is computed using the full
@@ -130,18 +66,18 @@ class MultiCycleDivider extends Module {
   /// divider uses an O(n) binary long-division algorithm instead.
   final bool computeRemainder;
 
-  /// The Divider module's constructor
-  MultiCycleDivider(MultiCycleDividerInterface interface,
+  /// Creates a one's complement multi-cycle divider.
+  OnesComplementDivider(MultiCycleDividerInterface interface,
       {this.computeRemainder = true,
-      super.name = 'multi_cycle_divider',
+      super.name = 'ones_complement_divider',
       super.reserveName,
       super.reserveDefinitionName,
       String? definitionName})
       : dataWidth = interface.dataWidth,
         logDataWidth = log2Ceil(interface.dataWidth),
         super(
-            definitionName:
-                definitionName ?? 'MultiCycleDivider_W${interface.dataWidth}') {
+            definitionName: definitionName ??
+                'OnesComplementDivider_W${interface.dataWidth}') {
     intf = interface.clone()
       ..pairConnectIO(
         this,
@@ -149,13 +85,11 @@ class MultiCycleDivider extends Module {
         PairRole.consumer,
         uniquify: (original) => '${super.name}_$original',
       );
-
     _build();
   }
 
-  /// Factory method to create a [MultiCycleDivider]
-  /// from explicit [Logic] signals instead of an interface.
-  factory MultiCycleDivider.ofLogics({
+  /// Factory constructor matching [MultiCycleDivider.ofLogics].
+  factory OnesComplementDivider.ofLogics({
     required Logic clk,
     required Logic reset,
     required Logic validIn,
@@ -179,15 +113,14 @@ class MultiCycleDivider extends Module {
     intf.divisor <= divisor;
     intf.isSigned <= isSigned;
     intf.readyOut <= readyOut;
-    return MultiCycleDivider(intf,
+    return OnesComplementDivider(intf,
         computeRemainder: computeRemainder,
         reserveName: reserveName,
         reserveDefinitionName: reserveDefinitionName,
         definitionName:
-            definitionName ?? 'MultiCycleDivider_W${intf.dataWidth}');
+            definitionName ?? 'OnesComplementDivider_W${intf.dataWidth}');
   }
 
-  /// Routes to the appropriate build method based on [computeRemainder].
   void _build() {
     if (computeRemainder) {
       _buildWithRemainder();
@@ -196,49 +129,45 @@ class MultiCycleDivider extends Module {
     }
   }
 
-  /// Full O(n²) greedy algorithm that computes both quotient and remainder.
+  // ---------------------------------------------------------------------------
+  // Signed-arithmetic helpers (1's complement)
+  //
+  //   negate(x)       = ~x
+  //   isZero(divisor) = ~d.or() | (d.and() & isSigned)
+  // ---------------------------------------------------------------------------
+
+  /// Detects a zero divisor: positive zero (all-zeros) OR negative zero
+  /// (all-ones, only when [MultiCycleDividerInterface.isSigned] is asserted).
+  Logic _isZero(Logic rawDivisor) =>
+      ~rawDivisor.or() | (rawDivisor.and() & intf.isSigned);
+
+  // ---------------------------------------------------------------------------
+  // O(n²) greedy algorithm — computes quotient AND remainder
+  // ---------------------------------------------------------------------------
+
   void _buildWithRemainder() {
-    // To capture current inputs
-    // as this operation takes multiple cycles.
     final aBuf = Logic(name: 'aBuf', width: dataWidth + 1);
     final rBuf = Logic(name: 'rBuf', width: dataWidth + 1);
     final bBuf = Logic(name: 'bBuf', width: dataWidth + 1);
     final signOut = Logic(name: 'signOut');
     final signNum = Logic(name: 'signNum');
 
-    // internal buffers for computation
-    // accumulator that contains dividend
     final outBuffer = Logic(name: 'outBuffer', width: dataWidth + 1);
-    // capture last successful power of 2
     final lastSuccess = Logic(name: 'lastSuccess', width: dataWidth + 1);
-    // combinational logic signal to compute current (a-b*2^i)
     final tmpDifference = Logic(name: 'tmpDifference', width: dataWidth + 1);
-    // store last diff
     final lastDifference = Logic(name: 'lastDifference', width: dataWidth + 1);
-    // combinational logic signal to check for overflow when shifting
     final tmpShift = Logic(name: 'tmpShift', width: dataWidth + 1);
-
-    // current value of i to try
-    // need log(dataWidth)+1 bits so currIndex can reach dataWidth,
-    // allowing bBuf<<currIndex to overflow to zero (loop-exit condition).
+    // logDataWidth+1 bits so currIndex can reach dataWidth, allowing
+    // bBuf<<currIndex to overflow to zero (loop-exit condition).
     final currIndex = Logic(name: 'currIndex', width: logDataWidth + 1);
 
-    intf.quotient <=
-        outBuffer.getRange(
-            0, dataWidth); // result is ultimately stored in out_buffer
-    intf.divZero <= ~bBuf.or(); // divide-by-0 if b==0 (NOR)
-    intf.remainder <=
-        rBuf.getRange(0, dataWidth); // synonymous with the remainder
+    intf.quotient <= outBuffer.getRange(0, dataWidth);
+    // After negating −0 (0xFF) via ~: ~0xFF = 0x00, so all-zeros check holds.
+    intf.divZero <= ~bBuf.or();
+    intf.remainder <= rBuf.getRange(0, dataWidth);
 
-    // special case: 2's complement MIN_INT ÷ −1 overflow detection.
-    final specialCase = bBuf[dataWidth - 1] &
-        ~bBuf.getRange(0, dataWidth - 2).or() &
-        (signOut ^ signNum);
-
-    // Build the FSM using ROHD's FiniteStateMachine.
-    // setupActions provide combinational defaults before state-specific logic.
-    // Each state's actions run before its events are evaluated, so tmpShift
-    // and tmpDifference computed in process actions are visible to its events.
+    // One's complement has a symmetric range — MIN_INT ÷ −1 never overflows,
+    // so the process state needs no special-case overflow guard.
     final fsm = FiniteStateMachine<MultiCycleDividerStates>(
       intf.clk,
       intf.reset,
@@ -247,10 +176,7 @@ class MultiCycleDivider extends Module {
         State<MultiCycleDividerStates>(
           MultiCycleDividerStates.ready,
           events: {
-            // divide-by-zero: jump straight to done
-            intf.validIn & ~intf.divisor.or():
-                MultiCycleDividerStates.done,
-            // normal: start processing
+            intf.validIn & _isZero(intf.divisor): MultiCycleDividerStates.done,
             intf.validIn: MultiCycleDividerStates.process,
           },
           actions: [],
@@ -258,37 +184,23 @@ class MultiCycleDivider extends Module {
         State<MultiCycleDividerStates>(
           MultiCycleDividerStates.process,
           events: {
-            // go to accumulate when:
-            //   - special case (b is most-negative), or
-            //   - shift would be zero, or
-            //   - difference went negative or exactly zero
-            specialCase |
-                ~tmpShift.or() |
+            ~tmpShift.or() |
                 tmpDifference[-1] |
                 ~tmpDifference.or(): MultiCycleDividerStates.accumulate,
           },
           actions: [
-            // compute shift; for special case set difference to -1,
-            // otherwise compute (a - b*2^i)
             tmpShift < (bBuf << currIndex),
-            If(
-              specialCase,
-              then: [tmpDifference < ~Const(0, width: dataWidth + 1)],
-              orElse: [tmpDifference < (aBuf - tmpShift)],
-            ),
+            tmpDifference < (aBuf - tmpShift),
           ],
         ),
         State<MultiCycleDividerStates>(
           MultiCycleDividerStates.accumulate,
           events: {
-            // done when remainder is zero or divisor exceeds what's left
             ~lastDifference.or() | (bBuf > aBuf):
                 MultiCycleDividerStates.convert,
-            // otherwise keep processing more bits
             Const(1): MultiCycleDividerStates.process,
           },
           actions: [
-            // expose lastDifference through tmpDifference for consistency
             tmpDifference < lastDifference,
           ],
         ),
@@ -299,38 +211,28 @@ class MultiCycleDivider extends Module {
         ),
         State<MultiCycleDividerStates>(
           MultiCycleDividerStates.done,
-          events: {
-            // return to ready once the consumer has accepted the result
-            intf.readyOut: MultiCycleDividerStates.ready,
-          },
+          events: {intf.readyOut: MultiCycleDividerStates.ready},
           actions: [],
         ),
       ],
-      setupActions: [
-        tmpShift < 0,
-        tmpDifference < 0,
-      ],
+      setupActions: [tmpShift < 0, tmpDifference < 0],
     );
 
-    // Helper to build a state-equality Logic for use in Sequential blocks.
     Logic inState(MultiCycleDividerStates s) => fsm.currentState
         .eq(Const(fsm.getStateIndex(s), width: fsm.currentState.width));
 
-    // ready/busy signals are based on internal state
     intf.validOut <= inState(MultiCycleDividerStates.done);
     intf.readyIn <= inState(MultiCycleDividerStates.ready);
 
-    // capture input arguments a, b into internal buffers
-    // so the consumer doesn't have to continually assert them
     final extDividendIn = Logic(name: 'extDividendIn', width: dataWidth + 1)
       ..gets(mux(intf.isSigned, intf.dividend.signExtend(dataWidth + 1),
           intf.dividend.zeroExtend(dataWidth + 1)));
     final extDivisorIn = Logic(name: 'extDivisorIn', width: dataWidth + 1)
       ..gets(mux(intf.isSigned, intf.divisor.signExtend(dataWidth + 1),
           intf.divisor.zeroExtend(dataWidth + 1)));
+
     Sequential(intf.clk, [
       If.block([
-        // only when READY and new inputs are available
         Iff(intf.reset, [
           aBuf < 0,
           bBuf < 0,
@@ -338,28 +240,25 @@ class MultiCycleDivider extends Module {
           signNum < 0,
         ]),
         ElseIf(inState(MultiCycleDividerStates.ready) & intf.validIn, [
-          // conditionally convert negative inputs to positive
-          // and compute the output sign
+          // Negate by ~x only (no carry chain).
           aBuf <
               mux(extDividendIn[dataWidth - 1] & intf.isSigned,
-                  ~extDividendIn + 1, extDividendIn),
+                  ~extDividendIn, extDividendIn),
           bBuf <
               mux(extDivisorIn[dataWidth - 1] & intf.isSigned,
-                  ~extDivisorIn + 1, extDivisorIn),
+                  ~extDivisorIn, extDivisorIn),
           signOut <
               (intf.dividend[dataWidth - 1] ^ intf.divisor[dataWidth - 1]) &
                   intf.isSigned,
           signNum < intf.dividend[dataWidth - 1] & intf.isSigned,
         ]),
         ElseIf(inState(MultiCycleDividerStates.accumulate), [
-          // reduce a_buf by the portion we've covered, retain others
           aBuf < lastDifference,
           bBuf < bBuf,
           signOut < signOut,
           signNum < signNum,
         ]),
         Else([
-          // retain all values
           aBuf < aBuf,
           bBuf < bBuf,
           signOut < signOut,
@@ -368,127 +267,88 @@ class MultiCycleDivider extends Module {
       ])
     ]);
 
-    // handle updates of remainder buffer
-    final aBufConv = mux(signNum, ~aBuf + 1, aBuf);
+    // Remainder sign correction: ~aBuf (no carry).
+    final aBufConv = mux(signNum, ~aBuf, aBuf);
     Sequential(intf.clk, [
       If.block([
         Iff(intf.reset, [rBuf < Const(0, width: dataWidth + 1)]),
-        ElseIf(
-          inState(MultiCycleDividerStates.convert),
-          [rBuf < aBufConv], // adjust positive remainder for signs
-        ),
-        Else(
-          [rBuf < rBuf], // retain
-        )
+        ElseIf(inState(MultiCycleDividerStates.convert), [rBuf < aBufConv]),
+        Else([rBuf < rBuf]),
       ])
     ]);
 
-    // handle updates of curr_index
     Sequential(intf.clk, [
       If.block([
         Iff(intf.reset, [currIndex < Const(0, width: logDataWidth + 1)]),
-        ElseIf(
-          inState(MultiCycleDividerStates.process),
-          [currIndex < (currIndex + Const(1, width: logDataWidth + 1))],
-          // increment current index each PROCESS cycle
-        ),
-        Else(
-          [currIndex < Const(0, width: logDataWidth + 1)], // reset curr_index
-        )
+        ElseIf(inState(MultiCycleDividerStates.process),
+            [currIndex < (currIndex + Const(1, width: logDataWidth + 1))]),
+        Else([currIndex < Const(0, width: logDataWidth + 1)]),
       ])
     ]);
 
-    // handle update of lastSuccess and lastDifference
     Sequential(intf.clk, [
       If.block([
-        Iff(intf.reset, [
-          lastSuccess < 0,
-          lastDifference < 0,
-        ]),
+        Iff(intf.reset, [lastSuccess < 0, lastDifference < 0]),
         ElseIf(inState(MultiCycleDividerStates.ready) & intf.validIn, [
           lastSuccess < 0,
           lastDifference <
-              mux(
-                  extDividendIn[dataWidth - 1] & intf.isSigned,
-                  ~extDividendIn + 1,
-                  extDividendIn), // start by matching aBuf
+              mux(extDividendIn[dataWidth - 1] & intf.isSigned,
+                  ~extDividendIn, extDividendIn),
         ]),
-        ElseIf(
-          inState(MultiCycleDividerStates.process),
-          // didn't exceed a_buf, so count as success
-          [
-            If(~tmpDifference[-1], then: [
-              lastSuccess <
-                  (Const(1, width: dataWidth + 1) << currIndex), // capture 2^i
-              lastDifference < tmpDifference
-            ], orElse: [
-              // failure so maintain
-              lastSuccess < lastSuccess,
-              lastDifference < lastDifference
-            ]),
-          ],
-        ),
-        Else(
-          [
-            // not needed so reset
-            lastSuccess < 0,
+        ElseIf(inState(MultiCycleDividerStates.process), [
+          If(~tmpDifference[-1], then: [
+            lastSuccess < (Const(1, width: dataWidth + 1) << currIndex),
+            lastDifference < tmpDifference,
+          ], orElse: [
+            lastSuccess < lastSuccess,
             lastDifference < lastDifference,
-          ],
-        )
+          ]),
+        ]),
+        Else([lastSuccess < 0, lastDifference < lastDifference]),
       ])
     ]);
 
-    // handle update of buffer
     Sequential(intf.clk, [
       If.block([
-        Iff(intf.reset, [outBuffer < 0]), // reset buffer
+        Iff(intf.reset, [outBuffer < 0]),
         ElseIf(inState(MultiCycleDividerStates.done), [
           outBuffer <
               mux(intf.readyOut, Const(0, width: dataWidth + 1), outBuffer),
-        ]), // reset buffer if consumed result
+        ]),
         ElseIf(inState(MultiCycleDividerStates.convert), [
-          outBuffer < mux(signOut, ~outBuffer + 1, outBuffer),
-        ]), // conditionally convert the result to the correct sign
-        ElseIf(inState(MultiCycleDividerStates.accumulate), [
-          outBuffer < (outBuffer + lastSuccess)
-        ]), // accumulate last_success into buffer
-        Else([outBuffer < outBuffer]), // maintain buffer
+          // Sign correction: ~outBuffer (no carry chain).
+          outBuffer < mux(signOut, ~outBuffer, outBuffer),
+        ]),
+        ElseIf(inState(MultiCycleDividerStates.accumulate),
+            [outBuffer < (outBuffer + lastSuccess)]),
+        Else([outBuffer < outBuffer]),
       ])
     ]);
   }
 
-  /// O(n) binary long division — one quotient bit per clock cycle.
-  ///
-  /// Processes the dividend MSB-first, shifting a partial remainder left and
-  /// trial-subtracting the divisor each cycle. The [remainder] output is
-  /// always 0 in this mode.
-  void _buildQuotientOnly() {
-    // Registers.
-    final aBuf = Logic(name: 'aBuf', width: dataWidth + 1); // |dividend|
-    final bBuf = Logic(name: 'bBuf', width: dataWidth + 1); // |divisor|
-    final signOut = Logic(name: 'signOut'); // output sign
-    final outBuffer =
-        Logic(name: 'outBuffer', width: dataWidth + 1); // quotient
-    final partialRem = Logic(name: 'partialRem', width: dataWidth + 1);
+  // ---------------------------------------------------------------------------
+  // O(n) binary long-division — quotient only, remainder always 0
+  // ---------------------------------------------------------------------------
 
-    // bitIdx counts DOWN from dataWidth-1 to 0; one bit of dividend per cycle.
+  void _buildQuotientOnly() {
+    final aBuf = Logic(name: 'aBuf', width: dataWidth + 1);
+    final bBuf = Logic(name: 'bBuf', width: dataWidth + 1);
+    final signOut = Logic(name: 'signOut');
+    final outBuffer = Logic(name: 'outBuffer', width: dataWidth + 1);
+    final partialRem = Logic(name: 'partialRem', width: dataWidth + 1);
     final bitIdx = Logic(name: 'bitIdx', width: widthFor(dataWidth));
 
-    // Combinational intermediates (reset to 0 by setupActions).
     final shiftedRem = Logic(name: 'shiftedRem', width: dataWidth + 1);
     final trialDiff = Logic(name: 'trialDiff', width: dataWidth + 1);
     final quotBit = Logic(name: 'quotBit');
 
-    // Outputs.
     intf.quotient <= outBuffer.getRange(0, dataWidth);
     intf.divZero <= ~bBuf.or();
-    intf.remainder <= Const(0, width: dataWidth); // not computed in this mode
+    intf.remainder <= Const(0, width: dataWidth);
 
-    // Select aBuf[bitIdx]: the dividend bit for this cycle (MSB-first).
     final dividendBitList = List<Logic>.generate(dataWidth, (i) => aBuf[i]);
     final currentDividendBit =
         bitIdx.selectFrom(dividendBitList).named('currentDividendBit');
-
     final bitIdxInit =
         Const(dataWidth - 1, width: widthFor(dataWidth)).named('bitIdxInit');
 
@@ -500,8 +360,7 @@ class MultiCycleDivider extends Module {
         State<MultiCycleDividerStates>(
           MultiCycleDividerStates.ready,
           events: {
-            intf.validIn & ~intf.divisor.or():
-                MultiCycleDividerStates.done,
+            intf.validIn & _isZero(intf.divisor): MultiCycleDividerStates.done,
             intf.validIn: MultiCycleDividerStates.process,
           },
           actions: [],
@@ -509,18 +368,14 @@ class MultiCycleDivider extends Module {
         State<MultiCycleDividerStates>(
           MultiCycleDividerStates.process,
           events: {
-            // Last bit: bitIdx is at 0 this cycle → go to sign-convert.
             bitIdx.eq(Const(0, width: widthFor(dataWidth))):
                 MultiCycleDividerStates.convert,
           },
           actions: [
-            // Shift partial remainder left and bring in the next dividend bit.
             shiftedRem <
                 ((partialRem << 1) |
                     currentDividendBit.zeroExtend(dataWidth + 1)),
-            // Trial subtraction: shiftedRem - bBuf.
             trialDiff < (shiftedRem - bBuf),
-            // Quotient bit = 1 when shiftedRem >= bBuf (MSB of diff = 0).
             quotBit < ~trialDiff[-1],
           ],
         ),
@@ -531,9 +386,7 @@ class MultiCycleDivider extends Module {
         ),
         State<MultiCycleDividerStates>(
           MultiCycleDividerStates.done,
-          events: {
-            intf.readyOut: MultiCycleDividerStates.ready,
-          },
+          events: {intf.readyOut: MultiCycleDividerStates.ready},
           actions: [],
         ),
       ],
@@ -564,13 +417,13 @@ class MultiCycleDivider extends Module {
           bitIdx < bitIdxInit,
         ]),
         ElseIf(inState(MultiCycleDividerStates.ready) & intf.validIn, [
-          // Convert negative inputs to positive and compute the output sign.
+          // Negate by ~x only (no carry chain).
           aBuf <
               mux(extDividendIn[dataWidth - 1] & intf.isSigned,
-                  ~extDividendIn + 1, extDividendIn),
+                  ~extDividendIn, extDividendIn),
           bBuf <
               mux(extDivisorIn[dataWidth - 1] & intf.isSigned,
-                  ~extDivisorIn + 1, extDivisorIn),
+                  ~extDivisorIn, extDivisorIn),
           signOut <
               (intf.dividend[dataWidth - 1] ^ intf.divisor[dataWidth - 1]) &
                   intf.isSigned,
@@ -579,20 +432,16 @@ class MultiCycleDivider extends Module {
           bitIdx < bitIdxInit,
         ]),
         ElseIf(inState(MultiCycleDividerStates.process), [
-          // Accept quotient bit; update partial remainder.
           partialRem < mux(quotBit, trialDiff, shiftedRem),
-          // Shift quotient accumulator left and insert new bit at LSB.
           outBuffer < ((outBuffer << 1) | quotBit.zeroExtend(dataWidth + 1)),
-          // Count down toward 0.
           bitIdx < (bitIdx - Const(1, width: widthFor(dataWidth))),
         ]),
         ElseIf(inState(MultiCycleDividerStates.convert), [
-          // Apply sign correction to quotient.
-          outBuffer < mux(signOut, ~outBuffer + 1, outBuffer),
+          // Sign correction: ~outBuffer (no carry chain).
+          outBuffer < mux(signOut, ~outBuffer, outBuffer),
           bitIdx < bitIdx,
         ]),
         ElseIf(inState(MultiCycleDividerStates.done), [
-          // Clear quotient once the consumer accepts the result.
           outBuffer <
               mux(intf.readyOut, Const(0, width: dataWidth + 1), outBuffer),
         ]),
@@ -608,3 +457,5 @@ class MultiCycleDivider extends Module {
     ]);
   }
 }
+
+// =============================================================================

--- a/test/arithmetic/divider_test.dart
+++ b/test/arithmetic/divider_test.dart
@@ -213,23 +213,26 @@ class MultiCycleDividerOutputMonitor
 class MultiCycleDividerScoreboard extends Component {
   final Stream<MultiCycleDividerInputSeqItem> inStream;
   final Stream<MultiCycleDividerOutputSeqItem> outStream;
-
   final MultiCycleDividerInterface intf;
+
+  /// When [false], only the quotient is verified and remainder is expected
+  /// to always be 0.
+  final bool computeRemainder;
 
   MultiCycleDividerScoreboard(
       this.inStream, this.outStream, this.intf, Component parent,
-      {String name = 'MultiCycleDividerScoreboard'})
+      {this.computeRemainder = true,
+      String name = 'MultiCycleDividerScoreboard'})
       : super(name, parent);
 
-  final List<int> lastA = [];
-  final List<int> lastB = [];
-  final List<bool> lastSign = [];
+  final List<int> _aQueue = [];
+  final List<int> _bQueue = [];
+  final List<bool> _signQueue = [];
 
-  int currResult = 0;
-  int currRemain = 0;
-  bool divZero = false;
-
-  bool triggerCheck = false;
+  int _currResult = 0;
+  int _currRemain = 0;
+  bool _divZero = false;
+  bool _triggerCheck = false;
 
   @override
   Future<void> run(Phase phase) async {
@@ -238,70 +241,69 @@ class MultiCycleDividerScoreboard extends Component {
     await intf.reset.nextNegedge;
 
     inStream.listen((event) {
-      lastA.add(event.mDividend);
-      lastB.add(event.mDivisor);
-      lastSign.add(event.mIsSigned);
+      _aQueue.add(event.mDividend);
+      _bQueue.add(event.mDivisor);
+      _signQueue.add(event.mIsSigned);
     });
 
-    // record the value we saw this cycle
     outStream.listen((event) {
-      currResult = event.mQuotient;
-      currRemain = event.mRemainder;
-      divZero = event.mDivZero;
-
-      triggerCheck = true;
+      _currResult = event.mQuotient;
+      _currRemain = event.mRemainder;
+      _divZero = event.mDivZero;
+      if (!computeRemainder) {
+        expect(event.mRemainder, 0,
+            reason: 'remainder must be 0 in quotient-only mode');
+      }
+      _triggerCheck = true;
     });
 
-    // check values on negative edge
-    intf.clk.negedge.listen((event) {
-      if (lastA.isNotEmpty) {
-        final in1 = lastA[0];
-        final in2 = lastB[0];
-        final inSign = lastSign[0];
-        lastA.removeAt(0);
-        lastB.removeAt(0);
-        lastSign.removeAt(0);
+    intf.clk.negedge.listen((_) {
+      if (_aQueue.isNotEmpty && _triggerCheck) {
+        final in1 = _aQueue.removeAt(0);
+        final in2 = _bQueue.removeAt(0);
+        final inSign = _signQueue.removeAt(0);
+
         final tCurrResult =
-            inSign ? _twosComp(currResult, intf.quotient.width) : currResult;
-        final tCurrRemain =
-            inSign ? _twosComp(currRemain, intf.remainder.width) : currRemain;
+            inSign ? _twosComp(_currResult, intf.quotient.width) : _currResult;
+        final tCurrRemain = inSign
+            ? _twosComp(_currRemain, intf.remainder.width)
+            : _currRemain;
+
         final overflow = inSign &&
             in1 ==
                 _twosComp(
                     1 << (intf.quotient.width - 1), intf.quotient.width) &&
             in2 == -1;
-        if (triggerCheck) {
-          var check1 = (in2 == 0) ? divZero : ((in1 ~/ in2) == tCurrResult);
-          var check2 = (in2 == 0)
-              ? divZero
-              : ((in1 - (in2 * tCurrResult)) == tCurrRemain);
-          if (overflow) {
-            check1 = tCurrResult ==
-                _twosComp(1 << (intf.quotient.width - 1), intf.quotient.width);
-            check2 = tCurrRemain == 0;
-          }
 
-          if (check1 && check2) {
-            final msg = (in2 == 0)
-                ? '''
-Divide by 0 error correctly encountered for denominator of 0.
-'''
-                : '''
-Correct result: dividend=$in1, divisor=$in2, quotient=$tCurrResult, remainder=$tCurrRemain,
-                ''';
-            logger.info(msg);
-          } else {
-            final msg = (in2 == 0)
-                ? '''
-No Divide by zero error for denominator of 0.
-'''
-                : '''
-Incorrect result: dividend=$in1, divisor=$in2, quotient=$tCurrResult, remainder=$tCurrRemain,
-''';
-            logger.severe(msg);
-          }
-          triggerCheck = false;
+        bool check1;
+        bool check2;
+
+        if (in2 == 0) {
+          check1 = _divZero;
+          check2 = _divZero;
+        } else if (overflow) {
+          check1 = tCurrResult ==
+              _twosComp(1 << (intf.quotient.width - 1), intf.quotient.width);
+          check2 = tCurrRemain == 0;
+        } else {
+          check1 = (in1 ~/ in2) == tCurrResult;
+          check2 = computeRemainder
+              ? (in1 - (in2 * tCurrResult)) == tCurrRemain
+              : true; // remainder not computed; skip check
         }
+
+        if (check1 && check2) {
+          logger.info(in2 == 0
+              ? 'Divide by 0 error correctly encountered for denominator of 0.'
+              : 'Correct result: dividend=$in1, divisor=$in2, '
+                  'quotient=$tCurrResult, remainder=$tCurrRemain');
+        } else {
+          logger.severe(in2 == 0
+              ? 'No Divide by zero error for denominator of 0.'
+              : 'Incorrect result: dividend=$in1, divisor=$in2, '
+                  'quotient=$tCurrResult, remainder=$tCurrRemain');
+        }
+        _triggerCheck = false;
       }
     });
   }
@@ -326,16 +328,19 @@ class MultiCycleDividerAgent extends Agent {
 
 class MultiCycleDividerEnv extends Env {
   final MultiCycleDividerInterface intf;
+  final bool computeRemainder;
 
   late final MultiCycleDividerAgent agent;
   late final MultiCycleDividerScoreboard scoreboard;
 
   MultiCycleDividerEnv(this.intf, Component parent,
-      {String name = 'MultiCycleDividerEnv'})
+      {this.computeRemainder = true,
+      String name = 'MultiCycleDividerEnv'})
       : super(name, parent) {
     agent = MultiCycleDividerAgent(intf, this);
     scoreboard = MultiCycleDividerScoreboard(
-        agent.inMonitor.stream, agent.outMonitor.stream, intf, this);
+        agent.inMonitor.stream, agent.outMonitor.stream, intf, this,
+        computeRemainder: computeRemainder);
   }
 
   @override
@@ -523,6 +528,11 @@ class MultiCycleDividerVolumeSequence extends Sequence {
 class MultiCycleDividerTest extends Test {
   final MultiCycleDivider dut;
   late final MultiCycleDividerInterface intf;
+  final bool computeRemainder;
+
+  /// Optional override sequences. When non-null, [run] starts these instead
+  /// of the default basic/evil/volume sequences.
+  final List<Sequence>? sequences;
 
   /// The test environment for [dut].
   late final MultiCycleDividerEnv env;
@@ -531,9 +541,11 @@ class MultiCycleDividerTest extends Test {
   late final MultiCycleDividerSequencer _divSequencer;
 
   MultiCycleDividerTest(this.dut, this.intf,
-      {String name = 'MultiCycleDividerTest'})
+      {this.computeRemainder = true,
+      this.sequences,
+      String name = 'MultiCycleDividerTest'})
       : super(name) {
-    env = MultiCycleDividerEnv(intf, this);
+    env = MultiCycleDividerEnv(intf, this, computeRemainder: computeRemainder);
     _divSequencer = env.agent.sequencer;
   }
 
@@ -553,7 +565,7 @@ class MultiCycleDividerTest extends Test {
     // simulation doesn't end before stimulus is injected
     final obj = phase.raiseObjection('div_test');
 
-    logger.info('Running the test...');
+    logger.info('Running the test (computeRemainder=$computeRemainder)...');
 
     // Add some simple reset behavior at specified timestamps
     Simulator.registerAction(1, () {
@@ -562,20 +574,22 @@ class MultiCycleDividerTest extends Test {
       intf.divisor.put(0);
       intf.validIn.put(0);
     });
-    Simulator.registerAction(10, () {
-      intf.reset.put(1);
-    });
-    Simulator.registerAction(20, () {
-      intf.reset.put(0);
-    });
+    Simulator.registerAction(10, () => intf.reset.put(1));
+    Simulator.registerAction(20, () => intf.reset.put(0));
 
     // Wait for the next negative edge of reset
     await intf.reset.nextNegedge;
 
-    // Kick off a sequence on the sequencer
-    await _divSequencer.start(MultiCycleDividerBasicSequence());
-    await _divSequencer.start(MultiCycleDividerEvilSequence(numBits: 32));
-    await _divSequencer.start(MultiCycleDividerVolumeSequence(1000));
+    // Kick off sequences on the sequencer
+    if (sequences != null) {
+      for (final seq in sequences!) {
+        await _divSequencer.start(seq);
+      }
+    } else {
+      await _divSequencer.start(MultiCycleDividerBasicSequence());
+      await _divSequencer.start(MultiCycleDividerEvilSequence(numBits: 32));
+      await _divSequencer.start(MultiCycleDividerVolumeSequence(1000));
+    }
 
     logger.info('Done adding stimulus to the sequencer');
 
@@ -585,71 +599,236 @@ class MultiCycleDividerTest extends Test {
 }
 
 class TopTB {
-  // Instance of the DUT
   late final MultiCycleDivider divider;
-
-  // A constant value for the width to use in this testbench
   static const int width = 32;
 
-  TopTB(MultiCycleDividerInterface intf) {
-    // Connect a generated clock to the interface
+  TopTB(MultiCycleDividerInterface intf, {bool computeRemainder = true}) {
     intf.clk <= SimpleClockGenerator(10).clk;
-
-    // Create the DUT, passing it our interface
-    divider = MultiCycleDivider(intf);
+    divider = MultiCycleDivider(intf, computeRemainder: computeRemainder);
   }
 }
+
+// ---------------------------------------------------------------------------
+// Corner-case sequence and narrow testbench
+// ---------------------------------------------------------------------------
+
+/// Corner-case sequence parameterised by [dataWidth] so numeric bounds match.
+class MultiCycleDividerCornerSequence extends Sequence {
+  final int dataWidth;
+
+  MultiCycleDividerCornerSequence(
+      {required this.dataWidth,
+      String name = 'MultiCycleDividerCornerSequence'})
+      : super(name);
+
+  @override
+  Future<void> body(Sequencer sequencer) async {
+    final seq = sequencer as MultiCycleDividerSequencer;
+
+    final maxU = (1 << dataWidth) - 1; // e.g. 255 for 8-bit
+    final maxS = (1 << (dataWidth - 1)) - 1; // e.g.  127
+    final minS = -(1 << (dataWidth - 1)); // e.g. -128
+
+    void add(int a, int b, {required bool signed, required String desc}) =>
+        seq.add(MultiCycleDividerInputSeqItem(
+            mDividend: a,
+            mDivisor: b,
+            mIsSigned: signed,
+            mValidIn: true,
+            mReadyOut: true));
+
+    // ---- unsigned -----------------------------------------------------------
+    add(0, 1, signed: false, desc: 'U: 0/1');
+    add(0, maxU, signed: false, desc: 'U: 0/MAX');
+    add(1, maxU, signed: false, desc: 'U: 1/MAX → q=0,r=1');
+    add(6, 3, signed: false, desc: 'U: even divide');
+    add(7, 3, signed: false, desc: 'U: divide with remainder');
+    add(5, 1, signed: false, desc: 'U: divide-by-1');
+    add(8, 4, signed: false, desc: 'U: power-of-2 divisor');
+    add(9, 4, signed: false, desc: 'U: power-of-2 divisor with rem');
+    add(maxU, 1, signed: false, desc: 'U: MAX/1 (worst-case latency)');
+    add(maxU, maxU, signed: false, desc: 'U: MAX/MAX=1');
+    add(maxU, maxU - 1, signed: false, desc: 'U: MAX/(MAX-1)=1,r=1');
+    add(6, 0, signed: false, desc: 'U: dz nonzero dividend');
+    add(0, 0, signed: false, desc: 'U: dz zero dividend');
+
+    // ---- signed: +/+ --------------------------------------------------------
+    add(6, 3, signed: true, desc: 'S: +6/+3');
+    add(7, 3, signed: true, desc: 'S: +7/+3 with rem');
+    add(1, maxS, signed: true, desc: 'S: 1/MAX → q=0');
+    add(maxS, 1, signed: true, desc: 'S: MAX/1 → q=MAX');
+    add(maxS, maxS, signed: true, desc: 'S: MAX/MAX=1');
+
+    // ---- signed: +/- --------------------------------------------------------
+    add(6, -3, signed: true, desc: 'S: +6/-3 → q=-2');
+    add(7, -3, signed: true, desc: 'S: +7/-3 → q=-2,r=1');
+    add(maxS, -1, signed: true, desc: 'S: MAX/-1 → q=-MAX');
+
+    // ---- signed: -/+ --------------------------------------------------------
+    add(-6, 3, signed: true, desc: 'S: -6/+3 → q=-2');
+    add(-7, 3, signed: true, desc: 'S: -7/+3 → q=-2,r=-1');
+    add(minS, 1, signed: true, desc: 'S: MIN/1 → q=MIN');
+
+    // ---- signed: -/- --------------------------------------------------------
+    add(-6, -3, signed: true, desc: 'S: -6/-3 → q=2');
+    add(-7, -3, signed: true, desc: 'S: -7/-3 → q=2,r=-1');
+    add(minS, minS, signed: true, desc: 'S: MIN/MIN=1');
+
+    // ---- signed overflow (the only true overflow case) ----------------------
+    add(minS, -1, signed: true, desc: 'S: ov MIN/-1');
+
+    // ---- signed divide-by-zero ----------------------------------------------
+    add(3, 0, signed: true, desc: 'S: dz positive');
+    add(-3, 0, signed: true, desc: 'S: dz negative');
+    add(0, 0, signed: true, desc: 'S: dz zero dividend');
+  }
+}
+
+class TopTBNarrow {
+  late final MultiCycleDivider divider;
+  static const int width = 8;
+
+  TopTBNarrow(MultiCycleDividerInterface intf, {bool computeRemainder = true}) {
+    intf.clk <= SimpleClockGenerator(10).clk;
+    divider = MultiCycleDivider(intf, computeRemainder: computeRemainder);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 void main() {
   tearDown(() async {
     await Simulator.reset();
   });
 
-  group('divider tests', () {
-    test('VF tests', () async {
-      // Set the logger level
-      Logger.root.level = Level.SEVERE;
+  // Run the full VF + factory-method smoke tests in both modes.
+  for (final computeRemainder in [true, false]) {
+    final label = computeRemainder ? 'with remainder' : 'quotient-only';
 
-      // Create the testbench
-      final intf = MultiCycleDividerInterface();
-      final tb = TopTB(intf);
+    group('divider tests ($label)', () {
+      test('VF tests', () async {
+        Logger.root.level = Level.SEVERE;
 
-      // Build the DUT
-      await tb.divider.build();
+        final intf = MultiCycleDividerInterface();
+        final tb = TopTB(intf, computeRemainder: computeRemainder);
+        await tb.divider.build();
 
-      // Attach a waveform dumper to the DUT
-      // WaveDumper(tb.divider);
+        Simulator.setMaxSimTime(200000);
 
-      // Set a maximum simulation time so it doesn't run forever
-      Simulator.setMaxSimTime(100000);
+        final test = MultiCycleDividerTest(tb.divider, intf,
+            computeRemainder: computeRemainder);
+        await test.start();
+      });
 
-      // Create and start the test!
-      final test = MultiCycleDividerTest(tb.divider, intf);
-      await test.start();
+      test('Factory method build', () async {
+        final clk = Logic(name: 'clk');
+        final reset = Logic(name: 'reset');
+        final validIn = Logic(name: 'validIn');
+        final dividend = Logic(name: 'dividend', width: 32);
+        final divisor = Logic(name: 'divisor', width: 32);
+        final isSigned = Logic(name: 'isSigned');
+        final readyOut = Logic(name: 'readyOut');
+        final div = MultiCycleDivider.ofLogics(
+            clk: clk,
+            reset: reset,
+            validIn: validIn,
+            dividend: dividend,
+            divisor: divisor,
+            isSigned: isSigned,
+            readyOut: readyOut,
+            computeRemainder: computeRemainder);
+        await div.build();
+
+        Logic(name: 'tValidOut').gets(div.validOut);
+        Logic(name: 'tQuotient', width: 32).gets(div.quotient);
+        Logic(name: 'tRemainder', width: 32).gets(div.remainder);
+        Logic(name: 'tDivZero').gets(div.divZero);
+        Logic(name: 'tReadyIn').gets(div.readyIn);
+      });
     });
+  }
 
-    test('Factory method build', () async {
-      final clk = Logic(name: 'clk');
-      final reset = Logic(name: 'reset');
-      final validIn = Logic(name: 'validIn');
-      final dividend = Logic(name: 'dividend', width: 32);
-      final divisor = Logic(name: 'divisor', width: 32);
-      final isSigned = Logic(name: 'isSigned');
-      final readyOut = Logic(name: 'readyOut');
-      final div = MultiCycleDivider.ofLogics(
-          clk: clk,
-          reset: reset,
-          validIn: validIn,
-          dividend: dividend,
-          divisor: divisor,
-          isSigned: isSigned,
-          readyOut: readyOut);
-      await div.build();
+  test('quotient-only is O(n) cycles — latency == dataWidth+2 cycles',
+      () async {
+    const w = 8;
+    final intf = MultiCycleDividerInterface(dataWidth: w);
+    intf.clk <= SimpleClockGenerator(10).clk;
+    final dut = MultiCycleDivider(intf, computeRemainder: false);
+    await dut.build();
 
-      Logic(name: 'tValidOut').gets(div.validOut);
-      Logic(name: 'tQuotient', width: 32).gets(div.quotient);
-      Logic(name: 'tDivZero').gets(div.divZero);
-      Logic(name: 'tReadyIn').gets(div.readyIn);
+    int? latency;
+    int startCycle = 0;
+    int cycleCount = 0;
+
+    intf.clk.posedge.listen((_) => cycleCount++);
+
+    Simulator.registerAction(1, () {
+      intf.reset.put(0);
+      intf.dividend.put(0);
+      intf.divisor.put(0);
+      intf.validIn.put(0);
+      intf.readyOut.put(1);
     });
+    Simulator.registerAction(10, () => intf.reset.put(1));
+    Simulator.registerAction(20, () => intf.reset.put(0));
+
+    Simulator.setMaxSimTime(5000);
+
+    unawaited(Simulator.run());
+
+    await intf.reset.nextNegedge;
+
+    // Worst-case: dividend=255, divisor=1 (unsigned 8-bit).
+    intf.validIn.put(1);
+    intf.dividend.put(255);
+    intf.divisor.put(1);
+    intf.isSigned.put(0);
+    startCycle = cycleCount;
+
+    await intf.clk.nextPosedge; // input accepted
+    intf.validIn.put(0);
+
+    await intf.validOut.nextPosedge;
+    latency = cycleCount - startCycle;
+
+    // O(n): exactly w process cycles + 1 convert + 1 done leading edge.
+    expect(latency, equals(w + 2),
+        reason: 'O(n) divider latency should be dataWidth+2=$w+2 cycles');
+    expect(intf.quotient.value.toInt(), equals(255));
+    expect(intf.remainder.value.toInt(), equals(0));
+
+    await Simulator.endSimulation();
   });
+
+  // ---------------------------------------------------------------------------
+  // Targeted corner-case tests using an 8-bit DUT via the VF harness.
+  //
+  // An 8-bit DUT keeps simulation fast (O(n²) worst-case ≤ 64 cycles/op)
+  // while each vector targets a distinct structural corner.
+  // ---------------------------------------------------------------------------
+  for (final computeRemainder in [true, false]) {
+    final label = computeRemainder ? 'with remainder' : 'quotient-only';
+
+    group('divider corner cases 8-bit ($label)', () {
+      test('targeted structural corners', () async {
+        Logger.root.level = Level.SEVERE;
+
+        final intf = MultiCycleDividerInterface(dataWidth: TopTBNarrow.width);
+        final tb = TopTBNarrow(intf, computeRemainder: computeRemainder);
+        await tb.divider.build();
+
+        Simulator.setMaxSimTime(500000);
+
+        final test = MultiCycleDividerTest(tb.divider, intf,
+            computeRemainder: computeRemainder,
+            sequences: [
+              MultiCycleDividerCornerSequence(dataWidth: TopTBNarrow.width)
+            ]);
+
+        await test.start();
+      }, timeout: const Timeout(Duration(minutes: 1)));
+    });
+  }
 }

--- a/test/arithmetic/divider_test.dart
+++ b/test/arithmetic/divider_test.dart
@@ -17,8 +17,11 @@ import 'package:rohd_hcl/rohd_hcl.dart';
 import 'package:rohd_vf/rohd_vf.dart';
 import 'package:test/test.dart';
 
-// helper method to compute 2's complement representation
-// of the provided value based on its bit width
+// ---------------------------------------------------------------------------
+// Helper: two's complement decode
+// ---------------------------------------------------------------------------
+
+/// Decode a raw unsigned bit pattern as a two's complement signed integer.
 int _twosComp(int val, int bits) {
   var tmp = val;
   if (val & (1 << (bits - 1)) != 0) {
@@ -26,6 +29,10 @@ int _twosComp(int val, int bits) {
   }
   return tmp;
 }
+
+// ---------------------------------------------------------------------------
+// Sequence items
+// ---------------------------------------------------------------------------
 
 class MultiCycleDividerInputSeqItem extends SequenceItem {
   final int mDividend;
@@ -85,6 +92,10 @@ readyIn=$mReadyIn
 ''';
 }
 
+// ---------------------------------------------------------------------------
+// Sequencer / Driver / Monitors
+// ---------------------------------------------------------------------------
+
 class MultiCycleDividerSequencer
     extends Sequencer<MultiCycleDividerInputSeqItem> {
   MultiCycleDividerSequencer(Component parent,
@@ -95,7 +106,6 @@ class MultiCycleDividerSequencer
 class MultiCycleDividerDriver extends Driver<MultiCycleDividerInputSeqItem> {
   final MultiCycleDividerInterface intf;
 
-  // Keep a queue of items from the sequencer to be driven when desired
   final Queue<MultiCycleDividerInputSeqItem> _pendingItems =
       Queue<MultiCycleDividerInputSeqItem>();
 
@@ -110,7 +120,6 @@ class MultiCycleDividerDriver extends Driver<MultiCycleDividerInputSeqItem> {
   Future<void> run(Phase phase) async {
     unawaited(super.run(phase));
 
-    // Listen to new items coming from the sequencer, and add them to a queue
     sequencer.stream.listen((newItem) async {
       _driverObjection ??= phase.raiseObjection('div_driver');
       unawaited(_driverObjection!.dropped
@@ -118,8 +127,6 @@ class MultiCycleDividerDriver extends Driver<MultiCycleDividerInputSeqItem> {
       _pendingItems.add(newItem);
     });
 
-    // Every clock negative edge, drive the next pending item if it exists
-    // but only when the DUT isn't busy
     intf.clk.negedge.listen((args) {
       if (_pendingItems.isNotEmpty && intf.readyIn.value == LogicValue.one) {
         final nextItem = _pendingItems.removeFirst();
@@ -132,7 +139,6 @@ class MultiCycleDividerDriver extends Driver<MultiCycleDividerInputSeqItem> {
     });
   }
 
-  // Translate a SequenceItem into pin wiggles
   void drive(MultiCycleDividerInputSeqItem? item) {
     if (item == null) {
       intf.dividend.inject(0);
@@ -152,7 +158,6 @@ class MultiCycleDividerDriver extends Driver<MultiCycleDividerInputSeqItem> {
 
 class MultiCycleDividerInputMonitor
     extends Monitor<MultiCycleDividerInputSeqItem> {
-  /// Instance of the [Interface] to the DUT.
   final MultiCycleDividerInterface intf;
 
   MultiCycleDividerInputMonitor(this.intf, Component parent,
@@ -163,7 +168,6 @@ class MultiCycleDividerInputMonitor
   Future<void> run(Phase phase) async {
     unawaited(super.run(phase));
 
-    // Every positive edge of the clock
     intf.clk.posedge.listen((event) {
       if (intf.validIn.value == LogicValue.one &&
           intf.readyIn.value == LogicValue.one) {
@@ -176,7 +180,7 @@ class MultiCycleDividerInputMonitor
                 : intf.divisor.value.toInt(),
             mIsSigned: intf.isSigned.value.toBool(),
             mValidIn: true,
-            mReadyOut: true)); // must convert to two's complement rep.
+            mReadyOut: true));
       }
     });
   }
@@ -184,22 +188,19 @@ class MultiCycleDividerInputMonitor
 
 class MultiCycleDividerOutputMonitor
     extends Monitor<MultiCycleDividerOutputSeqItem> {
-  /// Instance of the [Interface] to the DUT.
   final MultiCycleDividerInterface intf;
 
   MultiCycleDividerOutputMonitor(this.intf, Component parent,
-      {String name = 'MultiCycleDividerInputMonitor'})
+      {String name = 'MultiCycleDividerOutputMonitor'})
       : super(name, parent);
 
   @override
   Future<void> run(Phase phase) async {
     unawaited(super.run(phase));
 
-    // Every positive edge of the clock
     intf.clk.posedge.listen((event) {
       if (intf.validOut.value == LogicValue.one) {
         add(MultiCycleDividerOutputSeqItem(
-            // must convert to two's complement rep.
             mQuotient: intf.quotient.value.toInt(),
             mRemainder: intf.remainder.value.toInt(),
             mDivZero: intf.divZero.value == LogicValue.one,
@@ -210,13 +211,14 @@ class MultiCycleDividerOutputMonitor
   }
 }
 
+// ---------------------------------------------------------------------------
+// Scoreboard / Agent / Env
+// ---------------------------------------------------------------------------
+
 class MultiCycleDividerScoreboard extends Component {
   final Stream<MultiCycleDividerInputSeqItem> inStream;
   final Stream<MultiCycleDividerOutputSeqItem> outStream;
   final MultiCycleDividerInterface intf;
-
-  /// When `false`, only the quotient is verified and remainder is expected
-  /// to always be 0.
   final bool computeRemainder;
 
   MultiCycleDividerScoreboard(
@@ -286,7 +288,6 @@ class MultiCycleDividerScoreboard extends Component {
           check2 = tCurrRemain == 0;
         } else {
           check1 = (in1 ~/ in2) == tCurrResult;
-          // remainder not computed in quotient-only mode; skip check
           check2 =
               !computeRemainder || (in1 - (in2 * tCurrResult)) == tCurrRemain;
         }
@@ -347,6 +348,89 @@ class MultiCycleDividerEnv extends Env {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Test
+// ---------------------------------------------------------------------------
+
+class MultiCycleDividerTest extends Test {
+  final Module dut;
+  late final MultiCycleDividerInterface intf;
+  final bool computeRemainder;
+  final List<Sequence>? sequences;
+
+  late final MultiCycleDividerEnv env;
+  late final MultiCycleDividerSequencer _divSequencer;
+
+  MultiCycleDividerTest(this.dut, this.intf,
+      {this.computeRemainder = true,
+      this.sequences,
+      String name = 'MultiCycleDividerTest'})
+      : super(name) {
+    env = MultiCycleDividerEnv(intf, this, computeRemainder: computeRemainder);
+    _divSequencer = env.agent.sequencer;
+  }
+
+  @override
+  Future<void> run(Phase phase) async {
+    unawaited(super.run(phase));
+
+    final obj = phase.raiseObjection('div_test');
+    logger.info('Running the test (computeRemainder=$computeRemainder)...');
+
+    Simulator.registerAction(1, () {
+      intf.reset.put(0);
+      intf.dividend.put(0);
+      intf.divisor.put(0);
+      intf.validIn.put(0);
+    });
+    Simulator.registerAction(10, () => intf.reset.put(1));
+    Simulator.registerAction(20, () => intf.reset.put(0));
+
+    await intf.reset.nextNegedge;
+
+    if (sequences != null) {
+      for (final seq in sequences!) {
+        await _divSequencer.start(seq);
+      }
+    } else {
+      await _divSequencer.start(MultiCycleDividerBasicSequence());
+      await _divSequencer.start(MultiCycleDividerEvilSequence(numBits: 32));
+      await _divSequencer.start(MultiCycleDividerVolumeSequence(1000));
+    }
+
+    logger.info('Done adding stimulus to the sequencer');
+    obj.drop();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Testbenches
+// ---------------------------------------------------------------------------
+
+class TopTB {
+  late final MultiCycleDivider divider;
+  static const int width = 32;
+
+  TopTB(MultiCycleDividerInterface intf, {bool computeRemainder = true}) {
+    intf.clk <= SimpleClockGenerator(10).clk;
+    divider = MultiCycleDivider(intf, computeRemainder: computeRemainder);
+  }
+}
+
+class TopTBNarrow {
+  late final MultiCycleDivider divider;
+  static const int width = 8;
+
+  TopTBNarrow(MultiCycleDividerInterface intf, {bool computeRemainder = true}) {
+    intf.clk <= SimpleClockGenerator(10).clk;
+    divider = MultiCycleDivider(intf, computeRemainder: computeRemainder);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sequences
+// ---------------------------------------------------------------------------
+
 class MultiCycleDividerBasicSequence extends Sequence {
   MultiCycleDividerBasicSequence(
       {String name = 'MultiCycleDividerBasicSequence'})
@@ -360,56 +444,55 @@ class MultiCycleDividerBasicSequence extends Sequence {
           mDivisor: 2,
           mValidIn: true,
           mIsSigned: true,
-          mReadyOut: true)) // even divide by 2
+          mReadyOut: true))
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: 9,
           mDivisor: 3,
           mValidIn: true,
           mIsSigned: true,
-          mReadyOut: true)) // even divide not by 2
+          mReadyOut: true))
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: 5,
           mDivisor: 2,
           mValidIn: true,
           mIsSigned: false,
-          mReadyOut: true)) // not even divide
+          mReadyOut: true))
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: 4,
           mDivisor: 1,
           mValidIn: true,
           mIsSigned: false,
-          mReadyOut: true)) // divide by 1
+          mReadyOut: true))
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: -10,
           mDivisor: 2,
           mValidIn: true,
           mIsSigned: true,
-          mReadyOut: true)) // negative-positive
+          mReadyOut: true))
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: 13,
           mDivisor: -10,
           mValidIn: true,
           mIsSigned: true,
-          mReadyOut: true)) // positive-negative
+          mReadyOut: true))
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: -10,
           mDivisor: -9,
           mValidIn: true,
           mIsSigned: true,
-          mReadyOut: true)) // negative-negative
+          mReadyOut: true))
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: 1,
           mDivisor: 4,
           mValidIn: true,
           mIsSigned: true,
-          mReadyOut: true)) // bigger divisor
+          mReadyOut: true))
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: 4,
           mDivisor: 0,
           mValidIn: true,
           mIsSigned: true,
-          mReadyOut: true)) // divide by 0
-      // long latency division
+          mReadyOut: true))
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: 0xffffffec,
           mDivisor: 0x6,
@@ -429,65 +512,54 @@ class MultiCycleDividerEvilSequence extends Sequence {
   @override
   Future<void> body(Sequencer sequencer) async {
     sequencer as MultiCycleDividerSequencer
-      // largest positive divided by largest positive
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: (1 << (numBits - 1)) - 1,
           mDivisor: (1 << (numBits - 1)) - 1,
           mValidIn: true,
           mIsSigned: true,
           mReadyOut: true))
-      // largest positive divided by largest negative
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: (1 << (numBits - 1)) - 1,
           mDivisor: (1 << (numBits - 1)),
           mValidIn: true,
           mIsSigned: true,
           mReadyOut: true))
-      // largest negative divided by largest positive
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: (1 << (numBits - 1)),
           mDivisor: (1 << (numBits - 1)) - 1,
           mValidIn: true,
           mIsSigned: false,
           mReadyOut: true))
-      // largest negative divided by largest negative
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: (1 << (numBits - 1)),
           mDivisor: (1 << (numBits - 1)),
           mValidIn: true,
           mIsSigned: false,
           mReadyOut: true))
-      // largest positive divided by negative 1
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: (1 << (numBits - 1)) - 1,
           mDivisor: -1,
           mValidIn: true,
           mIsSigned: true,
           mReadyOut: true))
-      // largest negative divided by negative 1
-      // this is the only true overflow case...
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: (1 << (numBits - 1)),
           mDivisor: -1,
           mValidIn: true,
           mIsSigned: true,
           mReadyOut: true))
-      // largest positive divided by 1
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: (1 << (numBits - 1)) - 1,
           mDivisor: 1,
           mValidIn: true,
           mIsSigned: true,
           mReadyOut: true))
-      // largest negative divided by 1
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: (1 << (numBits - 1)),
           mDivisor: 1,
           mValidIn: true,
           mIsSigned: true,
           mReadyOut: true))
-      // unsigned version of overflow case
-      // which should not result in overflow
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: (1 << (numBits - 1)),
           mDivisor: -1,
@@ -499,7 +571,7 @@ class MultiCycleDividerEvilSequence extends Sequence {
 
 class MultiCycleDividerVolumeSequence extends Sequence {
   final int numReps;
-  final rng = Random(0xdeadbeef); // fixed seed
+  final rng = Random(0xdeadbeef);
 
   MultiCycleDividerVolumeSequence(this.numReps,
       {String name = 'MultiCycleDividerVolumeSequence'})
@@ -508,7 +580,6 @@ class MultiCycleDividerVolumeSequence extends Sequence {
   @override
   Future<void> body(Sequencer sequencer) async {
     final divSequencer = sequencer as MultiCycleDividerSequencer;
-
     for (var i = 0; i < numReps; i++) {
       final a = rng.nextInt(1 << 32);
       final b = rng.nextInt(1 << 32);
@@ -523,94 +594,7 @@ class MultiCycleDividerVolumeSequence extends Sequence {
   }
 }
 
-class MultiCycleDividerTest extends Test {
-  final MultiCycleDivider dut;
-  late final MultiCycleDividerInterface intf;
-  final bool computeRemainder;
-
-  /// Optional override sequences. When non-null, [run] starts these instead
-  /// of the default basic/evil/volume sequences.
-  final List<Sequence>? sequences;
-
-  /// The test environment for [dut].
-  late final MultiCycleDividerEnv env;
-
-  /// A private, local pointer to the test environment's [Sequencer].
-  late final MultiCycleDividerSequencer _divSequencer;
-
-  MultiCycleDividerTest(this.dut, this.intf,
-      {this.computeRemainder = true,
-      this.sequences,
-      String name = 'MultiCycleDividerTest'})
-      : super(name) {
-    env = MultiCycleDividerEnv(intf, this, computeRemainder: computeRemainder);
-    _divSequencer = env.agent.sequencer;
-  }
-
-  // A "time consuming" method, similar to `task` in SystemVerilog, which
-  // waits for a given number of cycles before completing.
-  Future<void> waitCycles(int numCycles) async {
-    for (var i = 0; i < numCycles; i++) {
-      await intf.clk.nextNegedge;
-    }
-  }
-
-  @override
-  Future<void> run(Phase phase) async {
-    unawaited(super.run(phase));
-
-    // Raise an objection at the start of the test so that the
-    // simulation doesn't end before stimulus is injected
-    final obj = phase.raiseObjection('div_test');
-
-    logger.info('Running the test (computeRemainder=$computeRemainder)...');
-
-    // Add some simple reset behavior at specified timestamps
-    Simulator.registerAction(1, () {
-      intf.reset.put(0);
-      intf.dividend.put(0);
-      intf.divisor.put(0);
-      intf.validIn.put(0);
-    });
-    Simulator.registerAction(10, () => intf.reset.put(1));
-    Simulator.registerAction(20, () => intf.reset.put(0));
-
-    // Wait for the next negative edge of reset
-    await intf.reset.nextNegedge;
-
-    // Kick off sequences on the sequencer
-    if (sequences != null) {
-      for (final seq in sequences!) {
-        await _divSequencer.start(seq);
-      }
-    } else {
-      await _divSequencer.start(MultiCycleDividerBasicSequence());
-      await _divSequencer.start(MultiCycleDividerEvilSequence(numBits: 32));
-      await _divSequencer.start(MultiCycleDividerVolumeSequence(1000));
-    }
-
-    logger.info('Done adding stimulus to the sequencer');
-
-    // Done adding stimulus, we can drop our objection now
-    obj.drop();
-  }
-}
-
-class TopTB {
-  late final MultiCycleDivider divider;
-  static const int width = 32;
-
-  TopTB(MultiCycleDividerInterface intf, {bool computeRemainder = true}) {
-    intf.clk <= SimpleClockGenerator(10).clk;
-    divider = MultiCycleDivider(intf, computeRemainder: computeRemainder);
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Corner-case sequence and narrow testbench
-// ---------------------------------------------------------------------------
-
-/// Corner-case sequence parameterised by [dataWidth] so numeric bounds match.
+/// Corner-case sequence parameterised by [dataWidth] — signed vectors only.
 class MultiCycleDividerCornerSequence extends Sequence {
   final int dataWidth;
 
@@ -623,11 +607,10 @@ class MultiCycleDividerCornerSequence extends Sequence {
   Future<void> body(Sequencer sequencer) async {
     final seq = sequencer as MultiCycleDividerSequencer;
 
-    final maxU = (1 << dataWidth) - 1; // e.g. 255 for 8-bit
-    final maxS = (1 << (dataWidth - 1)) - 1; // e.g.  127
-    final minS = -(1 << (dataWidth - 1)); // e.g. -128
+    final maxS = (1 << (dataWidth - 1)) - 1;
+    final minS = -(1 << (dataWidth - 1));
 
-    void add(int a, int b, {required bool signed, required String desc}) =>
+    void add(int a, int b, {required bool signed}) =>
         seq.add(MultiCycleDividerInputSeqItem(
             mDividend: a,
             mDivisor: b,
@@ -635,77 +618,474 @@ class MultiCycleDividerCornerSequence extends Sequence {
             mValidIn: true,
             mReadyOut: true));
 
-    // ---- unsigned -----------------------------------------------------------
-    add(0, 1, signed: false, desc: 'U: 0/1');
-    add(0, maxU, signed: false, desc: 'U: 0/MAX');
-    add(1, maxU, signed: false, desc: 'U: 1/MAX → q=0,r=1');
-    add(6, 3, signed: false, desc: 'U: even divide');
-    add(7, 3, signed: false, desc: 'U: divide with remainder');
-    add(5, 1, signed: false, desc: 'U: divide-by-1');
-    add(8, 4, signed: false, desc: 'U: power-of-2 divisor');
-    add(9, 4, signed: false, desc: 'U: power-of-2 divisor with rem');
-    add(maxU, 1, signed: false, desc: 'U: MAX/1 (worst-case latency)');
-    add(maxU, maxU, signed: false, desc: 'U: MAX/MAX=1');
-    add(maxU, maxU - 1, signed: false, desc: 'U: MAX/(MAX-1)=1,r=1');
-    add(6, 0, signed: false, desc: 'U: dz nonzero dividend');
-    add(0, 0, signed: false, desc: 'U: dz zero dividend');
-
-    // ---- signed: +/+ --------------------------------------------------------
-    add(6, 3, signed: true, desc: 'S: +6/+3');
-    add(7, 3, signed: true, desc: 'S: +7/+3 with rem');
-    add(1, maxS, signed: true, desc: 'S: 1/MAX → q=0');
-    add(maxS, 1, signed: true, desc: 'S: MAX/1 → q=MAX');
-    add(maxS, maxS, signed: true, desc: 'S: MAX/MAX=1');
-
-    // ---- signed: +/- --------------------------------------------------------
-    add(6, -3, signed: true, desc: 'S: +6/-3 → q=-2');
-    add(7, -3, signed: true, desc: 'S: +7/-3 → q=-2,r=1');
-    add(maxS, -1, signed: true, desc: 'S: MAX/-1 → q=-MAX');
-
-    // ---- signed: -/+ --------------------------------------------------------
-    add(-6, 3, signed: true, desc: 'S: -6/+3 → q=-2');
-    add(-7, 3, signed: true, desc: 'S: -7/+3 → q=-2,r=-1');
-    add(minS, 1, signed: true, desc: 'S: MIN/1 → q=MIN');
-
-    // ---- signed: -/- --------------------------------------------------------
-    add(-6, -3, signed: true, desc: 'S: -6/-3 → q=2');
-    add(-7, -3, signed: true, desc: 'S: -7/-3 → q=2,r=-1');
-    add(minS, minS, signed: true, desc: 'S: MIN/MIN=1');
-
-    // ---- signed overflow (the only true overflow case) ----------------------
-    add(minS, -1, signed: true, desc: 'S: ov MIN/-1');
-
-    // ---- signed divide-by-zero ----------------------------------------------
-    add(3, 0, signed: true, desc: 'S: dz positive');
-    add(-3, 0, signed: true, desc: 'S: dz negative');
-    add(0, 0, signed: true, desc: 'S: dz zero dividend');
+    // +/+
+    add(6, 3, signed: true);
+    add(7, 3, signed: true);
+    add(1, maxS, signed: true);
+    add(maxS, 1, signed: true);
+    add(maxS, maxS, signed: true);
+    // +/-
+    add(6, -3, signed: true);
+    add(7, -3, signed: true);
+    add(maxS, -1, signed: true);
+    // -/+
+    add(-6, 3, signed: true);
+    add(-7, 3, signed: true);
+    add(minS, 1, signed: true);
+    // -/-
+    add(-6, -3, signed: true);
+    add(-7, -3, signed: true);
+    add(minS, minS, signed: true);
+    // overflow
+    add(minS, -1, signed: true);
+    // divide-by-zero
+    add(3, 0, signed: true);
+    add(-3, 0, signed: true);
+    add(0, 0, signed: true);
   }
 }
 
-class TopTBNarrow {
-  late final MultiCycleDivider divider;
+int _to1sComp(int value, int bits) {
+  final mask = (1 << bits) - 1;
+  if (value < 0) {
+    return ~ -value & mask;
+  }
+  return value & mask;
+}
+
+/// Interpret an n-bit raw value as a one's complement signed integer.
+int _from1sComp(int raw, int bits) {
+  if (raw & (1 << (bits - 1)) != 0) {
+    return -(~raw & ((1 << bits) - 1));
+  }
+  return raw;
+}
+
+// ---------------------------------------------------------------------------
+// Testbench
+// ---------------------------------------------------------------------------
+
+class TopTBOnesComp {
+  late final OnesComplementDivider divider;
   static const int width = 8;
 
-  TopTBNarrow(MultiCycleDividerInterface intf, {bool computeRemainder = true}) {
+  TopTBOnesComp(MultiCycleDividerInterface intf,
+      {bool computeRemainder = true}) {
     intf.clk <= SimpleClockGenerator(10).clk;
-    divider = MultiCycleDivider(intf, computeRemainder: computeRemainder);
+    divider = OnesComplementDivider(intf, computeRemainder: computeRemainder);
   }
 }
 
 // ---------------------------------------------------------------------------
-// Tests
+// VF infrastructure
 // ---------------------------------------------------------------------------
+
+/// Input monitor that decodes pin values using [_from1sComp] instead of
+/// [twosComp], so signed dividends/divisors are captured correctly.
+class OnesComplementInputMonitor
+    extends Monitor<MultiCycleDividerInputSeqItem> {
+  final MultiCycleDividerInterface intf;
+
+  OnesComplementInputMonitor(this.intf, Component parent,
+      {String name = 'OnesComplementInputMonitor'})
+      : super(name, parent);
+
+  @override
+  Future<void> run(Phase phase) async {
+    unawaited(super.run(phase));
+    intf.clk.posedge.listen((event) {
+      if (intf.validIn.value == LogicValue.one &&
+          intf.readyIn.value == LogicValue.one) {
+        add(MultiCycleDividerInputSeqItem(
+            mDividend: intf.isSigned.value.toBool()
+                ? _from1sComp(intf.dividend.value.toInt(), intf.dividend.width)
+                : intf.dividend.value.toInt(),
+            mDivisor: intf.isSigned.value.toBool()
+                ? _from1sComp(intf.divisor.value.toInt(), intf.divisor.width)
+                : intf.divisor.value.toInt(),
+            mIsSigned: intf.isSigned.value.toBool(),
+            mValidIn: true,
+            mReadyOut: true));
+      }
+    });
+  }
+}
+
+/// Scoreboard for [OnesComplementDivider].
+///
+/// Interprets both inputs (via [_from1sComp] in the input monitor) and raw
+/// register outputs (via [_from1sComp]) as one's complement signed integers.
+/// For unsigned inputs the raw value is used as-is.
+/// Divide-by-zero: triggered by all-zeros OR (signed) all-ones divisor.
+class OnesComplementScoreboard extends Component {
+  final Stream<MultiCycleDividerInputSeqItem> inStream;
+  final Stream<MultiCycleDividerOutputSeqItem> outStream;
+  final MultiCycleDividerInterface intf;
+  final bool computeRemainder;
+
+  OnesComplementScoreboard(
+      this.inStream, this.outStream, this.intf, Component parent,
+      {this.computeRemainder = true, String name = 'OnesComplementScoreboard'})
+      : super(name, parent);
+
+  final List<int> _aQueue = [];
+  final List<int> _bQueue = [];
+  final List<bool> _signQueue = [];
+
+  int _currResult = 0;
+  int _currRemain = 0;
+  bool _divZero = false;
+  bool _triggerCheck = false;
+
+  @override
+  Future<void> run(Phase phase) async {
+    unawaited(super.run(phase));
+    await intf.reset.nextNegedge;
+
+    inStream.listen((event) {
+      _aQueue.add(event.mDividend);
+      _bQueue.add(event.mDivisor);
+      _signQueue.add(event.mIsSigned);
+    });
+
+    outStream.listen((event) {
+      _currResult = event.mQuotient;
+      _currRemain = event.mRemainder;
+      _divZero = event.mDivZero;
+      if (!computeRemainder) {
+        expect(event.mRemainder, 0,
+            reason: 'remainder must be 0 in quotient-only mode');
+      }
+      _triggerCheck = true;
+    });
+
+    intf.clk.negedge.listen((_) {
+      if (_aQueue.isNotEmpty && _triggerCheck) {
+        final in1 = _aQueue.removeAt(0);
+        final in2 = _bQueue.removeAt(0);
+        final inSign = _signQueue.removeAt(0);
+
+        final tCurrResult = inSign
+            ? _from1sComp(_currResult, intf.quotient.width)
+            : _currResult;
+        final tCurrRemain = inSign
+            ? _from1sComp(_currRemain, intf.remainder.width)
+            : _currRemain;
+
+        // in1/in2 already decoded by OnesComplementInputMonitor.
+        final isDivZero = in2 == 0;
+
+        bool check1;
+        bool check2;
+        if (isDivZero) {
+          check1 = _divZero;
+          check2 = _divZero;
+        } else {
+          check1 = (in1 ~/ in2) == tCurrResult;
+          check2 =
+              !computeRemainder || (in1 - (in2 * tCurrResult)) == tCurrRemain;
+        }
+
+        if (check1 && check2) {
+          logger.info(isDivZero
+              ? 'Divide by 0 error correctly encountered.'
+              : 'Correct result: dividend=$in1, divisor=$in2, '
+                  'quotient=$tCurrResult, remainder=$tCurrRemain');
+        } else {
+          logger.severe(isDivZero
+              ? 'No Divide by zero error for denominator of 0.'
+              : 'Incorrect result: dividend=$in1, divisor=$in2, '
+                  'quotient=$tCurrResult, remainder=$tCurrRemain');
+        }
+        _triggerCheck = false;
+      }
+    });
+  }
+}
+
+class OnesComplementAgent extends Agent {
+  final MultiCycleDividerInterface intf;
+  late final MultiCycleDividerSequencer sequencer;
+  late final MultiCycleDividerDriver driver;
+  late final OnesComplementInputMonitor inMonitor;
+  late final MultiCycleDividerOutputMonitor outMonitor;
+
+  OnesComplementAgent(this.intf, Component parent,
+      {String name = 'OnesComplementAgent'})
+      : super(name, parent) {
+    sequencer = MultiCycleDividerSequencer(this);
+    driver = MultiCycleDividerDriver(intf, sequencer, this);
+    inMonitor = OnesComplementInputMonitor(intf, this);
+    outMonitor = MultiCycleDividerOutputMonitor(intf, this);
+  }
+}
+
+class OnesComplementEnv extends Env {
+  final MultiCycleDividerInterface intf;
+  final bool computeRemainder;
+
+  late final OnesComplementAgent agent;
+  late final OnesComplementScoreboard scoreboard;
+
+  OnesComplementEnv(this.intf, Component parent,
+      {this.computeRemainder = true, String name = 'OnesComplementEnv'})
+      : super(name, parent) {
+    agent = OnesComplementAgent(intf, this);
+    scoreboard = OnesComplementScoreboard(
+        agent.inMonitor.stream, agent.outMonitor.stream, intf, this,
+        computeRemainder: computeRemainder);
+  }
+
+  @override
+  Future<void> run(Phase phase) async {
+    unawaited(super.run(phase));
+  }
+}
+
+class OnesComplementTest extends Test {
+  final Module dut;
+  late final MultiCycleDividerInterface intf;
+  final bool computeRemainder;
+  final List<Sequence>? sequences;
+
+  late final OnesComplementEnv env;
+  late final MultiCycleDividerSequencer _sequencer;
+
+  OnesComplementTest(this.dut, this.intf,
+      {this.computeRemainder = true,
+      this.sequences,
+      String name = 'OnesComplementTest'})
+      : super(name) {
+    env = OnesComplementEnv(intf, this, computeRemainder: computeRemainder);
+    _sequencer = env.agent.sequencer;
+  }
+
+  @override
+  Future<void> run(Phase phase) async {
+    unawaited(super.run(phase));
+    final obj = phase.raiseObjection('ones_comp_test');
+    logger.info(
+        'Running OnesComplementTest (computeRemainder=$computeRemainder)...');
+
+    Simulator.registerAction(1, () {
+      intf.reset.put(0);
+      intf.dividend.put(0);
+      intf.divisor.put(0);
+      intf.validIn.put(0);
+    });
+    Simulator.registerAction(10, () => intf.reset.put(1));
+    Simulator.registerAction(20, () => intf.reset.put(0));
+
+    await intf.reset.nextNegedge;
+
+    if (sequences != null) {
+      for (final seq in sequences!) {
+        await _sequencer.start(seq);
+      }
+    } else {
+      await _sequencer
+          .start(OnesCompSignedCornerSequence(dataWidth: intf.dataWidth));
+    }
+
+    obj.drop();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sequences
+// ---------------------------------------------------------------------------
+
+/// Basic smoke sequence for [OnesComplementDivider].
+class OnesCompBasicSequence extends Sequence {
+  final int dataWidth;
+
+  OnesCompBasicSequence(
+      {required this.dataWidth, String name = 'OnesCompBasicSequence'})
+      : super(name);
+
+  @override
+  Future<void> body(Sequencer sequencer) async {
+    final seq = sequencer as MultiCycleDividerSequencer;
+
+    void u(int a, int b) => seq.add(MultiCycleDividerInputSeqItem(
+        mDividend: a,
+        mDivisor: b,
+        mIsSigned: false,
+        mValidIn: true,
+        mReadyOut: true));
+    void s(int a, int b) => seq.add(MultiCycleDividerInputSeqItem(
+        mDividend: _to1sComp(a, dataWidth),
+        mDivisor: _to1sComp(b, dataWidth),
+        mIsSigned: true,
+        mValidIn: true,
+        mReadyOut: true));
+
+    s(4, 2);
+    s(9, 3);
+    u(5, 2);
+    u(4, 1);
+    s(-10, 2);
+    s(13, -10);
+    s(-10, -9);
+    s(1, 4);
+    s(4, 0);
+    u((1 << (dataWidth - 1)) - 1, 6);
+  }
+}
+
+/// Edge-case sequence for [OnesComplementDivider].
+///
+/// Targets boundary values specific to 1's complement including negative-zero
+/// (-0 = all-ones) as divisor.
+class OnesCompEvilSequence extends Sequence {
+  final int dataWidth;
+
+  OnesCompEvilSequence(
+      {required this.dataWidth, String name = 'OnesCompEvilSequence'})
+      : super(name);
+
+  @override
+  Future<void> body(Sequencer sequencer) async {
+    final seq = sequencer as MultiCycleDividerSequencer;
+    final maxS = (1 << (dataWidth - 1)) - 1;
+
+    void s(int a, int b) => seq.add(MultiCycleDividerInputSeqItem(
+        mDividend: _to1sComp(a, dataWidth),
+        mDivisor: _to1sComp(b, dataWidth),
+        mIsSigned: true,
+        mValidIn: true,
+        mReadyOut: true));
+    void u(int a, int b) => seq.add(MultiCycleDividerInputSeqItem(
+        mDividend: a,
+        mDivisor: b,
+        mIsSigned: false,
+        mValidIn: true,
+        mReadyOut: true));
+
+    s(maxS, maxS);
+    s(maxS, 1);
+    s(maxS, -1);
+    s(-maxS, 1);
+    s(-maxS, -1);
+    s(-maxS, maxS);
+    s(maxS, -maxS);
+    s(1, maxS);
+    s(-1, maxS);
+    u((1 << dataWidth) - 2, 1);
+    u(0, 1);
+    // negative-zero divisor (-0 = all-ones) → divZero
+    seq.add(MultiCycleDividerInputSeqItem(
+        mDividend: 5,
+        mDivisor: (1 << dataWidth) - 1,
+        mIsSigned: true,
+        mValidIn: true,
+        mReadyOut: true));
+  }
+}
+
+/// Random volume sequence for [OnesComplementDivider].
+class OnesCompVolumeSequence extends Sequence {
+  final int dataWidth;
+  final int numReps;
+  final Random rng;
+
+  OnesCompVolumeSequence(this.numReps,
+      {required this.dataWidth,
+      int seed = 0xdeadbeef,
+      String name = 'OnesCompVolumeSequence'})
+      : rng = Random(seed),
+        super(name);
+
+  @override
+  Future<void> body(Sequencer sequencer) async {
+    final seq = sequencer as MultiCycleDividerSequencer;
+    final maxS = (1 << (dataWidth - 1)) - 1;
+    final maxU = (1 << dataWidth) - 2; // exclude all-ones (-0)
+
+    for (var i = 0; i < numReps; i++) {
+      if (i % 2 == 0) {
+        seq.add(MultiCycleDividerInputSeqItem(
+            mDividend: rng.nextInt(maxU + 1),
+            mDivisor: rng.nextInt(maxU + 1),
+            mIsSigned: false,
+            mValidIn: true,
+            mReadyOut: true));
+      } else {
+        final a = rng.nextInt(2 * maxS + 1) - maxS;
+        final b = rng.nextInt(2 * maxS + 1) - maxS;
+        seq.add(MultiCycleDividerInputSeqItem(
+            mDividend: _to1sComp(a, dataWidth),
+            mDivisor: _to1sComp(b, dataWidth),
+            mIsSigned: true,
+            mValidIn: true,
+            mReadyOut: true));
+      }
+    }
+  }
+}
+
+/// Signed corner-case sequence for [OnesComplementDivider] — all four sign
+/// quadrants plus both forms of divide-by-zero (positive and negative zero).
+class OnesCompSignedCornerSequence extends Sequence {
+  final int dataWidth;
+
+  OnesCompSignedCornerSequence(
+      {required this.dataWidth, String name = 'OnesCompSignedCornerSequence'})
+      : super(name);
+
+  @override
+  Future<void> body(Sequencer sequencer) async {
+    final seq = sequencer as MultiCycleDividerSequencer;
+
+    void add(int a, int b) => seq.add(MultiCycleDividerInputSeqItem(
+        mDividend: _to1sComp(a, dataWidth),
+        mDivisor: _to1sComp(b, dataWidth),
+        mIsSigned: true,
+        mValidIn: true,
+        mReadyOut: true));
+
+    final maxS = (1 << (dataWidth - 1)) - 1;
+    final minS = -maxS;
+
+    // +/+
+    add(6, 3);
+    add(7, 3);
+    add(1, maxS);
+    add(maxS, 1);
+    add(maxS, maxS);
+    // +/-
+    add(6, -3);
+    add(7, -3);
+    add(maxS, -1);
+    // -/+
+    add(-6, 3);
+    add(-7, 3);
+    add(minS, 1);
+    // -/-
+    add(-6, -3);
+    add(-7, -3);
+    add(minS, minS);
+    // divide-by-zero: positive zero
+    add(5, 0);
+    // divide-by-zero: negative zero (-0 = all-ones)
+    seq.add(MultiCycleDividerInputSeqItem(
+        mDividend: 5,
+        mDivisor: (1 << dataWidth) - 1,
+        mIsSigned: true,
+        mValidIn: true,
+        mReadyOut: true));
+  }
+}
 
 void main() {
   tearDown(() async {
     await Simulator.reset();
   });
 
-  // Run the full VF + factory-method smoke tests in both modes.
   for (final computeRemainder in [true, false]) {
     final label = computeRemainder ? 'with remainder' : 'quotient-only';
 
-    group('divider tests ($label)', () {
+    group('2\'s C. Divider Tests ($label)', () {
       test('VF tests', () async {
         Logger.root.level = Level.SEVERE;
 
@@ -746,70 +1126,8 @@ void main() {
         Logic(name: 'tReadyIn').gets(div.readyIn);
       });
     });
-  }
 
-  test('quotient-only is O(n) cycles — latency == dataWidth+2 cycles',
-      () async {
-    const w = 8;
-    final intf = MultiCycleDividerInterface(dataWidth: w);
-    intf.clk <= SimpleClockGenerator(10).clk;
-    final dut = MultiCycleDivider(intf, computeRemainder: false);
-    await dut.build();
-
-    int? latency;
-    var startCycle = 0;
-    var cycleCount = 0;
-
-    intf.clk.posedge.listen((_) => cycleCount++);
-
-    Simulator.registerAction(1, () {
-      intf.reset.put(0);
-      intf.dividend.put(0);
-      intf.divisor.put(0);
-      intf.validIn.put(0);
-      intf.readyOut.put(1);
-    });
-    Simulator.registerAction(10, () => intf.reset.put(1));
-    Simulator.registerAction(20, () => intf.reset.put(0));
-
-    Simulator.setMaxSimTime(5000);
-
-    unawaited(Simulator.run());
-
-    await intf.reset.nextNegedge;
-
-    // Worst-case: dividend=255, divisor=1 (unsigned 8-bit).
-    intf.validIn.put(1);
-    intf.dividend.put(255);
-    intf.divisor.put(1);
-    intf.isSigned.put(0);
-    startCycle = cycleCount;
-
-    await intf.clk.nextPosedge; // input accepted
-    intf.validIn.put(0);
-
-    await intf.validOut.nextPosedge;
-    latency = cycleCount - startCycle;
-
-    // O(n): exactly w process cycles + 1 convert + 1 done leading edge.
-    expect(latency, equals(w + 2),
-        reason: 'O(n) divider latency should be dataWidth+2=$w+2 cycles');
-    expect(intf.quotient.value.toInt(), equals(255));
-    expect(intf.remainder.value.toInt(), equals(0));
-
-    await Simulator.endSimulation();
-  });
-
-  // ---------------------------------------------------------------------------
-  // Targeted corner-case tests using an 8-bit DUT via the VF harness.
-  //
-  // An 8-bit DUT keeps simulation fast (O(n²) worst-case ≤ 64 cycles/op)
-  // while each vector targets a distinct structural corner.
-  // ---------------------------------------------------------------------------
-  for (final computeRemainder in [true, false]) {
-    final label = computeRemainder ? 'with remainder' : 'quotient-only';
-
-    group('divider corner cases 8-bit ($label)', () {
+    group('2\'s C. Divider Corner Cases ${TopTBNarrow.width}-bit ($label)', () {
       test('targeted structural corners', () async {
         Logger.root.level = Level.SEVERE;
 
@@ -817,7 +1135,7 @@ void main() {
         final tb = TopTBNarrow(intf, computeRemainder: computeRemainder);
         await tb.divider.build();
 
-        Simulator.setMaxSimTime(500000);
+        Simulator.setMaxSimTime(300000);
 
         final test = MultiCycleDividerTest(tb.divider, intf,
             computeRemainder: computeRemainder,
@@ -825,6 +1143,77 @@ void main() {
               MultiCycleDividerCornerSequence(dataWidth: TopTBNarrow.width)
             ]);
 
+        await test.start();
+      }, timeout: const Timeout(Duration(minutes: 1)));
+    });
+  }
+
+  for (final computeRemainder in [true, false]) {
+    final label = computeRemainder ? 'with remainder' : 'quotient-only';
+
+    group('1\'s C. Divider Tests ($label)', () {
+      test('VF tests', () async {
+        Logger.root.level = Level.SEVERE;
+
+        final intf = MultiCycleDividerInterface(dataWidth: TopTB.width);
+        final tb = TopTBOnesComp(intf, computeRemainder: computeRemainder);
+        await tb.divider.build();
+
+        Simulator.setMaxSimTime(200000);
+
+        final test = OnesComplementTest(tb.divider, intf,
+            computeRemainder: computeRemainder,
+            sequences: [
+              OnesCompBasicSequence(dataWidth: TopTB.width),
+              OnesCompEvilSequence(dataWidth: TopTB.width),
+              OnesCompVolumeSequence(1000, dataWidth: TopTB.width),
+            ]);
+        await test.start();
+      });
+
+      test('Factory method build', () async {
+        final clk = Logic(name: 'clk');
+        final reset = Logic(name: 'reset');
+        final validIn = Logic(name: 'validIn');
+        final dividend = Logic(name: 'dividend', width: TopTB.width);
+        final divisor = Logic(name: 'divisor', width: TopTB.width);
+        final isSigned = Logic(name: 'isSigned');
+        final readyOut = Logic(name: 'readyOut');
+        final div = OnesComplementDivider.ofLogics(
+            clk: clk,
+            reset: reset,
+            validIn: validIn,
+            dividend: dividend,
+            divisor: divisor,
+            isSigned: isSigned,
+            readyOut: readyOut,
+            computeRemainder: computeRemainder);
+        await div.build();
+
+        Logic(name: 'tValidOut').gets(div.validOut);
+        Logic(name: 'tQuotient', width: TopTB.width).gets(div.quotient);
+        Logic(name: 'tRemainder', width: TopTB.width).gets(div.remainder);
+        Logic(name: 'tDivZero').gets(div.divZero);
+        Logic(name: 'tReadyIn').gets(div.readyIn);
+      });
+    });
+
+    group('1\'s C. Divider Corner Cases ${TopTBOnesComp.width}-bit ($label)',
+        () {
+      test('targeted structural corners', () async {
+        Logger.root.level = Level.SEVERE;
+
+        final intf = MultiCycleDividerInterface(dataWidth: TopTBOnesComp.width);
+        final tb = TopTBOnesComp(intf, computeRemainder: computeRemainder);
+        await tb.divider.build();
+
+        Simulator.setMaxSimTime(300000);
+
+        final test = OnesComplementTest(tb.divider, intf,
+            computeRemainder: computeRemainder,
+            sequences: [
+              OnesCompSignedCornerSequence(dataWidth: TopTBOnesComp.width),
+            ]);
         await test.start();
       }, timeout: const Timeout(Duration(minutes: 1)));
     });

--- a/test/arithmetic/divider_test.dart
+++ b/test/arithmetic/divider_test.dart
@@ -720,7 +720,7 @@ class TopTBOnesComp {
 // ---------------------------------------------------------------------------
 
 /// Input monitor that decodes pin values using [_from1sComp] instead of
-/// [twosComp], so signed dividends/divisors are captured correctly.
+/// [_twosComp], so signed dividends/divisors are captured correctly.
 class OnesComplementInputMonitor
     extends Monitor<MultiCycleDividerInputSeqItem> {
   final MultiCycleDividerInterface intf;
@@ -1042,7 +1042,7 @@ class OnesCompVolumeSequence extends Sequence {
     final maxU = (1 << dataWidth) - 2; // exclude all-ones (-0)
 
     for (var i = 0; i < numReps; i++) {
-      if (i % 2 == 0) {
+      if (i.isEven) {
         seq.add(MultiCycleDividerInputSeqItem(
             mDividend: rng.nextInt(maxU + 1),
             mDivisor: rng.nextInt(maxU + 1),
@@ -1124,7 +1124,7 @@ void main() {
   for (final computeRemainder in [true, false]) {
     final label = computeRemainder ? 'with remainder' : 'quotient-only';
 
-    group('2\'s C. Divider Tests ($label)', () {
+    group("2's C. Divider Tests ($label)", () {
       test('VF tests', () async {
         // Set the logger level
         Logger.root.level = Level.SEVERE;
@@ -1175,7 +1175,7 @@ void main() {
       });
     });
 
-    group('2\'s C. Divider Corner Cases ${TopTBNarrow.width}-bit ($label)', () {
+    group("2's C. Divider Corner Cases ${TopTBNarrow.width}-bit ($label)", () {
       test('targeted structural corners', () async {
         Logger.root.level = Level.SEVERE;
 
@@ -1199,11 +1199,11 @@ void main() {
   for (final computeRemainder in [true, false]) {
     final label = computeRemainder ? 'with remainder' : 'quotient-only';
 
-    group('1\'s C. Divider Tests ($label)', () {
+    group("1's C. Divider Tests ($label)", () {
       test('VF tests', () async {
         Logger.root.level = Level.SEVERE;
 
-        final intf = MultiCycleDividerInterface(dataWidth: TopTB.width);
+        final intf = MultiCycleDividerInterface();
         final tb = TopTBOnesComp(intf, computeRemainder: computeRemainder);
         await tb.divider.build();
 
@@ -1246,7 +1246,7 @@ void main() {
       });
     });
 
-    group('1\'s C. Divider Corner Cases ${TopTBOnesComp.width}-bit ($label)',
+    group("1's C. Divider Corner Cases ${TopTBOnesComp.width}-bit ($label)",
         () {
       test('targeted structural corners', () async {
         Logger.root.level = Level.SEVERE;

--- a/test/arithmetic/divider_test.dart
+++ b/test/arithmetic/divider_test.dart
@@ -106,6 +106,7 @@ class MultiCycleDividerSequencer
 class MultiCycleDividerDriver extends Driver<MultiCycleDividerInputSeqItem> {
   final MultiCycleDividerInterface intf;
 
+  // Keep a queue of items from the sequencer to be driven when desired
   final Queue<MultiCycleDividerInputSeqItem> _pendingItems =
       Queue<MultiCycleDividerInputSeqItem>();
 
@@ -120,6 +121,7 @@ class MultiCycleDividerDriver extends Driver<MultiCycleDividerInputSeqItem> {
   Future<void> run(Phase phase) async {
     unawaited(super.run(phase));
 
+    // Listen to new items coming from the sequencer, and add them to a queue
     sequencer.stream.listen((newItem) async {
       _driverObjection ??= phase.raiseObjection('div_driver');
       unawaited(_driverObjection!.dropped
@@ -127,6 +129,8 @@ class MultiCycleDividerDriver extends Driver<MultiCycleDividerInputSeqItem> {
       _pendingItems.add(newItem);
     });
 
+    // Every clock negative edge, drive the next pending item if it exists
+    // but only when the DUT isn't busy
     intf.clk.negedge.listen((args) {
       if (_pendingItems.isNotEmpty && intf.readyIn.value == LogicValue.one) {
         final nextItem = _pendingItems.removeFirst();
@@ -139,6 +143,7 @@ class MultiCycleDividerDriver extends Driver<MultiCycleDividerInputSeqItem> {
     });
   }
 
+  // Translate a SequenceItem into pin wiggles
   void drive(MultiCycleDividerInputSeqItem? item) {
     if (item == null) {
       intf.dividend.inject(0);
@@ -158,6 +163,7 @@ class MultiCycleDividerDriver extends Driver<MultiCycleDividerInputSeqItem> {
 
 class MultiCycleDividerInputMonitor
     extends Monitor<MultiCycleDividerInputSeqItem> {
+  /// Instance of the [Interface] to the DUT.
   final MultiCycleDividerInterface intf;
 
   MultiCycleDividerInputMonitor(this.intf, Component parent,
@@ -168,6 +174,7 @@ class MultiCycleDividerInputMonitor
   Future<void> run(Phase phase) async {
     unawaited(super.run(phase));
 
+    // Every positive edge of the clock
     intf.clk.posedge.listen((event) {
       if (intf.validIn.value == LogicValue.one &&
           intf.readyIn.value == LogicValue.one) {
@@ -180,7 +187,7 @@ class MultiCycleDividerInputMonitor
                 : intf.divisor.value.toInt(),
             mIsSigned: intf.isSigned.value.toBool(),
             mValidIn: true,
-            mReadyOut: true));
+            mReadyOut: true)); // must convert to two's complement rep.
       }
     });
   }
@@ -188,6 +195,7 @@ class MultiCycleDividerInputMonitor
 
 class MultiCycleDividerOutputMonitor
     extends Monitor<MultiCycleDividerOutputSeqItem> {
+  /// Instance of the [Interface] to the DUT.
   final MultiCycleDividerInterface intf;
 
   MultiCycleDividerOutputMonitor(this.intf, Component parent,
@@ -198,9 +206,11 @@ class MultiCycleDividerOutputMonitor
   Future<void> run(Phase phase) async {
     unawaited(super.run(phase));
 
+    // Every positive edge of the clock
     intf.clk.posedge.listen((event) {
       if (intf.validOut.value == LogicValue.one) {
         add(MultiCycleDividerOutputSeqItem(
+            // must convert to two's complement rep.
             mQuotient: intf.quotient.value.toInt(),
             mRemainder: intf.remainder.value.toInt(),
             mDivZero: intf.divZero.value == LogicValue.one,
@@ -358,7 +368,10 @@ class MultiCycleDividerTest extends Test {
   final bool computeRemainder;
   final List<Sequence>? sequences;
 
+  /// The test environment for [dut].
   late final MultiCycleDividerEnv env;
+
+  /// A private, local pointer to the test environment's [Sequencer].
   late final MultiCycleDividerSequencer _divSequencer;
 
   MultiCycleDividerTest(this.dut, this.intf,
@@ -374,9 +387,13 @@ class MultiCycleDividerTest extends Test {
   Future<void> run(Phase phase) async {
     unawaited(super.run(phase));
 
+    // Raise an objection at the start of the test so that the
+    // simulation doesn't end before stimulus is injected
     final obj = phase.raiseObjection('div_test');
+
     logger.info('Running the test (computeRemainder=$computeRemainder)...');
 
+    // Add some simple reset behavior at specified timestamps
     Simulator.registerAction(1, () {
       intf.reset.put(0);
       intf.dividend.put(0);
@@ -386,8 +403,10 @@ class MultiCycleDividerTest extends Test {
     Simulator.registerAction(10, () => intf.reset.put(1));
     Simulator.registerAction(20, () => intf.reset.put(0));
 
+    // Wait for the next negative edge of reset
     await intf.reset.nextNegedge;
 
+    // Kick off a sequence on the sequencer
     if (sequences != null) {
       for (final seq in sequences!) {
         await _divSequencer.start(seq);
@@ -399,6 +418,8 @@ class MultiCycleDividerTest extends Test {
     }
 
     logger.info('Done adding stimulus to the sequencer');
+
+    // Done adding stimulus, we can drop our objection now
     obj.drop();
   }
 }
@@ -408,11 +429,17 @@ class MultiCycleDividerTest extends Test {
 // ---------------------------------------------------------------------------
 
 class TopTB {
+  // Instance of the DUT
   late final MultiCycleDivider divider;
+
+  // A constant value for the width to use in this testbench
   static const int width = 32;
 
   TopTB(MultiCycleDividerInterface intf, {bool computeRemainder = true}) {
+    // Connect a generated clock to the interface
     intf.clk <= SimpleClockGenerator(10).clk;
+
+    // Create the DUT, passing it our interface
     divider = MultiCycleDivider(intf, computeRemainder: computeRemainder);
   }
 }
@@ -444,55 +471,56 @@ class MultiCycleDividerBasicSequence extends Sequence {
           mDivisor: 2,
           mValidIn: true,
           mIsSigned: true,
-          mReadyOut: true))
+          mReadyOut: true)) // even divide by 2
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: 9,
           mDivisor: 3,
           mValidIn: true,
           mIsSigned: true,
-          mReadyOut: true))
+          mReadyOut: true)) // even divide not by 2
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: 5,
           mDivisor: 2,
           mValidIn: true,
           mIsSigned: false,
-          mReadyOut: true))
+          mReadyOut: true)) // not even divide
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: 4,
           mDivisor: 1,
           mValidIn: true,
           mIsSigned: false,
-          mReadyOut: true))
+          mReadyOut: true)) // divide by 1
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: -10,
           mDivisor: 2,
           mValidIn: true,
           mIsSigned: true,
-          mReadyOut: true))
+          mReadyOut: true)) // negative-positive
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: 13,
           mDivisor: -10,
           mValidIn: true,
           mIsSigned: true,
-          mReadyOut: true))
+          mReadyOut: true)) // positive-negative
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: -10,
           mDivisor: -9,
           mValidIn: true,
           mIsSigned: true,
-          mReadyOut: true))
+          mReadyOut: true)) // negative-negative
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: 1,
           mDivisor: 4,
           mValidIn: true,
           mIsSigned: true,
-          mReadyOut: true))
+          mReadyOut: true)) // bigger divisor
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: 4,
           mDivisor: 0,
           mValidIn: true,
           mIsSigned: true,
-          mReadyOut: true))
+          mReadyOut: true)) // divide by 0
+      // long latency division
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: 0xffffffec,
           mDivisor: 0x6,
@@ -512,54 +540,65 @@ class MultiCycleDividerEvilSequence extends Sequence {
   @override
   Future<void> body(Sequencer sequencer) async {
     sequencer as MultiCycleDividerSequencer
+      // largest positive divided by largest positive
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: (1 << (numBits - 1)) - 1,
           mDivisor: (1 << (numBits - 1)) - 1,
           mValidIn: true,
           mIsSigned: true,
           mReadyOut: true))
+      // largest positive divided by largest negative
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: (1 << (numBits - 1)) - 1,
           mDivisor: (1 << (numBits - 1)),
           mValidIn: true,
           mIsSigned: true,
           mReadyOut: true))
+      // largest negative divided by largest positive
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: (1 << (numBits - 1)),
           mDivisor: (1 << (numBits - 1)) - 1,
           mValidIn: true,
           mIsSigned: false,
           mReadyOut: true))
+      // largest negative divided by largest negative
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: (1 << (numBits - 1)),
           mDivisor: (1 << (numBits - 1)),
           mValidIn: true,
           mIsSigned: false,
           mReadyOut: true))
+      // largest positive divided by negative 1
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: (1 << (numBits - 1)) - 1,
           mDivisor: -1,
           mValidIn: true,
           mIsSigned: true,
           mReadyOut: true))
+      // largest negative divided by negative 1
+      // this is the only true overflow case...
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: (1 << (numBits - 1)),
           mDivisor: -1,
           mValidIn: true,
           mIsSigned: true,
           mReadyOut: true))
+      // largest positive divided by 1
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: (1 << (numBits - 1)) - 1,
           mDivisor: 1,
           mValidIn: true,
           mIsSigned: true,
           mReadyOut: true))
+      // largest negative divided by 1
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: (1 << (numBits - 1)),
           mDivisor: 1,
           mValidIn: true,
           mIsSigned: true,
           mReadyOut: true))
+      // unsigned version of overflow case
+      // which should not result in overflow
       ..add(MultiCycleDividerInputSeqItem(
           mDividend: (1 << (numBits - 1)),
           mDivisor: -1,
@@ -571,7 +610,7 @@ class MultiCycleDividerEvilSequence extends Sequence {
 
 class MultiCycleDividerVolumeSequence extends Sequence {
   final int numReps;
-  final rng = Random(0xdeadbeef);
+  final rng = Random(0xdeadbeef); // fixed seed
 
   MultiCycleDividerVolumeSequence(this.numReps,
       {String name = 'MultiCycleDividerVolumeSequence'})
@@ -1087,14 +1126,23 @@ void main() {
 
     group('2\'s C. Divider Tests ($label)', () {
       test('VF tests', () async {
+        // Set the logger level
         Logger.root.level = Level.SEVERE;
 
+        // Create the testbench
         final intf = MultiCycleDividerInterface();
         final tb = TopTB(intf, computeRemainder: computeRemainder);
+
+        // Build the DUT
         await tb.divider.build();
 
+        // Attach a waveform dumper to the DUT
+        // WaveDumper(tb.divider);
+
+        // Set a maximum simulation time so it doesn't run forever
         Simulator.setMaxSimTime(200000);
 
+        // Create and start the test!
         final test = MultiCycleDividerTest(tb.divider, intf,
             computeRemainder: computeRemainder);
         await test.start();

--- a/test/arithmetic/divider_test.dart
+++ b/test/arithmetic/divider_test.dart
@@ -265,9 +265,8 @@ class MultiCycleDividerScoreboard extends Component {
 
         final tCurrResult =
             inSign ? _twosComp(_currResult, intf.quotient.width) : _currResult;
-        final tCurrRemain = inSign
-            ? _twosComp(_currRemain, intf.remainder.width)
-            : _currRemain;
+        final tCurrRemain =
+            inSign ? _twosComp(_currRemain, intf.remainder.width) : _currRemain;
 
         final overflow = inSign &&
             in1 ==
@@ -334,8 +333,7 @@ class MultiCycleDividerEnv extends Env {
   late final MultiCycleDividerScoreboard scoreboard;
 
   MultiCycleDividerEnv(this.intf, Component parent,
-      {this.computeRemainder = true,
-      String name = 'MultiCycleDividerEnv'})
+      {this.computeRemainder = true, String name = 'MultiCycleDividerEnv'})
       : super(name, parent) {
     agent = MultiCycleDividerAgent(intf, this);
     scoreboard = MultiCycleDividerScoreboard(

--- a/test/arithmetic/divider_test.dart
+++ b/test/arithmetic/divider_test.dart
@@ -215,7 +215,7 @@ class MultiCycleDividerScoreboard extends Component {
   final Stream<MultiCycleDividerOutputSeqItem> outStream;
   final MultiCycleDividerInterface intf;
 
-  /// When [false], only the quotient is verified and remainder is expected
+  /// When `false`, only the quotient is verified and remainder is expected
   /// to always be 0.
   final bool computeRemainder;
 
@@ -286,9 +286,9 @@ class MultiCycleDividerScoreboard extends Component {
           check2 = tCurrRemain == 0;
         } else {
           check1 = (in1 ~/ in2) == tCurrResult;
-          check2 = computeRemainder
-              ? (in1 - (in2 * tCurrResult)) == tCurrRemain
-              : true; // remainder not computed; skip check
+          // remainder not computed in quotient-only mode; skip check
+          check2 =
+              !computeRemainder || (in1 - (in2 * tCurrResult)) == tCurrRemain;
         }
 
         if (check1 && check2) {
@@ -757,8 +757,8 @@ void main() {
     await dut.build();
 
     int? latency;
-    int startCycle = 0;
-    int cycleCount = 0;
+    var startCycle = 0;
+    var cycleCount = 0;
 
     intf.clk.posedge.listen((_) => cycleCount++);
 


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

This PR refactors and extends the MultiCycleDivider with two key changes:

1. FSM Refactor (divider.dart): Replaces the manual ad-hoc FSM (using _MultiCycleDividerState static constants, raw Combinational/Sequential blocks, and a currentState/nextState pair) with ROHD's FiniteStateMachine<MultiCycleDividerStates>. The state constants are promoted to a proper enum MultiCycleDividerStates. This reduces boilerplate, improves readability, and aligns with idiomatic ROHD patterns.

2. Quotient-only mode (computeRemainder flag): Adds a computeRemainder parameter to MultiCycleDivider. When false, the divider uses a faster O(n) binary long-division algorithm (one quotient bit per clock cycle) instead of the full O(n²) greedy algorithm, and the remainder output is always 0.

3. New OnesComplementDivider (ones_complement_divider.dart): Adds a new sibling divider that uses one's complement signed arithmetic instead of two's complement. It shares the same MultiCycleDividerInterface and MultiCycleDividerStates FSM but replaces the sign-negate operation (~x + 1) with a simpler bitwise invert (~x), reducing the critical path in the convert state. It also supports the computeRemainder flag with both O(n²) and O(n) modes.

## Related Issue(s)

#139

## Testing

* Existing tests for MultiCycleDivider were extended to run in both computeRemainder: true and computeRemainder: false modes (all test groups are now parameterised over both modes).
* New VF test infrastructure added for OnesComplementDivider: dedicated OnesComplementInputMonitor, OnesComplementScoreboard, OnesComplementAgent, OnesComplementEnv, and OnesComplementTest classes.
* New test sequences added: OnesCompBasicSequence, OnesCompEvilSequence (including negative-zero divisor edge cases), OnesCompVolumeSequence (1000 random vectors), and OnesCompSignedCornerSequence (all four sign quadrants + both divide-by-zero forms).
* Corner-case sequence (MultiCycleDividerCornerSequence) added for the two's complement divider covering signed boundaries, overflow (MIN_INT ÷ −1), and divide-by-zero.
* A fix to currIndex width (logDataWidth + 1 bits) ensures the loop-exit condition works correctly for all data widths.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Doc changes included in this PR. 
