### PR TITLE
fix(axi4_bfm): fix _captureWriteData and _respondWrite in Axi4MemorySubordinate

### DIFF
--- a/lib/src/models/amba/amba4_bfm/axi4_memory_subordinate.dart
+++ b/lib/src/models/amba/amba4_bfm/axi4_memory_subordinate.dart
@@ -459,14 +459,23 @@ class Axi4SubordinateMemoryAgent extends Agent {
     // TODO(kimmeljo): what about interleaving data on the same lane but w/ different IDs...
 
     // NOTE: we are dropping wUser on the floor for now...
-    final dataPacket =
-        Axi4DataPacket(data: wIntf.data.value, strb: wIntf.strb.value);
-    _writeDataQueue[mapIdx].add(dataPacket);
-    logger.info('Captured write data on channel $index.');
-    if (wIntf.last!.value.toBool()) {
-      logger.info('Finished capturing write data on channel $index.');
-      _writeReadyToOccur[mapIdx] = true;
+    // The W-channel monitor fires once per burst with all beats aggregated in
+    // packet.data via rswizzle(); clear any stale entry then unpack each beat.
+    _writeDataQueue[mapIdx].clear();
+    final dw = wIntf.dataWidth;
+    final sw = wIntf.strbWidth;
+    final numBeats = packet.data.width ~/ dw;
+    for (var i = 0; i < numBeats; i++) {
+      final beatData = packet.data.getRange(i * dw, (i + 1) * dw);
+      final beatStrb = packet.strb != null
+          ? packet.strb!.getRange(i * sw, (i + 1) * sw)
+          : LogicValue.filled(sw, LogicValue.one);
+      _writeDataQueue[mapIdx]
+          .add(Axi4DataPacket(data: beatData, strb: beatStrb));
     }
+    logger.info('Captured write data on channel $index.');
+    logger.info('Finished capturing write data on channel $index.');
+    _writeReadyToOccur[mapIdx] = true;
   }
 
   void _respondWrite({int index = 0}) {
@@ -607,6 +616,7 @@ class Axi4SubordinateMemoryAgent extends Agent {
 
       // pop this write response off the queue
       _writeMetadataQueue[mapIdx].removeAt(0);
+      _writeDataQueue[mapIdx].clear();
       _writeReadyToOccur[mapIdx] = false;
 
       logger.info('Sent write response on channel $index.');

--- a/lib/src/models/amba/amba4_bfm/axi4_memory_subordinate.dart
+++ b/lib/src/models/amba/amba4_bfm/axi4_memory_subordinate.dart
@@ -473,8 +473,8 @@ class Axi4SubordinateMemoryAgent extends Agent {
       _writeDataQueue[mapIdx]
           .add(Axi4DataPacket(data: beatData, strb: beatStrb));
     }
-    logger.info('Captured write data on channel $index.');
-    logger.info('Finished capturing write data on channel $index.');
+    logger.info('Captured write data on channel $index.')
+      ..info('Finished capturing write data on channel $index.');
     _writeReadyToOccur[mapIdx] = true;
   }
 

--- a/lib/src/models/amba/amba4_bfm/axi4_memory_subordinate.dart
+++ b/lib/src/models/amba/amba4_bfm/axi4_memory_subordinate.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // axi4_memory_subordinate.dart

--- a/lib/src/models/amba/amba4_bfm/axi4_memory_subordinate.dart
+++ b/lib/src/models/amba/amba4_bfm/axi4_memory_subordinate.dart
@@ -473,7 +473,8 @@ class Axi4SubordinateMemoryAgent extends Agent {
       _writeDataQueue[mapIdx]
           .add(Axi4DataPacket(data: beatData, strb: beatStrb));
     }
-    logger.info('Captured write data on channel $index.')
+    logger
+      ..info('Captured write data on channel $index.')
       ..info('Finished capturing write data on channel $index.');
     _writeReadyToOccur[mapIdx] = true;
   }

--- a/test/amba/amba4/axi4_bfm_test.dart
+++ b/test/amba/amba4/axi4_bfm_test.dart
@@ -1244,6 +1244,73 @@ class Axi4ReadComplianceEvilTest extends Test {
   void check() {}
 }
 
+/// Verifies that a multi-beat INCR write burst stores each beat's data at its
+/// own address, not just the last beat's data at every address.
+class Axi4BfmMultiBeatDataIntegrityTest extends Axi4BfmTest {
+  static const int _startAddr = 0x100;
+  static const int _numBeats = 4;
+
+  final List<int> _writtenData = [];
+
+  Axi4BfmMultiBeatDataIntegrityTest(super.name);
+
+  @override
+  Future<void> run(Phase phase) async {
+    unawaited(super.run(phase));
+
+    final obj = phase.raiseObjection('${name}Obj');
+    await resetFlow();
+
+    const laneId = 0;
+    final wIntfC = lanes[laneId].write.wIntf;
+    const transLen = _numBeats - 1;
+    const transSize = 2; // 32-bit word per beat
+
+    final pData = List.generate(_numBeats, (i) => 0x11111111 * (i + 1));
+    final pStrobes = List.generate(_numBeats,
+        (_) => LogicValue.filled(wIntfC.strbWidth, LogicValue.one).toInt());
+
+    _writtenData
+      ..clear()
+      ..addAll(pData);
+
+    final wrPkts = genWrPacket(
+      laneId,
+      addr: _startAddr,
+      data: pData,
+      len: transLen,
+      size: transSize,
+      strb: pStrobes,
+      burst: Axi4BurstField.incr,
+      lock: false,
+    );
+    mainAgents[laneId].writeAgent.reqAgent.sequencer.add(wrPkts.$1);
+    mainAgents[laneId].writeAgent.dataAgent.sequencer!.add(wrPkts.$2);
+
+    await wrPkts.$1.completed;
+    await wrPkts.$2.completed;
+
+    obj.drop();
+  }
+
+  @override
+  void check() {
+    const increment = 4; // bytes per 32-bit beat (size=2)
+    for (var i = 0; i < _writtenData.length; i++) {
+      final addr = LogicValue.ofInt(_startAddr + i * increment, addrWidth);
+      final stored = storage.readData(addr).toInt();
+      expect(
+        stored,
+        equals(_writtenData[i]),
+        reason:
+            'Beat $i at 0x${(_startAddr + i * increment).toRadixString(16)}: '
+            'expected 0x${_writtenData[i].toRadixString(16)}, '
+            'got 0x${stored.toRadixString(16)}',
+      );
+    }
+  }
+}
+
 void main() {
   tearDown(() async {
     await Test.reset();
@@ -1351,5 +1418,9 @@ void main() {
     } on Exception catch (e) {
       expect(e.toString(), contains('Test failed'));
     }
+  });
+
+  test('multi-beat write burst stores each beat at its own address', () async {
+    await runTest(Axi4BfmMultiBeatDataIntegrityTest('multiBeatDataIntegrity'));
   });
 }

--- a/test/amba/amba4/axi4_bfm_test.dart
+++ b/test/amba/amba4/axi4_bfm_test.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // axi4_bfm_test.dart


### PR DESCRIPTION
## Summary

`Axi4SubordinateMemoryAgent._captureWriteData` was reading `wIntf.data.value`
directly to build each `Axi4DataPacket`. The W-channel monitor fires **once per
burst** with all beats already aggregated in `packet.data` via
`_dataBuf.rswizzle()`, so `wIntf.data.value` holds only the **last beat's
data** at that point. Every address in a multi-beat write burst ended up storing
the last beat's value.

## Bugs Fixed

1. **Multi-beat burst data corruption** — read `packet.data` and unpack each
   beat with `getRange(i*dw, (i+1)*dw)` instead of reading `wIntf.data.value`.

2. **Stale beat-0 entry on simultaneous AW+W** — `_receiveWrite` can enqueue a
   beat-0 packet when AW and the first W beat arrive together; clear the queue
   before unpacking so the complete authoritative burst data is used.

3. **Queue accumulation across back-to-back bursts** — `_writeDataQueue` was
   never cleared after `_respondWrite` completed, causing stale entries to
   corrupt subsequent transactions. Added a `clear()` call after the response
   is sent.

## Changes

- `lib/src/models/amba/amba4_bfm/axi4_memory_subordinate.dart` — surgical fix
  to `_captureWriteData` and `_respondWrite`
- `test/amba/amba4/axi4_bfm_test.dart` — new test
  `multi-beat write burst stores each beat at its own address` verifies a
  4-beat INCR burst writes distinct data to each consecutive address

## Testing

All 1354 tests pass (`dart test`). The new test explicitly exercises the bug
that was previously silent.
