### PR TITLE
Bug fix in loadMemString for unaligned sections

### DIFF
--- a/lib/src/models/sparse_memory_storage.dart
+++ b/lib/src/models/sparse_memory_storage.dart
@@ -176,18 +176,24 @@ abstract class MemoryStorage {
         final lineAddr = int.parse(line.substring(1), radix: 16);
         final lineAddrLv =
             LogicValue.ofInt(lineAddr - lineAddr % addrIncrPerLine, addrWidth);
-        if (getData(lineAddrLv) != null) {
-          // must reconstruct the bytes array ending at the provided address
-          final endOff = lineAddr % addrIncrPerLine;
-          final origData = getData(lineAddrLv);
-          chunks.clear();
 
-          if (endOff != 0) {
-            chunks.add(origData!
-                .getRange(0, endOff * bitsPerAddress)
-                .toInt()
-                .toRadixString(radix));
-          }
+        // if the address is not word-aligned, pre-fill the lower byte
+        // positions so that new data lands at the correct byte offset within
+        // the word.  When the word already has data (e.g. written by the
+        // previous section), preserve those lower bytes; otherwise use zeros.
+        final endOff = lineAddr % addrIncrPerLine;
+        if (endOff != 0) {
+          final lowerBytesCharsCount = endOff * bitsPerAddress ~/ bitsPerChar;
+          final origData = getData(lineAddrLv);
+          final lowerStr = origData != null
+              ? origData
+                  .getRange(0, endOff * bitsPerAddress)
+                  .toInt()
+                  .toRadixString(radix)
+                  .padLeft(lowerBytesCharsCount, '0')
+              : '0' * lowerBytesCharsCount;
+          chunks.add(lowerStr);
+          chunksLength += lowerStr.length;
         }
 
         address = lineAddrLv.toInt();

--- a/test/memory/sparse_memory_storage_test.dart
+++ b/test/memory/sparse_memory_storage_test.dart
@@ -152,6 +152,67 @@ void main() {
       expect(memStr, expected);
     });
 
+    group('non-word-aligned section address', () {
+      // Regression tests for the fix that pre-fills lower byte positions when
+      // a hex section starts at a non-word-aligned address.
+
+      test('lower bytes are zero-padded when no prior data exists', () {
+        // @1 means byte 1 of the first 32-bit word (address 0x00).
+        // Bytes below the start offset should be filled with 0x00.
+        const hex = '''
+@1
+AA BB CC
+''';
+        final storage = SparseMemoryStorage(addrWidth: 32, dataWidth: 32)
+          ..loadMemString(hex);
+
+        // Word at 0x00: byte0=0x00 (padding), byte1=0xAA, byte2=0xBB,
+        // byte3=0xCC → little-endian word = 0xCCBBAA00
+        expect(
+          storage.getData(LogicValue.ofInt(0x00, 32))!.toInt(),
+          equals(0xCCBBAA00),
+        );
+      });
+
+      test('lower bytes are preserved when prior section already wrote them',
+          () {
+        // First section writes 0x11 0x22 0x33 0x44 starting at byte 0.
+        // Second section starts at byte 1 of the same word; byte 0 (0x11)
+        // must be preserved rather than zeroed out.
+        const hex = '''
+@0
+11 22 33 44
+@1
+AA BB CC
+''';
+        final storage = SparseMemoryStorage(addrWidth: 32, dataWidth: 32)
+          ..loadMemString(hex);
+
+        // Word at 0x00: byte0=0x11 (preserved), byte1=0xAA, byte2=0xBB,
+        // byte3=0xCC → little-endian word = 0xCCBBAA11
+        expect(
+          storage.getData(LogicValue.ofInt(0x00, 32))!.toInt(),
+          equals(0xCCBBAA11),
+        );
+      });
+
+      test('offset of 3 bytes with no prior data is zero-padded correctly', () {
+        // @3 means byte 3 of the first word; bytes 0-2 should be zero-padded.
+        const hex = '''
+@3
+AA
+''';
+        final storage = SparseMemoryStorage(addrWidth: 32, dataWidth: 32)
+          ..loadMemString(hex);
+
+        // Word at 0x00: bytes 0-2 = 0x00, byte3 = 0xAA → 0xAA000000
+        expect(
+          storage.getData(LogicValue.ofInt(0x00, 32))!.toInt(),
+          equals(0xAA000000),
+        );
+      });
+    });
+
     test('comments and whitespace and out of order work properly', () {
       const data = '''
 


### PR DESCRIPTION
## Description & Motivation

`loadMemString` has a bug when there is a discontinuity at a start address that is not aligned with the word size where it is possible for data to get squashed.

## Related Issue(s)

N/A

## Testing

Confirmed in user environment and will add a unit test.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

Backwards compatible as this is a bug fix.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

N/A
