### PR TITLE
docs: add DataPortInterface usage example #192

### DIFF
--- a/lib/src/memory/memory.dart
+++ b/lib/src/memory/memory.dart
@@ -45,7 +45,20 @@ class MaskedDataPortInterface extends DataPortInterface {
 /// An interface to a simple memory that only needs enable, address, and data.
 ///
 /// Can be used for either read or write direction by grouping signals using
-/// [DataPortGroup].
+/// [DataPortGroup]. Drive [en], [addr], and [data] on a write port. Drive [en]
+/// and [addr] on a read port; [data] is returned by the memory.
+///
+/// ```dart
+/// final clk = SimpleClockGenerator(10).clk;
+/// final reset = Logic();
+/// final wrPort = DataPortInterface(32, 5);
+/// final rdPort = DataPortInterface(32, 5);
+/// RegisterFile(clk, reset, [wrPort], [rdPort], numEntries: 20);
+///
+/// wrPort.en.put(1);
+/// wrPort.addr.put(3);
+/// wrPort.data.put(0xdeadbeef);
+/// ```
 class DataPortInterface extends Interface<DataPortGroup> {
   /// The width of data in the memory.
   final int dataWidth;


### PR DESCRIPTION
## Description & Motivation

The generated class page for `DataPortInterface` did not show how to wire it. I added a short dartdoc example that constructs read/write ports, passes them to `RegisterFile`, and drives `en`/`addr`/`data`.

## Related Issue(s)

Fixes #192

## Testing

Snippet matches the simple write path in `test/memory/memory_test.dart`. Docs-only, no behavior change.

## Backwards-compatibility

No.

## Documentation

Yes — class dartdoc on `DataPortInterface`, which is what https://intel.github.io/rohd-hcl/rohd_hcl/DataPortInterface-class.html is built from.