### PR TITLE
FifoChecker unsafe use of previousValue on error signal fix

### DIFF
--- a/lib/src/memory/fifo.dart
+++ b/lib/src/memory/fifo.dart
@@ -363,7 +363,8 @@ class FifoChecker extends Component {
       }
 
       if (fifo.generateError && enableErrorCheck) {
-        if (fifo.error!.previousValue!.toBool()) {
+        if (fifo.error!.previousValue!.isValid &&
+            fifo.error!.previousValue!.toBool()) {
           logger.severe('Fifo $fifo error signal was asserted.');
         }
       }


### PR DESCRIPTION
## Description & Motivation

In some cases code can be reached in `FifoChecker` where we examine the `error` signal's value (by calling `toBool()`) without first checking if the value is valid. When this happens, the Simulator crashes.

In this case, it seems safe and still correct to just further qualify the code to check for the value being valid.

## Related Issue(s)

N/A

## Testing

Confirmed to work in user environment but hard to reproduce in unit tests. Given the scope of the fix, no further testing is really needed.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

Fully backwards compatible.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No.
